### PR TITLE
Fixing the issue of applying ordinals in order by for distinct queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -353,11 +353,11 @@ public class CalciteSqlParser {
       pinotQuery.setHavingExpression(updateComparisonPredicate(havingExpression));
     }
 
-    // Rewrite GroupBy to Distinct
-    rewriteNonAggregationGroupByToDistinct(pinotQuery);
-
     // Update Ordinals
     applyOrdinals(pinotQuery);
+
+    // Rewrite GroupBy to Distinct
+    rewriteNonAggregationGroupByToDistinct(pinotQuery);
 
     // Update alias
     Map<Identifier, Expression> aliasMap = extractAlias(pinotQuery.getSelectList());

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1611,6 +1611,15 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
+  public void testOrdinalsQueryRewriteWithDistinctOrderby() {
+    String query = "SELECT baseballStats.playerName AS playerName FROM baseballStats GROUP BY baseballStats.playerName ORDER BY 1 ASC";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "baseballStats.playerName");
+    Assert.assertTrue(pinotQuery.getGroupByList().isEmpty());
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "baseballStats.playerName");
+  }
+
+  @Test
   public void testNoArgFunction() {
     String query = "SELECT noArgFunc() FROM foo ";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);


### PR DESCRIPTION
## Description
Fixing the issue of distinct order by with ordinals. We should rewrite the query to distinct after applying the ordinals.

Query:
```
SELECT baseballStats.playerName AS playerName
FROM baseballStats
GROUP BY baseballStats.playerName
ORDER BY 1 ASC
```

Exceptions:
```
[
  {
    "message": "QueryValidationError:\njava.lang.UnsupportedOperationException: ORDER By should be only on some/all of the columns passed as arguments to DISTINCT\n\tat org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.validateRequest(BaseBrokerRequestHandler.java:1095)\n\tat org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:279)\n\tat org.apache.pinot.broker.api.resources.PinotClientRequest.processSqlQueryPost(PinotClientRequest.java:155)\n\tat jdk.internal.reflect.GeneratedMethodAccessor28.invoke(Unknown Source)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n\tat org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)\n\tat org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159)\n\tat org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)\n\tat org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)\n\tat org.glassfish.jersey.server.model.ResourceMethodInvoker.lambda$apply$0(ResourceMethodInvoker.java:381)\n\tat org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2$1.run(ServerRuntime.java:819)",
    "errorCode": 700
  }
]
```

Result after the fix:
![image](https://user-images.githubusercontent.com/1202120/96789474-1d303a00-13aa-11eb-88de-938b7f8d8691.png)
