### PR TITLE
Update license and notice for 0.6.0 release

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -241,7 +241,6 @@ com.google.http-client:google-http-client:1.32.1
 com.google.j2objc:j2objc-annotations:1.3
 com.google.oauth-client:google-oauth-client:1.30.3
 com.google.protobuf:protobuf-java-util:3.10.0
-com.google.protobuf:protobuf-java:2.5.0
 com.jayway.jsonpath:json-path:2.4.0
 com.lmax:disruptor:3.3.4
 com.ning:async-http-client:1.9.21
@@ -263,7 +262,7 @@ io.confluent:common-config:5.3.1
 io.confluent:common-utils:5.3.1
 io.confluent:kafka-avro-serializer:5.3.1
 io.confluent:kafka-schema-registry-client:5.3.1
-io.dropwizard.metrics:metrics-core:3.2.3
+io.dropwizard.metrics:metrics-core:4.1.2
 io.grpc:grpc-api:1.30.0
 io.grpc:grpc-context:1.30.0
 io.grpc:grpc-core:1.30.0
@@ -282,13 +281,13 @@ io.netty:netty-handler-proxy:4.1.42.Final
 io.netty:netty-handler:4.1.42.Final
 io.netty:netty-resolver:4.1.42.Final
 io.netty:netty-tcnative-boringssl-static:2.0.26.Final
-io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.42.Final
+io.netty:netty-transport-native-epoll:jar:4.1.42.Final
 io.netty:netty-transport-native-unix-common:4.1.42.Final
 io.netty:netty-transport:4.1.42.Final
 io.netty:netty:3.9.6.Final
 io.opencensus:opencensus-api:0.24.0
 io.opencensus:opencensus-contrib-http-util:0.24.0
-io.perfmark:perfmark-api
+io.perfmark:perfmark-api:0.19.0
 io.projectreactor.addons:reactor-pool:0.1.0.RELEASE
 io.projectreactor.netty:reactor-netty:0.9.0.RELEASE
 io.projectreactor:reactor-core:3.3.0.RELEASE
@@ -350,8 +349,8 @@ org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.javassist:javassist:3.19.0-GA
 org.lz4:lz4-java:1.4.1
-org.roaringbitmap:RoaringBitmap:0.8.0
-org.roaringbitmap:shims:0.8.0
+org.roaringbitmap:RoaringBitmap:0.9.0
+org.roaringbitmap:shims:0.9.0
 org.scala-lang:scala-library:2.11.11
 org.webjars:swagger-ui:3.18.2
 org.xerial.java:xerial-core:2.1
@@ -450,7 +449,7 @@ javax.annotation:javax.annotation-api:1.3.2
 javax.ws.rs:javax.ws.rs-api:2.0.1
 javax.xml.bind:jaxb-api:2.3.0
 org.glassfish.hk2:osgi-resource-locator:1.0.1
-org.glassfish.tyrus.bundles:tyrus-standalone-client:1.5
+org.glassfish.jersey.containers:jersey-container-servlet-core:2.25.1
 
 
 Common Public License (CPL) 1.0
@@ -490,6 +489,7 @@ org.glassfish.jersey.inject:jersey-hk2:2.28
 org.glassfish.jersey.media:jersey-media-jaxb:2.28
 org.glassfish.jersey.media:jersey-media-json-jackson:2.28
 org.glassfish.jersey.media:jersey-media-multipart:2.28
+org.glassfish.tyrus.bundles:tyrus-standalone-client:1.15
 org.locationtech.jts:jts-core:1.16.1
 
 Eclipse Distribution License (EDL) 1.0

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 // ------------------------------------------------------------------
 // NOTICE file corresponding to the section 4d of The Apache License,
-// Version 2.0, in this case for 
+// Version 2.0, in this case for
 // ------------------------------------------------------------------
 
 The HermiteInterpolator class and its corresponding test have been imported from
@@ -28,7 +28,7 @@ This product includes software developed by
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java contains 
+src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java contains
 test data from http://aspell.sourceforge.net/test/batch0.tab.
 
 Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org). Verbatim copying
@@ -167,16 +167,16 @@ are met:
 1. Redistributions of source code must retain the above copyright
    notice, this list of conditions and the following disclaimer.
 
-2. The origin of this software must not be misrepresented; you must 
-   not claim that you wrote the original software.  If you use this 
-   software in a product, an acknowledgment in the product 
+2. The origin of this software must not be misrepresented; you must
+   not claim that you wrote the original software.  If you use this
+   software in a product, an acknowledgment in the product
    documentation would be appreciated but is not required.
 
 3. Altered source versions must be plainly marked as such, and must
    not be misrepresented as being the original software.
 
-4. The name of the author may not be used to endorse or promote 
-   products derived from this software without specific prior written 
+4. The name of the author may not be used to endorse or promote
+   products derived from this software without specific prior written
    permission.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS


### PR DESCRIPTION
This PR updates LICENSE and NOTICE for new Pinot release 0.6.0.

This is following the instructions in https://cwiki.apache.org/confluence/display/PINOT/Creating+an+Apache+Release