### PR TITLE
Adding a new Server API for computing average off heap memory consumed

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -240,7 +240,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   }
 
   public synchronized boolean isEmpty() {
-    return getNumntriesToScan() == 0;
+    return getNumEntriesToScan() == 0;
   }
 
   public synchronized void setMinIntervalBetweenUpdatesMillis(long millis) {
@@ -272,7 +272,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
    * @return estimated
    */
   public synchronized int getEstimatedCardinality(@Nonnull String columnName) {
-    int numEntriesToScan = getNumntriesToScan();
+    int numEntriesToScan = getNumEntriesToScan();
     if (numEntriesToScan == 0) {
       return DEFAULT_EST_CARDINALITY;
     }
@@ -303,7 +303,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
    * @return estimated average string size
    */
   public synchronized int getEstimatedAvgColSize(@Nonnull String columnName) {
-    int numEntriesToScan = getNumntriesToScan();
+    int numEntriesToScan = getNumEntriesToScan();
     if (numEntriesToScan == 0) {
       return DEFAULT_EST_AVG_COL_SIZE;
     }
@@ -327,7 +327,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   }
 
   public synchronized int getEstimatedRowsToIndex() {
-    int numEntriesToScan = getNumntriesToScan();
+    int numEntriesToScan = getNumEntriesToScan();
     if (numEntriesToScan == 0) {
       return DEFAULT_ROWS_TO_INDEX;
     }
@@ -339,6 +339,20 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     }
 
     return (numRowsIndexed > 0) ? (int) (numRowsIndexed / numEntriesToScan) : DEFAULT_ROWS_TO_INDEX;
+  }
+
+  public synchronized double getAvgMemoryConsumed() {
+    int numEntriesToScan = getNumEntriesToScan();
+    if (numEntriesToScan == 0) {
+      return 0;
+    }
+
+    long totalMemUsedBytes = 0;
+    for (int i = 0; i < numEntriesToScan; i++) {
+      SegmentStats segmentStats = getSegmentStatsAt(i);
+      totalMemUsedBytes += segmentStats.getMemUsedBytes();
+    }
+    return (double) totalMemUsedBytes / numEntriesToScan;
   }
 
   public SegmentStats getSegmentStatsAt(int index) {
@@ -374,7 +388,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     }
   }
 
-  private int getNumntriesToScan() {
+  private int getNumEntriesToScan() {
     if (isFull()) {
       return getArraySize();
     }
@@ -385,7 +399,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
       throws Exception {
     RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(new File("/tmp/stats.ser"));
     System.out.println(history.toString());
-    for (int i = 0; i < history.getNumntriesToScan(); i++) {
+    for (int i = 0; i < history.getNumEntriesToScan(); i++) {
       SegmentStats segmentStats = history.getSegmentStatsAt(i);
       System.out.println(segmentStats.toString());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -343,7 +343,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
 
   public synchronized long getLatestSegmentMemoryConsumed() {
     if (isEmpty()) {
-      return 0;
+      return -1;
     }
     // Get the last updated index
     int latestSegmentIndex = (_cursor + _arraySize - 1) % _arraySize;
@@ -389,15 +389,5 @@ public class RealtimeSegmentStatsHistory implements Serializable {
       return getArraySize();
     }
     return getCursor();
-  }
-
-  public static void main(String[] args)
-      throws Exception {
-    RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(new File("/tmp/stats.ser"));
-    System.out.println(history.toString());
-    for (int i = 0; i < history.getNumEntriesToScan(); i++) {
-      SegmentStats segmentStats = history.getSegmentStatsAt(i);
-      System.out.println(segmentStats.toString());
-    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -341,18 +341,14 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     return (numRowsIndexed > 0) ? (int) (numRowsIndexed / numEntriesToScan) : DEFAULT_ROWS_TO_INDEX;
   }
 
-  public synchronized double getAvgMemoryConsumed() {
-    int numEntriesToScan = getNumEntriesToScan();
-    if (numEntriesToScan == 0) {
+  public synchronized long getLatestSegmentMemoryConsumed() {
+    if (isEmpty()) {
       return 0;
     }
-
-    long totalMemUsedBytes = 0;
-    for (int i = 0; i < numEntriesToScan; i++) {
-      SegmentStats segmentStats = getSegmentStatsAt(i);
-      totalMemUsedBytes += segmentStats.getMemUsedBytes();
-    }
-    return (double) totalMemUsedBytes / numEntriesToScan;
+    // Get the last updated index
+    int latestSegmentIndex = (_cursor + _arraySize - 1) % _arraySize;
+    SegmentStats stats = getSegmentStatsAt(latestSegmentIndex);
+    return stats._memUsedBytes;
   }
 
   public SegmentStats getSegmentStatsAt(int index) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -252,7 +252,7 @@ public class RealtimeSegmentStatsHistoryTest {
   }
 
   @Test
-  public void testAvgConsumedMemory()
+  public void testLatestConsumedMemory()
       throws IOException, ClassNotFoundException {
     final String tmpDir = System.getProperty("java.io.tmpdir");
     File serializedFile = new File(tmpDir, STATS_FILE_NAME);
@@ -261,18 +261,17 @@ public class RealtimeSegmentStatsHistoryTest {
     long[] memoryValues = {100, 100, 200, 400, 450, 600};
 
     RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+    Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), 0);
     RealtimeSegmentStatsHistory.SegmentStats segmentStats = null;
 
-    long total = 0;
     for (int i=0;i< memoryValues.length; i++) {
       segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
       segmentStats.setMemUsedBytes(memoryValues[i]);
       history.addSegmentStats(segmentStats);
-      total += memoryValues[i];
     }
 
-    double expectedAvgMemUsed = (double) total / memoryValues.length;
-    Assert.assertEquals(history.getAvgMemoryConsumed(), expectedAvgMemUsed);
+    long expectedMemUsed = memoryValues[memoryValues.length-1];
+    Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), expectedMemUsed);
   }
 
   private static class StatsUpdater implements Runnable {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -261,16 +261,16 @@ public class RealtimeSegmentStatsHistoryTest {
     long[] memoryValues = {100, 100, 200, 400, 450, 600};
 
     RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
-    Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), 0);
+    Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), -1);
     RealtimeSegmentStatsHistory.SegmentStats segmentStats = null;
 
-    for (int i=0;i< memoryValues.length; i++) {
+    for (int i = 0; i < memoryValues.length; i++) {
       segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
       segmentStats.setMemUsedBytes(memoryValues[i]);
       history.addSegmentStats(segmentStats);
     }
 
-    long expectedMemUsed = memoryValues[memoryValues.length-1];
+    long expectedMemUsed = memoryValues[memoryValues.length - 1];
     Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), expectedMemUsed);
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -53,7 +53,7 @@ import org.apache.pinot.server.starter.ServerInstance;
 public class TableSizeResource {
 
   @Inject
-  ServerInstance serverInstance;
+  private ServerInstance _serverInstance;
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
@@ -64,7 +64,7 @@ public class TableSizeResource {
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
       throws WebApplicationException {
-    InstanceDataManager instanceDataManager = serverInstance.getInstanceDataManager();
+    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
 
     if (instanceDataManager == null) {
       throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -41,11 +41,8 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
-import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.server.starter.ServerInstance;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 /**
@@ -121,34 +118,5 @@ public class TableSizeResource {
       @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
       throws WebApplicationException {
     return this.getTableSize(tableName, detailed);
-  }
-
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/tables/{tableName}/avgMemoryConsumedRealtime")
-  @ApiOperation(value = "Show average off heap memory consumed by mutable segments", notes = "Averages off heap memory consumed by consuming segments of realtime table")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"), @ApiResponse(code = 404, message = "Table not found")})
-  public String getTableSize(
-      @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName)
-      throws WebApplicationException {
-    double avgMemoryConsumed = 0;
-    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
-    if (tableType != TableType.REALTIME) {
-      throw new WebApplicationException("This api cannot be used with non real-time table: " + tableName,
-          Response.Status.BAD_REQUEST);
-    }
-
-    InstanceDataManager instanceDataManager = serverInstance.getInstanceDataManager();
-    if (instanceDataManager == null) {
-      throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);
-    }
-    RealtimeTableDataManager realtimeTableDataManager =
-        (RealtimeTableDataManager) instanceDataManager.getTableDataManager(tableName);
-    if (realtimeTableDataManager == null) {
-      throw new WebApplicationException("Table: " + tableName + " is not found", Response.Status.NOT_FOUND);
-    }
-
-    avgMemoryConsumed = realtimeTableDataManager.getStatsHistory().getAvgMemoryConsumed();
-    return ResourceUtils.convertToJsonString(avgMemoryConsumed);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -67,7 +67,7 @@ public class TablesResource {
   private static final String PEER_SEGMENT_DOWNLOAD_DIR = "peerSegmentDownloadDir";
 
   @Inject
-  ServerInstance serverInstance;
+  private ServerInstance _serverInstance;
 
   @Inject
   private AccessControlFactory _accessControlFactory;
@@ -85,10 +85,10 @@ public class TablesResource {
   }
 
   private InstanceDataManager checkGetInstanceDataManager() {
-    if (serverInstance == null) {
+    if (_serverInstance == null) {
       throw new WebApplicationException("Server initialization error. Missing server instance");
     }
-    InstanceDataManager instanceDataManager = serverInstance.getInstanceDataManager();
+    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
     if (instanceDataManager == null) {
       throw new WebApplicationException("Server initialization error. Missing data manager",
           Response.Status.INTERNAL_SERVER_ERROR);
@@ -218,7 +218,7 @@ public class TablesResource {
       // Note that two clients asking the same segment file will result in the same tar.gz files being created twice.
       // Will revisit for optimization if performance becomes an issue.
       File tmpSegmentTarDir =
-          new File(serverInstance.getInstanceDataManager().getSegmentFileDirectory(), PEER_SEGMENT_DOWNLOAD_DIR);
+          new File(_serverInstance.getInstanceDataManager().getSegmentFileDirectory(), PEER_SEGMENT_DOWNLOAD_DIR);
       tmpSegmentTarDir.mkdir();
 
       File segmentTarFile = new File(tmpSegmentTarDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()


### PR DESCRIPTION
## Description
Adding a new API for getting average off heap memory consumed by consuming segments
of a given real-time table. This number is useful for the caller to get an accurate idea of memory
requirements (and thus subsequent provisioning).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes?
No