### PR TITLE
Add OnHeapGuavaBloomFilterReader

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -100,7 +100,7 @@ public class IndexLoadingConfig {
     List<String> bloomFilterColumns = indexingConfig.getBloomFilterColumns();
     if (bloomFilterColumns != null) {
       for (String bloomFilterColumn : bloomFilterColumns) {
-        _bloomFilterConfigs.put(bloomFilterColumn, new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP));
+        _bloomFilterConfigs.put(bloomFilterColumn, new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 0, false));
       }
     }
     Map<String, BloomFilterConfig> bloomFilterConfigs = indexingConfig.getBloomFilterConfigs();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BloomFilterReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BloomFilterReader.java
@@ -36,5 +36,5 @@ public interface BloomFilterReader extends Closeable {
    * otherwise.
    * <p>This method is provided to prevent hashing the same value multiple times.
    */
-  boolean mightContain(byte[] hash);
+  boolean mightContain(long hash1, long hash2);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/BaseGuavaBloomFilterReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/BaseGuavaBloomFilterReader.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.readers.bloom;
+
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Longs;
+import org.apache.pinot.core.segment.index.readers.BloomFilterReader;
+import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * Base implementation of the reader for guava bloom filter.
+ * <p>The format of the data should be aligned with the guava bloom filter.
+ */
+public abstract class BaseGuavaBloomFilterReader implements BloomFilterReader {
+  // Format of the data buffer header:
+  //   - Strategy ordinal: 1 byte
+  //   - Number of hash functions: 1 byte
+  //   - Number of long values: 4 bytes
+  private static final int STRATEGY_ORDINAL_OFFSET = 0;
+  private static final int NUM_HASH_FUNCTIONS_OFFSET = 1;
+  private static final int NUM_LONGS_OFFSET = 2;
+  private static final int HEADER_SIZE = 6;
+
+  protected final int _numHashFunctions;
+  protected final long _numBits;
+  protected final PinotDataBuffer _valueBuffer;
+
+  public BaseGuavaBloomFilterReader(PinotDataBuffer dataBuffer) {
+    byte strategyOrdinal = dataBuffer.getByte(STRATEGY_ORDINAL_OFFSET);
+    Preconditions.checkState(strategyOrdinal == 1, "Unsupported strategy ordinal: %s", strategyOrdinal);
+    _numHashFunctions = dataBuffer.getByte(NUM_HASH_FUNCTIONS_OFFSET) & 0xFF;
+    _numBits = (long) dataBuffer.getInt(NUM_LONGS_OFFSET) * Long.SIZE;
+    _valueBuffer = dataBuffer.view(HEADER_SIZE, dataBuffer.size());
+  }
+
+  @Override
+  public boolean mightContain(String value) {
+    byte[] hash = GuavaBloomFilterReaderUtils.hash(value);
+    long hash1 = Longs.fromBytes(hash[7], hash[6], hash[5], hash[4], hash[3], hash[2], hash[1], hash[0]);
+    long hash2 = Longs.fromBytes(hash[15], hash[14], hash[13], hash[12], hash[11], hash[10], hash[9], hash[8]);
+    return mightContain(hash1, hash2);
+  }
+
+  @Override
+  public void close() {
+    // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
+    // caller is responsible of closing the PinotDataBuffer.
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/BloomFilterReaderFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/BloomFilterReaderFactory.java
@@ -32,12 +32,14 @@ public class BloomFilterReaderFactory {
   private static final int VERSION_OFFSET = 4;
   private static final int HEADER_SIZE = 8;
 
-  public static BloomFilterReader getBloomFilterReader(PinotDataBuffer dataBuffer) {
+  public static BloomFilterReader getBloomFilterReader(PinotDataBuffer dataBuffer, boolean onHeap) {
     int typeValue = dataBuffer.getInt(TYPE_VALUE_OFFSET);
     int version = dataBuffer.getInt(VERSION_OFFSET);
     Preconditions.checkState(
         typeValue == OnHeapGuavaBloomFilterCreator.TYPE_VALUE && version == OnHeapGuavaBloomFilterCreator.VERSION,
         "Unsupported bloom filter type value: %s and version: %s", typeValue, version);
-    return new OffHeapGuavaBloomFilterReader(dataBuffer.view(HEADER_SIZE, dataBuffer.size()));
+    PinotDataBuffer bloomFilterDataBuffer = dataBuffer.view(HEADER_SIZE, dataBuffer.size());
+    return onHeap ? new OnHeapGuavaBloomFilterReader(bloomFilterDataBuffer)
+        : new OffHeapGuavaBloomFilterReader(bloomFilterDataBuffer);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
@@ -37,4 +37,29 @@ public class GuavaBloomFilterReaderUtils {
   public static byte[] hash(String value) {
     return HASH_FUNCTION.hashBytes(StringUtils.encodeUtf8(value)).asBytes();
   }
+
+  /* Cheat sheet:
+
+     m: total bits
+     n: expected insertions
+     b: m/n, bits per insertion
+     p: expected false positive probability
+     k: number of hash functions
+
+     1) Optimal k = b * ln2
+     2) p = (1 - e ^ (-kn/m)) ^ k
+     3) For optimal k: p = 2 ^ (-k) ~= 0.6185^b
+     4) For optimal k: m = -nlnp / ((ln2) ^ 2)
+
+     See http://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives for the formula.
+   */
+
+  /**
+   * Calculates the fpp (false positive probability) based on the given bloom filter size and number of insertions.
+   */
+  public static double computeFPP(int sizeInBytes, int numInsertions) {
+    double b = (double) sizeInBytes * Byte.SIZE / numInsertions;
+    double k = b * Math.log(2);
+    return Math.pow(2, -k);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
@@ -28,14 +28,32 @@ public class BloomFilterConfig extends BaseJsonConfig {
   public static final double DEFAULT_FPP = 0.05;
 
   private final double _fpp;
+  private final int _maxSizeInBytes;
+  private final boolean _loadOnHeap;
 
   @JsonCreator
-  public BloomFilterConfig(@JsonProperty(value = "fpp", required = true) double fpp) {
-    Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid fpp (false positive probability): %s", fpp);
-    _fpp = fpp;
+  public BloomFilterConfig(@JsonProperty(value = "fpp") double fpp,
+      @JsonProperty(value = "maxSizeInBytes") int maxSizeInBytes,
+      @JsonProperty(value = "loadOnHeap") boolean loadOnHeap) {
+    if (fpp != 0.0) {
+      Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid fpp (false positive probability): %s", fpp);
+      _fpp = fpp;
+    } else {
+      _fpp = DEFAULT_FPP;
+    }
+    _maxSizeInBytes = maxSizeInBytes;
+    _loadOnHeap = loadOnHeap;
   }
 
   public double getFpp() {
     return _fpp;
+  }
+
+  public int getMaxSizeInBytes() {
+    return _maxSizeInBytes;
+  }
+
+  public boolean isLoadOnHeap() {
+    return _loadOnHeap;
   }
 }


### PR DESCRIPTION
## Description
Add the on-heap version of the guava bloom filter reader
Add 2 new fields into the `BloomFilterConfig`:
- maxSizeInBytes: if configured, limit the max size of the bloom filter (will use a larger fpp if the configured fpp hits the limit)
- loadOnHeap: load the bloom filter on-heap or off-heap