### PR TITLE
Bump up Tyrus version to 1.15

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -111,6 +111,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-grizzly2-http</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1126,7 +1126,7 @@
       <dependency>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-standalone-client</artifactId>
-        <version>1.5</version>
+        <version>1.15</version>
       </dependency>
       <!-- hadoop-common & jmh-core use common-math3 -->
       <dependency>


### PR DESCRIPTION
## Description
This PR bumps up Tyrus version to 1.15. This is to solve the issue that pinot-tools modules happens to use two classes with the same name and package.