### PR TITLE
Adding grpcPort in controller instance API response

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
@@ -31,6 +31,7 @@ public class InstanceUtils {
   }
 
   public static final String POOL_KEY = "pool";
+  public static final String GRPC_PORT_KEY = "grpcPort";
 
   /**
    * Returns the Helix instance id (e.g. {@code Server_localhost_1234}) for the given instance.
@@ -75,6 +76,7 @@ public class InstanceUtils {
       }
       instanceConfig.getRecord().setMapField(POOL_KEY, mapValue);
     }
+    instanceConfig.getRecord().setSimpleField(GRPC_PORT_KEY, Integer.toString(instance.getGrpcPort()));
     return instanceConfig;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -101,8 +101,18 @@ public class PinotInstanceRestletResource {
     response.put("port", instanceConfig.getPort());
     response.set("tags", JsonUtils.objectToJsonNode(instanceConfig.getTags()));
     response.set("pools", JsonUtils.objectToJsonNode(instanceConfig.getRecord().getMapField(InstanceUtils.POOL_KEY)));
-    response.put("grpcPort", instanceConfig.getRecord().getSimpleField(InstanceUtils.GRPC_PORT_KEY));
+    response.put("grpcPort", getGrpcPort(instanceConfig));
     return response.toString();
+  }
+
+  private int getGrpcPort(InstanceConfig instanceConfig) {
+    int grpcPort;
+    try {
+      grpcPort = Integer.parseInt(instanceConfig.getRecord().getSimpleField(InstanceUtils.GRPC_PORT_KEY));
+    } catch (Exception e) {
+      grpcPort = Instance.NOT_SET_GRPC_PORT_VALUE;
+    }
+    return grpcPort;
   }
 
   @POST

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -101,6 +101,7 @@ public class PinotInstanceRestletResource {
     response.put("port", instanceConfig.getPort());
     response.set("tags", JsonUtils.objectToJsonNode(instanceConfig.getTags()));
     response.set("pools", JsonUtils.objectToJsonNode(instanceConfig.getRecord().getMapField(InstanceUtils.POOL_KEY)));
+    response.put("grpcPort", instanceConfig.getRecord().getSimpleField(InstanceUtils.GRPC_PORT_KEY));
     return response.toString();
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.config.instance.Instance.NOT_SET_GRPC_PORT_VALUE;
 import static org.testng.Assert.fail;
 
 
@@ -75,7 +76,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     Instance brokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null);
     sendPostRequest(createInstanceUrl, brokerInstance.toJsonString());
 
-    Instance serverInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, null, null);
+    Instance serverInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, null, null, 8090);
     sendPostRequest(createInstanceUrl, serverInstance.toJsonString());
 
     // Check that there are 3 instances -- controller, broker and server
@@ -89,7 +90,8 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     serverPools.put("tag_OFFLINE", 0);
     serverPools.put("tag_REALTIME", 1);
     serverInstance =
-        new Instance("2.3.4.5", 2345, InstanceType.SERVER, Arrays.asList("tag_OFFLINE", "tag_REALTIME"), serverPools);
+        new Instance("2.3.4.5", 2345, InstanceType.SERVER, Arrays.asList("tag_OFFLINE", "tag_REALTIME"), serverPools,
+            18090);
     sendPostRequest(createInstanceUrl, serverInstance.toJsonString());
 
     // Check that there are 5 instances
@@ -116,26 +118,28 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
 
     // Check that the instances are properly created
     checkInstanceInfo("Broker_1.2.3.4_1234", "Broker_1.2.3.4", 1234, new String[0], null, null);
-    checkInstanceInfo("Server_1.2.3.4_2345", "Server_1.2.3.4", 2345, new String[0], null, null);
+    checkInstanceInfo("Server_1.2.3.4_2345", "Server_1.2.3.4", 2345, new String[0], null, null, 8090);
     checkInstanceInfo("Broker_2.3.4.5_1234", "Broker_2.3.4.5", 1234, new String[]{"tag_BROKER"}, null, null);
     checkInstanceInfo("Server_2.3.4.5_2345", "Server_2.3.4.5", 2345, new String[]{"tag_OFFLINE", "tag_REALTIME"},
-        new String[]{"tag_OFFLINE", "tag_REALTIME"}, new int[]{0, 1});
+        new String[]{"tag_OFFLINE", "tag_REALTIME"}, new int[]{0, 1}, 18090);
 
     // Test PUT Instance API
     String newBrokerTag = "new-broker-tag";
-    Instance newBrokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null);
+    Instance newBrokerInstance =
+        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null);
     String brokerInstanceId = "Broker_1.2.3.4_1234";
     String brokerInstanceUrl = _controllerRequestURLBuilder.forInstance(brokerInstanceId);
     sendPutRequest(brokerInstanceUrl, newBrokerInstance.toJsonString());
 
     String newServerTag = "new-server-tag";
-    Instance newServerInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, Collections.singletonList(newServerTag), null);
+    Instance newServerInstance =
+        new Instance("1.2.3.4", 2345, InstanceType.SERVER, Collections.singletonList(newServerTag), null, 28090);
     String serverInstanceId = "Server_1.2.3.4_2345";
     String serverInstanceUrl = _controllerRequestURLBuilder.forInstance(serverInstanceId);
     sendPutRequest(serverInstanceUrl, newServerInstance.toJsonString());
 
     checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{newBrokerTag}, null, null);
-    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null);
+    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null, 28090);
 
     // Test Instance updateTags API
     String brokerInstanceUpdateTagsUrl = _controllerRequestURLBuilder
@@ -144,14 +148,18 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     String serverInstanceUpdateTagsUrl = _controllerRequestURLBuilder.forInstanceUpdateTags(serverInstanceId,
         Lists.newArrayList("tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"));
     sendPutRequest(serverInstanceUpdateTagsUrl);
-    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null,
-        null);
+    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null, null);
     checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345,
-        new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null);
+        new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null, 28090);
   }
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,
       int[] poolValues) {
+    checkInstanceInfo(instanceName, hostName, port, tags, pools, poolValues, NOT_SET_GRPC_PORT_VALUE);
+  }
+
+  private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,
+      int[] poolValues, int grpcPort) {
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Nullable
       @Override
@@ -164,7 +172,8 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
                   && (instance.get("hostName") != null) && (instance.get("hostName").asText().equals(hostName)) && (
                   instance.get("port") != null) && (instance.get("port").asText().equals(String.valueOf(port)))
                   && (instance.get("enabled").asBoolean()) && (instance.get("tags") != null) && (
-                  instance.get("tags").size() == tags.length);
+                  instance.get("tags").size() == tags.length) && (instance.get("grpcPort").asText()
+                  .equals(String.valueOf(grpcPort)));
 
           for (int i = 0; i < tags.length; i++) {
             result = result && instance.get("tags").get(i).asText().equals(tags[i]);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.config.instance.Instance.NOT_SET_GRPC_PORT_VALUE;
 import static org.testng.Assert.fail;
 
 
@@ -73,7 +72,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
 
     // Create untagged broker and server instances
     String createInstanceUrl = _controllerRequestURLBuilder.forInstanceCreate();
-    Instance brokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null);
+    Instance brokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null, 0);
     sendPostRequest(createInstanceUrl, brokerInstance.toJsonString());
 
     Instance serverInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, null, null, 8090);
@@ -83,7 +82,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     checkNumInstances(listInstancesUrl, 3);
 
     // Create broker and server instances with tags and pools
-    brokerInstance = new Instance("2.3.4.5", 1234, InstanceType.BROKER, Collections.singletonList("tag_BROKER"), null);
+    brokerInstance = new Instance("2.3.4.5", 1234, InstanceType.BROKER, Collections.singletonList("tag_BROKER"), null, 0);
     sendPostRequest(createInstanceUrl, brokerInstance.toJsonString());
 
     Map<String, Integer> serverPools = new TreeMap<>();
@@ -126,7 +125,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     // Test PUT Instance API
     String newBrokerTag = "new-broker-tag";
     Instance newBrokerInstance =
-        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null);
+        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null, 0);
     String brokerInstanceId = "Broker_1.2.3.4_1234";
     String brokerInstanceUrl = _controllerRequestURLBuilder.forInstance(brokerInstanceId);
     sendPutRequest(brokerInstanceUrl, newBrokerInstance.toJsonString());
@@ -155,7 +154,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,
       int[] poolValues) {
-    checkInstanceInfo(instanceName, hostName, port, tags, pools, poolValues, NOT_SET_GRPC_PORT_VALUE);
+    checkInstanceInfo(instanceName, hostName, port, tags, pools, poolValues, Instance.NOT_SET_GRPC_PORT_VALUE);
   }
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -186,7 +186,7 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
 
     // Add new instance.
     Instance instance = new Instance("localhost", biggerRandomNumber, InstanceType.SERVER,
-        Collections.singletonList(UNTAGGED_SERVER_INSTANCE), null);
+        Collections.singletonList(UNTAGGED_SERVER_INSTANCE), null, 0);
     _helixResourceManager.addInstance(instance);
 
     List<String> allInstances = _helixResourceManager.getAllInstances();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
@@ -53,11 +53,6 @@ public class Instance extends BaseJsonConfig {
   private final Map<String, Integer> _pools;
   private final int _grpcPort;
 
-
-  public Instance(String host, int port, InstanceType type, List<String> tags, Map<String, Integer> pools) {
-    this(host, port, type, tags, pools, NOT_SET_GRPC_PORT_VALUE);
-  }
-
   @JsonCreator
   public Instance(@JsonProperty(value = "host", required = true) String host,
       @JsonProperty(value = "port", required = true) int port,
@@ -71,7 +66,11 @@ public class Instance extends BaseJsonConfig {
     _type = type;
     _tags = tags;
     _pools = pools;
-    _grpcPort = grpcPort;
+    if (grpcPort == 0) {
+      _grpcPort = NOT_SET_GRPC_PORT_VALUE;
+    } else {
+      _grpcPort = grpcPort;
+    }
   }
 
   public String getHost() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
@@ -38,22 +38,32 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  *   "tags": ["example_OFFLINE"],
  *   "pools": {
  *     "example_OFFLINE": 0
- *   }
+ *   },
+ *   "grpcPort": 8090
  * }
  * </pre>
  */
 public class Instance extends BaseJsonConfig {
+  public static int NOT_SET_GRPC_PORT_VALUE = -1;
+
   private final String _host;
   private final int _port;
   private final InstanceType _type;
   private final List<String> _tags;
   private final Map<String, Integer> _pools;
+  private final int _grpcPort;
+
+
+  public Instance(String host, int port, InstanceType type, List<String> tags, Map<String, Integer> pools) {
+    this(host, port, type, tags, pools, NOT_SET_GRPC_PORT_VALUE);
+  }
 
   @JsonCreator
   public Instance(@JsonProperty(value = "host", required = true) String host,
       @JsonProperty(value = "port", required = true) int port,
       @JsonProperty(value = "type", required = true) InstanceType type,
-      @JsonProperty("tags") @Nullable List<String> tags, @JsonProperty("pools") @Nullable Map<String, Integer> pools) {
+      @JsonProperty("tags") @Nullable List<String> tags, @JsonProperty("pools") @Nullable Map<String, Integer> pools,
+      @JsonProperty("grpcPort") int grpcPort) {
     Preconditions.checkArgument(host != null, "'host' must be configured");
     Preconditions.checkArgument(type != null, "'type' must be configured");
     _host = host;
@@ -61,6 +71,7 @@ public class Instance extends BaseJsonConfig {
     _type = type;
     _tags = tags;
     _pools = pools;
+    _grpcPort = grpcPort;
   }
 
   public String getHost() {
@@ -83,5 +94,9 @@ public class Instance extends BaseJsonConfig {
   @Nullable
   public Map<String, Integer> getPools() {
     return _pools;
+  }
+
+  public int getGrpcPort() {
+    return _grpcPort;
   }
 }


### PR DESCRIPTION
## Description
Adding field "grpcPort" in controller's /instance API responses.
So external services can get the grpc port used for the given pinot server.
The default grpc port is 8090 if enabled, for non-enabled server instances, will put -1 there.