### PR TITLE
[TE] allow `@` character in jira user name

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/notification/commons/ThirdEyeJiraClient.java
@@ -104,7 +104,7 @@ public class ThirdEyeJiraClient {
     StringBuilder jiraQuery = new StringBuilder();
     // Query by project first as a jira optimization
     jiraQuery.append("project=").append(project);
-    jiraQuery.append(" and ").append("reporter IN (").append(reporter).append(")");
+    jiraQuery.append(" and ").append("reporter IN (\"").append(reporter).append("\")");
     jiraQuery.append(" and ").append(buildQueryOnLabels(labels));
     jiraQuery.append(" and ").append(buildQueryOnCreatedBy(lookBackMillis));
 


### PR DESCRIPTION
## Description
For the Jira Alert in ThirdEye: 

If a jira reporter user name  contains  a `@` character, eg `name@mycompany.com`, an error is raised when trying to run the JQL query to get issues (for alert merging purpose): 
```
Error in the JQL Query: The character '@' is a reserved JQL character. You must enclose it in a string or use the escape '\u0040' instead. (line 1, character 34)]}
```
A current solution seems to use the jira user id (the one that looks like a hash), but it could be convenient to use a mail.

--> This small fix consists in enclosing the reporter name.
