### PR TITLE
Support reloading upsert table

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
 import org.apache.pinot.core.segment.index.datasource.ImmutableDataSource;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
@@ -50,25 +51,29 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   private final SegmentMetadataImpl _segmentMetadata;
   private final Map<String, ColumnIndexContainer> _indexContainerMap;
   private final StarTreeIndexContainer _starTreeIndexContainer;
-  private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
-  private final ValidDocIndexReader _validDocIndex;
+
+  // For upsert
+  private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
+  private ThreadSafeMutableRoaringBitmap _validDocIds;
+  private ValidDocIndexReader _validDocIndex;
 
   public ImmutableSegmentImpl(SegmentDirectory segmentDirectory, SegmentMetadataImpl segmentMetadata,
       Map<String, ColumnIndexContainer> columnIndexContainerMap,
-      @Nullable StarTreeIndexContainer starTreeIndexContainer,
-      @Nullable PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
+      @Nullable StarTreeIndexContainer starTreeIndexContainer) {
     _segmentDirectory = segmentDirectory;
     _segmentMetadata = segmentMetadata;
     _indexContainerMap = columnIndexContainerMap;
     _starTreeIndexContainer = starTreeIndexContainer;
-    if (partitionUpsertMetadataManager != null) {
-      _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
-      _validDocIndex =
-          new ValidDocIndexReaderImpl(partitionUpsertMetadataManager.createValidDocIds(getSegmentName()));
-    } else {
-      _partitionUpsertMetadataManager = null;
-      _validDocIndex = null;
-    }
+  }
+
+  /**
+   * Enables upsert for this segment.
+   */
+  public void enableUpsert(PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      ThreadSafeMutableRoaringBitmap validDocIds) {
+    _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
+    _validDocIds = validDocIds;
+    _validDocIndex = new ValidDocIndexReaderImpl(validDocIds);
   }
 
   @Override
@@ -147,7 +152,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
       }
     }
     if (_partitionUpsertMetadataManager != null) {
-      _partitionUpsertMetadataManager.removeSegment(segmentName);
+      _partitionUpsertMetadataManager.removeSegment(segmentName, _validDocIds);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -67,7 +67,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   }
 
   /**
-   * Enables upsert for this segment.
+   * Enables upsert for this segment. It should be called before the segment getting queried.
    */
   public void enableUpsert(PartitionUpsertMetadataManager partitionUpsertMetadataManager,
       ThreadSafeMutableRoaringBitmap validDocIds) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -39,7 +39,6 @@ import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnContext;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
 import org.apache.pinot.core.startree.v2.store.StarTreeIndexContainer;
-import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
@@ -65,29 +64,12 @@ public class ImmutableSegmentLoader {
   /**
    * For tests only.
    */
-  public static ImmutableSegment load(File indexDir, ReadMode readMode,
-      @Nullable PartitionUpsertMetadataManager partitionUpsertMetadataManager)
-      throws Exception {
-    IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
-    defaultIndexLoadingConfig.setReadMode(readMode);
-    return load(indexDir, defaultIndexLoadingConfig, null, partitionUpsertMetadataManager);
-  }
-
-  /**
-   * For tests only.
-   */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     return load(indexDir, indexLoadingConfig, null);
   }
 
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema)
-      throws Exception {
-    return load(indexDir, indexLoadingConfig, schema, null);
-  }
-
-  public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema,
-      @Nullable PartitionUpsertMetadataManager partitionUpsertMetadataManager)
       throws Exception {
     Preconditions
         .checkArgument(indexDir.isDirectory(), "Index directory: %s does not exist or is not a directory", indexDir);
@@ -152,8 +134,7 @@ public class ImmutableSegmentLoader {
     }
 
     ImmutableSegmentImpl segment =
-        new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer,
-            partitionUpsertMetadataManager);
+        new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
     LOGGER.info("Successfully loaded segment {} with readMode: {}", segmentName, readMode);
     return segment;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -68,7 +68,7 @@ import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager;
-import org.apache.pinot.core.upsert.RecordLocation;
+import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager.RecordInfo;
 import org.apache.pinot.core.util.FixedIntArray;
 import org.apache.pinot.core.util.FixedIntArrayOffHeapIdMap;
 import org.apache.pinot.core.util.IdMap;
@@ -92,7 +92,6 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class MutableSegmentImpl implements MutableSegment {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MutableSegmentImpl.class);
   // For multi-valued column, forward-index.
   // Maximum number of multi-values per row. We assert on this.
   private static final int MAX_MULTI_VALUES_PER_ROW = 1000;
@@ -484,8 +483,8 @@ public class MutableSegmentImpl implements MutableSegment {
     Object timeValue = row.getValue(_timeColumnName);
     Preconditions.checkArgument(timeValue instanceof Comparable, "time column shall be comparable");
     long timestamp = IngestionUtils.extractTimeValue((Comparable) timeValue);
-    RecordLocation recordLocation = new RecordLocation(_segmentName, docId, timestamp, true);
-    _partitionUpsertMetadataManager.updateRecordLocation(primaryKey, recordLocation, _validDocIds);
+    _partitionUpsertMetadataManager
+        .updateRecord(_segmentName, new RecordInfo(primaryKey, docId, timestamp), _validDocIds);
   }
 
   private void updateDictionary(GenericRow row) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
@@ -81,11 +81,9 @@ public class SelectionQuerySegmentPruner implements SegmentPruner {
       return segmentDataManagers;
     }
 
-    // Do not prune for upsert table
-    if (!segmentDataManagers.isEmpty()) {
-      if (segmentDataManagers.get(0).getSegment().getValidDocIndex() != null) {
-        return segmentDataManagers;
-      }
+    // Skip pruning segments for upsert table because valid doc index is equivalent to a filter
+    if (segmentDataManagers.get(0).getSegment().getValidDocIndex() != null) {
+      return segmentDataManagers;
     }
 
     if (queryContext.getOrderByExpressions() == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pinot.core.upsert;
 
-import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
@@ -29,97 +30,142 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Manages the upsert metadata per partition.
+ * <p>For multiple records with the same timestamp, there is no guarantee on which record to be preserved.
+ * <p>There will be short term inconsistency when updating the upsert metadata, but should be consistent after the
+ * operation is done:
+ * <ul>
+ *   <li>
+ *     When updating a new record, it first removes the doc id from the current location, then update the new location.
+ *   </li>
+ *   <li>
+ *     When adding a new segment, it removes the doc ids from the current locations before the segment being added to
+ *     the RealtimeTableDataManager.
+ *   </li>
+ *   <li>
+ *     When replacing an existing segment, the updates applied to the new segment won't be reflected to the replaced
+ *     segment.
+ *   </li>
+ * </ul>
  */
 @ThreadSafe
 public class PartitionUpsertMetadataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionUpsertMetadataManager.class);
 
   // TODO(upset): consider an off-heap KV store to persist this index to improve the recovery speed.
-  private final ConcurrentHashMap<PrimaryKey, RecordLocation> _primaryKeyToRecordLocationMap =
-      new ConcurrentHashMap<>();
-  // the mapping between the (sealed) segment and its validDocuments
-  private final ConcurrentHashMap<String, ThreadSafeMutableRoaringBitmap> _segmentToValidDocIdsMap =
-      new ConcurrentHashMap<>();
+  @VisibleForTesting
+  final ConcurrentHashMap<PrimaryKey, RecordLocation> _primaryKeyToRecordLocationMap = new ConcurrentHashMap<>();
 
   /**
-   * Creates the valid doc ids for the given (immutable) segment.
+   * Initializes the upsert metadata for the given immutable segment, returns the valid doc ids for the segment.
    */
-  public ThreadSafeMutableRoaringBitmap createValidDocIds(String segmentName) {
-    LOGGER.info("Creating valid doc ids for segment: {}", segmentName);
+  public ThreadSafeMutableRoaringBitmap addSegment(String segmentName, Iterator<RecordInfo> recordInfoIterator) {
+    LOGGER.info("Adding upsert metadata for segment: {}", segmentName);
+
     ThreadSafeMutableRoaringBitmap validDocIds = new ThreadSafeMutableRoaringBitmap();
-    if (_segmentToValidDocIdsMap.put(segmentName, validDocIds) != null) {
-      LOGGER.warn("Valid doc ids exist for segment: {}, replacing it", segmentName);
+    while (recordInfoIterator.hasNext()) {
+      RecordInfo recordInfo = recordInfoIterator.next();
+      _primaryKeyToRecordLocationMap.compute(recordInfo._primaryKey, (primaryKey, currentRecordLocation) -> {
+        if (currentRecordLocation != null) {
+          // Existing primary key
+
+          if (segmentName.equals(currentRecordLocation.getSegmentName())) {
+            // The current record location has the same segment name
+
+            if (validDocIds == currentRecordLocation.getValidDocIds()) {
+              // The current record location is pointing to the new segment being loaded
+
+              // Update the record location when getting a newer timestamp
+              if (recordInfo._timestamp > currentRecordLocation.getTimestamp()) {
+                validDocIds.remove(currentRecordLocation.getDocId());
+                validDocIds.add(recordInfo._docId);
+                return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
+              }
+            } else {
+              // The current record location is pointing to the old segment being replaced. This could happen when
+              // committing a consuming segment, or reloading a completed segment.
+
+              // Update the record location when the new timestamp is greater than or equal to the current timestamp.
+              // Update the record location when there is a tie because the record locations should point to the new
+              // segment instead of the old segment being replaced. Also, do not update the valid doc ids for the old
+              // segment because it has not been replaced yet.
+              if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {
+                validDocIds.add(recordInfo._docId);
+                return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
+              }
+            }
+            return currentRecordLocation;
+          }
+
+          // Update the record location when getting a newer timestamp
+          if (recordInfo._timestamp > currentRecordLocation.getTimestamp()) {
+            currentRecordLocation.getValidDocIds().remove(currentRecordLocation.getDocId());
+            validDocIds.add(recordInfo._docId);
+            return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
+          } else {
+            return currentRecordLocation;
+          }
+        } else {
+          // New primary key
+          validDocIds.add(recordInfo._docId);
+          return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
+        }
+      });
     }
     return validDocIds;
   }
 
   /**
-   * Returns the valid doc ids for the given (immutable) segment.
+   * Updates the upsert metadata for a new consumed record in the given consuming segment.
    */
-  public ThreadSafeMutableRoaringBitmap getValidDocIds(String segmentName) {
-    return Preconditions
-        .checkNotNull(_segmentToValidDocIdsMap.get(segmentName), "Failed to find valid doc ids for segment: %s",
-            segmentName);
-  }
-
-  /**
-   * Updates the record location of the given primary key if the given record location is newer than the current record
-   * location. Also updates the valid doc ids accordingly if the record location is updated.
-   */
-  public void updateRecordLocation(PrimaryKey primaryKey, RecordLocation recordLocation,
+  public synchronized void updateRecord(String segmentName, RecordInfo recordInfo,
       ThreadSafeMutableRoaringBitmap validDocIds) {
-    _primaryKeyToRecordLocationMap.compute(primaryKey, (k, v) -> {
-      if (v != null) {
+    _primaryKeyToRecordLocationMap.compute(recordInfo._primaryKey, (primaryKey, currentRecordLocation) -> {
+      if (currentRecordLocation != null) {
         // Existing primary key
 
-        if (recordLocation.getTimestamp() >= v.getTimestamp()) {
-          // Update the record location
-          // NOTE: Update the record location when there is a tie on the timestamp because during the segment
-          //       commitment, when loading the committed segment, it should replace the old record locations in case
-          //       the order of records changed.
-
-          // Remove the doc from the valid doc ids of the previous location
-          if (v.isConsuming()) {
-            // Previous location is a consuming segment, whose valid doc ids are maintained locally. Only update the
-            // valid doc ids when the update is from the same segment.
-            if (recordLocation.isConsuming() && recordLocation.getSegmentName().equals(v.getSegmentName())) {
-              validDocIds.remove(v.getDocId());
-            }
-          } else {
-            ThreadSafeMutableRoaringBitmap validDocIdsForPreviousLocation =
-                _segmentToValidDocIdsMap.get(v.getSegmentName());
-            if (validDocIdsForPreviousLocation != null) {
-              validDocIdsForPreviousLocation.remove(v.getDocId());
-            } else {
-              LOGGER.warn("Failed to find valid doc ids for previous location: {}", v.getSegmentName());
-            }
-          }
-
-          validDocIds.add(recordLocation.getDocId());
-          return recordLocation;
+        // Update the record location when getting a newer timestamp
+        if (recordInfo._timestamp > currentRecordLocation.getTimestamp()) {
+          currentRecordLocation.getValidDocIds().remove(currentRecordLocation.getDocId());
+          validDocIds.add(recordInfo._docId);
+          return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
         } else {
-          // No need to update
-          return v;
+          return currentRecordLocation;
         }
       } else {
         // New primary key
-        validDocIds.add(recordLocation.getDocId());
-        return recordLocation;
+        validDocIds.add(recordInfo._docId);
+        return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
       }
     });
   }
 
   /**
-   * Removes the upsert metadata for the given segment.
+   * Removes the upsert metadata for the given immutable segment. No need to remove the upsert metadata for the
+   * consuming segment because it should be replaced by the committed segment.
    */
-  public void removeSegment(String segmentName) {
+  public synchronized void removeSegment(String segmentName, ThreadSafeMutableRoaringBitmap validDocIds) {
     LOGGER.info("Removing upsert metadata for segment: {}", segmentName);
-    _primaryKeyToRecordLocationMap.forEach((k, v) -> {
-      if (v.getSegmentName().equals(segmentName)) {
-        // NOTE: Check and remove to prevent removing the key that is just updated.
-        _primaryKeyToRecordLocationMap.remove(k, v);
-      }
-    });
-    _segmentToValidDocIdsMap.remove(segmentName);
+
+    if (!validDocIds.getMutableRoaringBitmap().isEmpty()) {
+      // Remove all the record locations that point to the valid doc ids of the removed segment.
+      _primaryKeyToRecordLocationMap.forEach((primaryKey, recordLocation) -> {
+        if (recordLocation.getValidDocIds() == validDocIds) {
+          // Check and remove to prevent removing the key that is just updated.
+          _primaryKeyToRecordLocationMap.remove(primaryKey, recordLocation);
+        }
+      });
+    }
+  }
+
+  public static final class RecordInfo {
+    private final PrimaryKey _primaryKey;
+    private final int _docId;
+    private final long _timestamp;
+
+    public RecordInfo(PrimaryKey primaryKey, int docId, long timestamp) {
+      _primaryKey = primaryKey;
+      _docId = docId;
+      _timestamp = timestamp;
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/RecordLocation.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/RecordLocation.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.upsert;
 
-import java.util.Objects;
+import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 
 
 /**
@@ -28,13 +28,13 @@ public class RecordLocation {
   private final String _segmentName;
   private final int _docId;
   private final long _timestamp;
-  private final boolean _isConsuming;
+  private final ThreadSafeMutableRoaringBitmap _validDocIds;
 
-  public RecordLocation(String segmentName, int docId, long timestamp, boolean isConsuming) {
+  public RecordLocation(String segmentName, int docId, long timestamp, ThreadSafeMutableRoaringBitmap validDocIds) {
     _segmentName = segmentName;
     _docId = docId;
     _timestamp = timestamp;
-    _isConsuming = isConsuming;
+    _validDocIds = validDocIds;
   }
 
   public String getSegmentName() {
@@ -49,25 +49,7 @@ public class RecordLocation {
     return _timestamp;
   }
 
-  public boolean isConsuming() {
-    return _isConsuming;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof RecordLocation)) {
-      return false;
-    }
-    RecordLocation that = (RecordLocation) o;
-    return _docId == that._docId && _timestamp == that._timestamp && _isConsuming == that._isConsuming && Objects
-        .equals(_segmentName, that._segmentName);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(_segmentName, _docId, _timestamp, _isConsuming);
+  public ThreadSafeMutableRoaringBitmap getValidDocIds() {
+    return _validDocIds;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.plan.AggregationGroupByPlanNode;
 import org.apache.pinot.core.plan.AggregationPlanNode;
@@ -37,6 +38,7 @@ import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.plan.SelectionPlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager;
@@ -117,8 +119,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void loadSegment()
       throws Exception {
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    _upsertIndexSegment = ImmutableSegmentLoader
-        .load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap, new PartitionUpsertMetadataManager());
+    _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
+    ((ImmutableSegmentImpl) _upsertIndexSegment)
+        .enableUpsert(new PartitionUpsertMetadataManager(), new ThreadSafeMutableRoaringBitmap());
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
@@ -91,6 +91,19 @@ public class PartitionUpsertMetadataManagerTest {
     assertEquals(newValidDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 4});
     assertSame(recordLocationMap.get(getPrimaryKey(0)).getValidDocIds(), newValidDocIds1);
     assertSame(recordLocationMap.get(getPrimaryKey(1)).getValidDocIds(), newValidDocIds1);
+
+    // Remove the original segment1
+    upsertMetadataManager.removeSegment(segment1, validDocIds1);
+    // segment2: 2 -> {2, 120}, 3 -> {3, 80}
+    // new segment1: 0 -> {0, 100}, 1 -> {4, 120}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 4, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 2, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 3, 80);
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{2, 3});
+    assertEquals(newValidDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 4});
+    assertSame(recordLocationMap.get(getPrimaryKey(0)).getValidDocIds(), newValidDocIds1);
+    assertSame(recordLocationMap.get(getPrimaryKey(1)).getValidDocIds(), newValidDocIds1);
   }
 
   private static PrimaryKey getPrimaryKey(int value) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.upsert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager.RecordInfo;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+
+public class PartitionUpsertMetadataManagerTest {
+  private static final String SEGMENT_PREFIX = "testSegment";
+
+  @Test
+  public void testAddSegment() {
+    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add the first segment
+    String segment1 = SEGMENT_PREFIX + 1;
+    List<RecordInfo> recordInfoList1 = new ArrayList<>();
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(0), 0, 100));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(1), 1, 100));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(2), 2, 100));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(0), 3, 80));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(1), 4, 120));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(0), 5, 100));
+    ThreadSafeMutableRoaringBitmap validDocIds1 =
+        upsertMetadataManager.addSegment(segment1, recordInfoList1.iterator());
+    // segment1: 0 -> {0, 100}, 1 -> {4, 120}, 2 -> {2, 100}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 4, 120);
+    checkRecordLocation(recordLocationMap, 2, segment1, 2, 100);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 2, 4});
+
+    // Add the second segment
+    String segment2 = SEGMENT_PREFIX + 2;
+    List<RecordInfo> recordInfoList2 = new ArrayList<>();
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(0), 0, 100));
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(1), 1, 100));
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(2), 2, 120));
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(3), 3, 80));
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(0), 4, 80));
+    ThreadSafeMutableRoaringBitmap validDocIds2 =
+        upsertMetadataManager.addSegment(segment2, recordInfoList2.iterator());
+    // segment1: 0 -> {0, 100}, 1 -> {4, 120}
+    // segment2: 2 -> {2, 120}, 3 -> {3, 80}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 4, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 2, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 3, 80);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 4});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{2, 3});
+
+    // Replace (reload) the first segment
+    ThreadSafeMutableRoaringBitmap newValidDocIds1 =
+        upsertMetadataManager.addSegment(segment1, recordInfoList1.iterator());
+    // original segment1: 0 -> {0, 100}, 1 -> {4, 120}
+    // segment2: 2 -> {2, 120}, 3 -> {3, 80}
+    // new segment1: 0 -> {0, 100}, 1 -> {4, 120}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 4, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 2, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 3, 80);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 4});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{2, 3});
+    assertEquals(newValidDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 4});
+    assertSame(recordLocationMap.get(getPrimaryKey(0)).getValidDocIds(), newValidDocIds1);
+    assertSame(recordLocationMap.get(getPrimaryKey(1)).getValidDocIds(), newValidDocIds1);
+  }
+
+  private static PrimaryKey getPrimaryKey(int value) {
+    return new PrimaryKey(new Object[]{value});
+  }
+
+  private static void checkRecordLocation(Map<PrimaryKey, RecordLocation> recordLocationMap, int keyValue,
+      String segmentName, int docId, long timestamp) {
+    RecordLocation recordLocation = recordLocationMap.get(getPrimaryKey(keyValue));
+    assertNotNull(recordLocation);
+    assertEquals(recordLocation.getSegmentName(), segmentName);
+    assertEquals(recordLocation.getDocId(), docId);
+    assertEquals(recordLocation.getTimestamp(), timestamp);
+  }
+
+  @Test
+  public void testUpdateRecord() {
+    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add the first segment
+    // segment1: 0 -> {0, 100}, 1 -> {1, 120}, 2 -> {2, 100}
+    String segment1 = SEGMENT_PREFIX + 1;
+    List<RecordInfo> recordInfoList1 = new ArrayList<>();
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(0), 0, 100));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(1), 1, 120));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(2), 2, 100));
+    ThreadSafeMutableRoaringBitmap validDocIds1 =
+        upsertMetadataManager.addSegment(segment1, recordInfoList1.iterator());
+
+    // Update records from the second segment
+    String segment2 = SEGMENT_PREFIX + 2;
+    ThreadSafeMutableRoaringBitmap validDocIds2 = new ThreadSafeMutableRoaringBitmap();
+
+    upsertMetadataManager.updateRecord(segment2, new RecordInfo(getPrimaryKey(3), 0, 100), validDocIds2);
+    // segment1: 0 -> {0, 100}, 1 -> {1, 120}, 2 -> {2, 100}
+    // segment2: 3 -> {0, 100}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 1, 120);
+    checkRecordLocation(recordLocationMap, 2, segment1, 2, 100);
+    checkRecordLocation(recordLocationMap, 3, segment2, 0, 100);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1, 2});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0});
+
+    upsertMetadataManager.updateRecord(segment2, new RecordInfo(getPrimaryKey(2), 1, 120), validDocIds2);
+    // segment1: 0 -> {0, 100}, 1 -> {1, 120}
+    // segment2: 2 -> {1, 120}, 3 -> {0, 100}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 1, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 1, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 0, 100);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+
+    upsertMetadataManager.updateRecord(segment2, new RecordInfo(getPrimaryKey(1), 2, 100), validDocIds2);
+    // segment1: 0 -> {0, 100}, 1 -> {1, 120}
+    // segment2: 2 -> {1, 120}, 3 -> {0, 100}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 1, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 1, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 0, 100);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+
+    upsertMetadataManager.updateRecord(segment2, new RecordInfo(getPrimaryKey(0), 3, 100), validDocIds2);
+    // segment1: 0 -> {0, 100}, 1 -> {1, 120}
+    // segment2: 2 -> {1, 120}, 3 -> {0, 100}
+    checkRecordLocation(recordLocationMap, 0, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 1, segment1, 1, 120);
+    checkRecordLocation(recordLocationMap, 2, segment2, 1, 120);
+    checkRecordLocation(recordLocationMap, 3, segment2, 0, 100);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+  }
+
+  @Test
+  public void testRemoveSegment() {
+    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add 2 segments
+    // segment1: 0 -> {0, 100}, 1 -> {1, 100}
+    // segment2: 2 -> {0, 100}, 3 -> {0, 100}
+    String segment1 = SEGMENT_PREFIX + 1;
+    List<RecordInfo> recordInfoList1 = new ArrayList<>();
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(0), 0, 100));
+    recordInfoList1.add(new RecordInfo(getPrimaryKey(1), 1, 100));
+    ThreadSafeMutableRoaringBitmap validDocIds1 =
+        upsertMetadataManager.addSegment(segment1, recordInfoList1.iterator());
+    String segment2 = SEGMENT_PREFIX + 1;
+    List<RecordInfo> recordInfoList2 = new ArrayList<>();
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(2), 0, 100));
+    recordInfoList2.add(new RecordInfo(getPrimaryKey(3), 1, 100));
+    ThreadSafeMutableRoaringBitmap validDocIds2 =
+        upsertMetadataManager.addSegment(segment2, recordInfoList2.iterator());
+
+    // Remove the first segment
+    upsertMetadataManager.removeSegment(segment1, validDocIds1);
+    // segment2: 2 -> {0, 100}, 3 -> {0, 100}
+    assertNull(recordLocationMap.get(getPrimaryKey(0)));
+    assertNull(recordLocationMap.get(getPrimaryKey(1)));
+    checkRecordLocation(recordLocationMap, 2, segment1, 0, 100);
+    checkRecordLocation(recordLocationMap, 3, segment1, 1, 100);
+    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -203,12 +203,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       LOGGER.warn("Failed to find table data manager for table: {}, skipping reloading segment", tableNameWithType);
       return;
     }
-    // TODO: Support reloading segments from upsert enabled table
-    if (tableDataManager instanceof RealtimeTableDataManager && ((RealtimeTableDataManager) tableDataManager)
-        .isUpsertEnabled()) {
-      LOGGER.warn("Skip reloading segment from upsert enabled table: {}", tableNameWithType);
-      return;
-    }
 
     File indexDir = segmentMetadata.getIndexDir();
     if (indexDir == null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -70,7 +70,8 @@ public class UpsertQuickStart {
     printStatus(Color.CYAN, "***** Starting Kafka *****");
     final ZkStarter.ZookeeperInstance zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
-      _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, KafkaStarterUtils.getDefaultKafkaConfiguration());
+      _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
+          KafkaStarterUtils.getDefaultKafkaConfiguration());
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }
@@ -98,7 +99,7 @@ public class UpsertQuickStart {
     printStatus(Color.CYAN, "***** Waiting for 5 seconds for a few events to get populated *****");
     Thread.sleep(5000);
 
-    printStatus(Color.YELLOW, "***** Realtime quickstart setup complete *****");
+    printStatus(Color.YELLOW, "***** Upsert quickstart setup complete *****");
 
     String q1 = "select event_id, count(*) from meetupRsvp group by event_id limit 10";
     printStatus(Color.YELLOW, "Total number of documents per event_id in the table");
@@ -106,8 +107,6 @@ public class UpsertQuickStart {
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q1)));
     printStatus(Color.GREEN, "***************************************************");
 
-    printStatus(Quickstart.Color.YELLOW, "***** Realtime quickstart setup complete *****");
-
-    printStatus(Quickstart.Color.GREEN, "You can always go to http://localhost:9000/query/ to play around in the query console");
+    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
   }
 }


### PR DESCRIPTION
## Description
Part of a series of PRs for #4261 

Re-implement the `PartitionUpsertMetadataManager` to correctly handle the following 2 scenarios:
1. Reload the segment which replaces the upsert metadata of the existing segment
2. Manage the valid doc ids of the consuming segment within the manager so that the updates can be applied to the consuming segment

One behavior change is that if 2 records have the same timestamp, the second one won't replace the first one in order to reduce the number of updates.

Add `PartitionUpsertMetadataManagerTest` to verify the functionalities.