### PR TITLE
add query option of disabling upsert during query

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -183,6 +183,7 @@ public class CommonConstants {
         public static final String PRESERVE_TYPE = "preserveType";
         public static final String RESPONSE_FORMAT = "responseFormat";
         public static final String GROUP_BY_MODE = "groupByMode";
+        public static final String DISABLE_UPSERT = "disableUpsert";
       }
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -183,7 +183,7 @@ public class CommonConstants {
         public static final String PRESERVE_TYPE = "preserveType";
         public static final String RESPONSE_FORMAT = "responseFormat";
         public static final String GROUP_BY_MODE = "groupByMode";
-        public static final String DISABLE_UPSERT = "disableUpsert";
+        public static final String SKIP_UPSERT = "skipUpsert";
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -61,13 +61,13 @@ public class FilterPlanNode implements PlanNode {
   public BaseFilterOperator run() {
     FilterContext filter = _queryContext.getFilter();
     ValidDocIndexReader validDocIndexReader = _indexSegment.getValidDocIndex();
-    boolean upsertDisabled = false;
+    boolean upsertSkipped = false;
     if (_queryContext.getQueryOptions() != null) {
-      upsertDisabled = new QueryOptions(_queryContext.getQueryOptions()).isUpsertDisabled();
+      upsertSkipped = new QueryOptions(_queryContext.getQueryOptions()).isUpsertSkipped();
     }
     if (filter != null) {
       BaseFilterOperator filterOperator = constructPhysicalOperator(filter, _queryContext.getDebugOptions());
-      if (validDocIndexReader != null && !upsertDisabled) {
+      if (validDocIndexReader != null && !upsertSkipped) {
         BaseFilterOperator validDocFilter =
             new BitmapBasedFilterOperator(validDocIndexReader.getValidDocBitmap(), false, _numDocs);
         return FilterOperatorUtils.getAndFilterOperator(Arrays.asList(filterOperator, validDocFilter), _numDocs,
@@ -75,7 +75,7 @@ public class FilterPlanNode implements PlanNode {
       } else {
         return filterOperator;
       }
-    } else if (validDocIndexReader != null && !upsertDisabled) {
+    } else if (validDocIndexReader != null && !upsertSkipped) {
       return new BitmapBasedFilterOperator(validDocIndexReader.getValidDocBitmap(), false, _numDocs);
     } else {
       return new MatchAllFilterOperator(_numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -63,7 +63,7 @@ public class FilterPlanNode implements PlanNode {
     ValidDocIndexReader validDocIndexReader = _indexSegment.getValidDocIndex();
     boolean upsertSkipped = false;
     if (_queryContext.getQueryOptions() != null) {
-      upsertSkipped = new QueryOptions(_queryContext.getQueryOptions()).isUpsertSkipped();
+      upsertSkipped = new QueryOptions(_queryContext.getQueryOptions()).isSkipUpsert();
     }
     if (filter != null) {
       BaseFilterOperator filterOperator = constructPhysicalOperator(filter, _queryContext.getDebugOptions());

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.query.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.predicate.TextMatchPredicate;
 import org.apache.pinot.core.segment.index.readers.NullValueVectorReader;
 import org.apache.pinot.core.segment.index.readers.ValidDocIndexReader;
+import org.apache.pinot.core.util.QueryOptions;
 
 
 public class FilterPlanNode implements PlanNode {
@@ -60,9 +61,13 @@ public class FilterPlanNode implements PlanNode {
   public BaseFilterOperator run() {
     FilterContext filter = _queryContext.getFilter();
     ValidDocIndexReader validDocIndexReader = _indexSegment.getValidDocIndex();
+    boolean upsertDisabled = false;
+    if (_queryContext.getQueryOptions() != null) {
+      upsertDisabled = new QueryOptions(_queryContext.getQueryOptions()).isUpsertDisabled();
+    }
     if (filter != null) {
       BaseFilterOperator filterOperator = constructPhysicalOperator(filter, _queryContext.getDebugOptions());
-      if (validDocIndexReader != null) {
+      if (validDocIndexReader != null && !upsertDisabled) {
         BaseFilterOperator validDocFilter =
             new BitmapBasedFilterOperator(validDocIndexReader.getValidDocBitmap(), false, _numDocs);
         return FilterOperatorUtils.getAndFilterOperator(Arrays.asList(filterOperator, validDocFilter), _numDocs,
@@ -70,7 +75,7 @@ public class FilterPlanNode implements PlanNode {
       } else {
         return filterOperator;
       }
-    } else if (validDocIndexReader != null) {
+    } else if (validDocIndexReader != null && !upsertDisabled) {
       return new BitmapBasedFilterOperator(validDocIndexReader.getValidDocBitmap(), false, _numDocs);
     } else {
       return new MatchAllFilterOperator(_numDocs);
@@ -122,8 +127,8 @@ public class FilterPlanNode implements PlanNode {
           DataSource dataSource = _indexSegment.getDataSource(lhs.getIdentifier());
           switch (predicate.getType()) {
             case TEXT_MATCH:
-              return new TextMatchFilterOperator(dataSource.getTextIndex(),
-                  ((TextMatchPredicate) predicate).getValue(), _numDocs);
+              return new TextMatchFilterOperator(dataSource.getTextIndex(), ((TextMatchPredicate) predicate).getValue(),
+                  _numDocs);
             case IS_NULL:
               NullValueVectorReader nullValueVector = dataSource.getNullValueVector();
               if (nullValueVector != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -32,6 +32,7 @@ public class QueryOptions {
   private final boolean _groupByModeSQL;
   private final boolean _responseFormatSQL;
   private final boolean _preserveType;
+  private final boolean _disableUpsert;
 
   public QueryOptions(@Nullable Map<String, String> queryOptions) {
     if (queryOptions != null) {
@@ -39,11 +40,13 @@ public class QueryOptions {
       _groupByModeSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.GROUP_BY_MODE));
       _responseFormatSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.RESPONSE_FORMAT));
       _preserveType = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.PRESERVE_TYPE));
+      _disableUpsert = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.DISABLE_UPSERT));
     } else {
       _timeoutMs = null;
       _groupByModeSQL = false;
       _responseFormatSQL = false;
       _preserveType = false;
+      _disableUpsert = false;
     }
   }
 
@@ -62,6 +65,10 @@ public class QueryOptions {
 
   public boolean isPreserveType() {
     return _preserveType;
+  }
+
+  public boolean isUpsertDisabled() {
+    return _disableUpsert;
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -32,7 +32,7 @@ public class QueryOptions {
   private final boolean _groupByModeSQL;
   private final boolean _responseFormatSQL;
   private final boolean _preserveType;
-  private final boolean _disableUpsert;
+  private final boolean _skipUpsert;
 
   public QueryOptions(@Nullable Map<String, String> queryOptions) {
     if (queryOptions != null) {
@@ -40,13 +40,13 @@ public class QueryOptions {
       _groupByModeSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.GROUP_BY_MODE));
       _responseFormatSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.RESPONSE_FORMAT));
       _preserveType = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.PRESERVE_TYPE));
-      _disableUpsert = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.DISABLE_UPSERT));
+      _skipUpsert = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
     } else {
       _timeoutMs = null;
       _groupByModeSQL = false;
       _responseFormatSQL = false;
       _preserveType = false;
-      _disableUpsert = false;
+      _skipUpsert = false;
     }
   }
 
@@ -67,8 +67,8 @@ public class QueryOptions {
     return _preserveType;
   }
 
-  public boolean isUpsertDisabled() {
-    return _disableUpsert;
+  public boolean isUpsertSkipped() {
+    return _skipUpsert;
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -67,7 +67,7 @@ public class QueryOptions {
     return _preserveType;
   }
 
-  public boolean isUpsertSkipped() {
+  public boolean isSkipUpsert() {
     return _skipUpsert;
   }
 


### PR DESCRIPTION
## Description
Part of a series of PRs for #4261
Check this [doc](https://docs.google.com/document/d/1qljEMndPMxbbKtjlVn9mn2toz7Qrk0TGQsHLfI--7h8/edit#heading=h.lsfmyoyyxtgt) out for the new design


Add a query option for disabling upsert (mostly for debugging purpose)

```
select event_id, count(*) from meetupRsvp option(disableUpsert=false) group by event_id limit 10
```

displays:
![Screen Shot 2020-10-06 at 4 49 06 PM](https://user-images.githubusercontent.com/13425258/95945175-bb1a7800-0d9e-11eb-8d27-6760afc4ecf7.png)




