### PR TITLE
Add table level lock for segment upload

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -55,7 +55,7 @@ public class HelixHelper {
   private static final String ENABLE_COMPRESSIONS_KEY = "enableCompression";
 
   private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 2.0f);
-  private static final RetryPolicy DEFAULT_TABLE_IDEALSTATES_UPDATE_RETRY_POLICY = RetryPolicies.fixedDelayRetryPolicy(20, 100L);
+  private static final RetryPolicy DEFAULT_TABLE_IDEALSTATES_UPDATE_RETRY_POLICY = RetryPolicies.randomDelayRetryPolicy(20, 100L, 200L);
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixHelper.class);
   private static final ZNRecordSerializer ZN_RECORD_SERIALIZER = new ZNRecordSerializer();
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -55,6 +55,7 @@ public class HelixHelper {
   private static final String ENABLE_COMPRESSIONS_KEY = "enableCompression";
 
   private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 2.0f);
+  private static final RetryPolicy DEFAULT_TABLE_IDEALSTATES_UPDATE_RETRY_POLICY = RetryPolicies.fixedDelayRetryPolicy(20, 100L);
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixHelper.class);
   private static final ZNRecordSerializer ZN_RECORD_SERIALIZER = new ZNRecordSerializer();
 
@@ -167,7 +168,7 @@ public class HelixHelper {
 
   public static void updateIdealState(HelixManager helixManager, String resourceName,
       Function<IdealState, IdealState> updater) {
-    updateIdealState(helixManager, resourceName, updater, DEFAULT_RETRY_POLICY, false);
+    updateIdealState(helixManager, resourceName, updater, DEFAULT_TABLE_IDEALSTATES_UPDATE_RETRY_POLICY, false);
   }
 
   public static void updateIdealState(final HelixManager helixManager, final String resourceName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1680,7 +1680,7 @@ public class PinotHelixResourceManager {
   }
 
   private Object getTableUpdaterLock(String offlineTableName) {
-    return _tableUpdaterLocks[offlineTableName.hashCode() % _tableUpdaterLocks.length];
+    return _tableUpdaterLocks[(offlineTableName.hashCode() & Integer.MAX_VALUE) % _tableUpdaterLocks.length];
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RandomDelayRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RandomDelayRetryPolicy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.utils.retry;
 
+import com.google.common.base.Preconditions;
 import java.util.Random;
 
 
@@ -27,18 +28,17 @@ import java.util.Random;
 public class RandomDelayRetryPolicy extends BaseRetryPolicy {
   private final static Random RANDOM = new Random(System.currentTimeMillis());
   private final long _minDelayMs;
-  private final int _rangeUpper;
-  private final int _rangeLower;
+  private final long _maxDelayMs;
 
   public RandomDelayRetryPolicy(int maxNumAttempts, long minDelayMs, long maxDelayMs) {
     super(maxNumAttempts);
+    Preconditions.checkState(maxDelayMs > minDelayMs, "RandomDelayRetryPolicy requires maxDelayMs > minDelayMs");
     _minDelayMs = minDelayMs;
-    _rangeUpper = (int) ((maxDelayMs - minDelayMs) / Integer.MAX_VALUE + 1);
-    _rangeLower = (int) ((maxDelayMs - minDelayMs) % Integer.MAX_VALUE);
+    _maxDelayMs = maxDelayMs;
   }
 
   @Override
   protected long getDelayMs(int currentAttempt) {
-    return RANDOM.nextInt(_rangeUpper) * Integer.MAX_VALUE + RANDOM.nextInt(_rangeLower) + _minDelayMs;
+    return _minDelayMs + (long) (RANDOM.nextDouble() * (_maxDelayMs - _minDelayMs));
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RandomDelayRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RandomDelayRetryPolicy.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils.retry;
+
+import java.util.Random;
+
+
+/**
+ * Delay policy with random delay between attempts.
+ */
+public class RandomDelayRetryPolicy extends BaseRetryPolicy {
+  private final static Random RANDOM = new Random(System.currentTimeMillis());
+  private final long _minDelayMs;
+  private final int _rangeUpper;
+  private final int _rangeLower;
+
+  public RandomDelayRetryPolicy(int maxNumAttempts, long minDelayMs, long maxDelayMs) {
+    super(maxNumAttempts);
+    _minDelayMs = minDelayMs;
+    _rangeUpper = (int) ((maxDelayMs - minDelayMs) / Integer.MAX_VALUE + 1);
+    _rangeLower = (int) ((maxDelayMs - minDelayMs) % Integer.MAX_VALUE);
+  }
+
+  @Override
+  protected long getDelayMs(int currentAttempt) {
+    return RANDOM.nextInt(_rangeUpper) * Integer.MAX_VALUE + RANDOM.nextInt(_rangeLower) + _minDelayMs;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetryPolicies.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetryPolicies.java
@@ -50,6 +50,18 @@ public class RetryPolicies {
   }
 
   /**
+   * Creates a {@link RandomDelayRetryPolicy}.
+   *
+   * @param maxNumAttempts The maximum number of attempts to try
+   * @param minDelayMs The min delay in milliseconds between attempts (inclusive)
+   * @param maxDelayMs The max delay in milliseconds between attempts (exclusive)
+   * @return The retry policy
+   */
+  public static RandomDelayRetryPolicy randomDelayRetryPolicy(int maxNumAttempts, long minDelayMs, long maxDelayMs) {
+    return new RandomDelayRetryPolicy(maxNumAttempts, minDelayMs, maxDelayMs);
+  }
+
+  /**
    * Creates a {@link NoDelayRetryPolicy}.
    *
    * @param maxNumAttempts The maximum number of attempts to try

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
@@ -54,6 +54,38 @@ public class RetryPolicyTest {
   }
 
   @Test
+  public void testRandomDelayRetryPolicy() {
+    RandomDelayRetryPolicy randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, 10, 11);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= 10);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < 11);
+      }
+    }
+    randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, 10, 100);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= 10);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < 100);
+      }
+    }
+    randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, Integer.MAX_VALUE, (long)Integer.MAX_VALUE + 1);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= Integer.MAX_VALUE);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long)Integer.MAX_VALUE + 1);
+      }
+    }
+    randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, (long)Integer.MAX_VALUE + 1, (long)Integer.MAX_VALUE + 10);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= (long)Integer.MAX_VALUE + 1);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long)Integer.MAX_VALUE + 10);
+      }
+    }
+  }
+
+  @Test
   public void testExponentialBackoffRetryPolicy() {
     ExponentialBackoffRetryPolicy exponentialBackoffRetryPolicy =
         new ExponentialBackoffRetryPolicy(MAX_NUM_ATTEMPTS, 10, 2.0);


### PR DESCRIPTION
## Description
Add table level lock for segment upload to avoid unnecessary race conditions to cause idealstates update failure when pushing new segments with high parallelism.
