### PR TITLE
Fix quick demo instructions #6155

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ cd incubator-pinot
 $ mvn clean install -DskipTests -Pbin-dist
 
 # Run the Quick Demo
-$ cd pinot-distribution/target/apache-pinot-incubating-<version>-SNAPSHOT-bin
+$ cd pinot-distribution/target/apache-pinot-incubating-<version>-SNAPSHOT-bin/apache-pinot-incubating-<version>-SNAPSHOT-bin
 $ bin/quick-start-batch.sh
 ```
 


### PR DESCRIPTION
## Description

In the readme document, I noticed that the quick demo instruction has:

```
Run the Quick Demo
$ cd pinot-distribution/target/apache-pinot-incubating--SNAPSHOT-bin
```
While in reality, it is :
`$ cd pinot-distribution/target/apache-pinot-incubating--SNAPSHOT-bin/apache-pinot-incubating--SNAPSHOT-bin`

Also, the running_locally.md file has the correct path, fixing the README.md will make it consistent.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
