### PR TITLE
Added recursive functions validation check for group by

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -174,17 +174,23 @@ public class CalciteSqlParser {
     }
   }
 
+  /**
+   * Check recursively if an expression contains any reference not appearing in the GROUP BY clause.
+   */
   private static boolean expressionOutsideGroupByList(Expression expr, Set<Expression> groupByExprs) {
+    // return early for Literal, Aggregate and if we have an exact match
     if (expr.getType() == ExpressionType.LITERAL || isAggregateExpression(expr) || groupByExprs.contains(expr)) {
       return false;
     }
 
     final Function funcExpr = expr.getFunctionCall();
+    // function expression
     if (funcExpr != null) {
+      // for Alias function, check the actual value
       if (funcExpr.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
         return expressionOutsideGroupByList(funcExpr.getOperands().get(0), groupByExprs);
       }
-      // Expression is invalid if any of its child is invalid
+      // Expression is invalid if any of its children is invalid
       return funcExpr.getOperands().stream().anyMatch(e -> expressionOutsideGroupByList(e, groupByExprs));
     }
     return true;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.SqlBasicCall;
@@ -157,25 +158,11 @@ public class CalciteSqlParser {
       return;
     }
     // Sanity check group by query: All non-aggregate expression in selection list should be also included in group by list.
+    Set<Expression> groupByExprs = new HashSet<>(pinotQuery.getGroupByList());
     for (Expression selectExpression : pinotQuery.getSelectList()) {
-      if (!isAggregateExpression(selectExpression)) {
-        boolean foundInGroupByClause = false;
-        Expression selectionToCheck;
-        if (selectExpression.getFunctionCall() != null && selectExpression.getFunctionCall().getOperator()
-            .equalsIgnoreCase(SqlKind.AS.toString())) {
-          selectionToCheck = selectExpression.getFunctionCall().getOperands().get(0);
-        } else {
-          selectionToCheck = selectExpression;
-        }
-        for (Expression groupByExpression : pinotQuery.getGroupByList()) {
-          if (groupByExpression.equals(selectionToCheck)) {
-            foundInGroupByClause = true;
-          }
-        }
-        if (!foundInGroupByClause) {
-          throw new SqlCompilationException(
-              "'" + RequestUtils.prettyPrint(selectionToCheck) + "' should appear in GROUP BY clause.");
-        }
+      if (!isAggregateExpression(selectExpression) && expressionOutsideGroupByList(selectExpression, groupByExprs)) {
+        throw new SqlCompilationException(
+            "'" + RequestUtils.prettyPrint(selectExpression) + "' should appear in GROUP BY clause.");
       }
     }
     // Sanity check on group by clause shouldn't contain aggregate expression.
@@ -185,6 +172,22 @@ public class CalciteSqlParser {
             + "' is not allowed in GROUP BY clause.");
       }
     }
+  }
+
+  private static boolean expressionOutsideGroupByList(Expression expr, Set<Expression> groupByExprs) {
+    if (expr.getType() == ExpressionType.LITERAL || isAggregateExpression(expr) || groupByExprs.contains(expr)) {
+      return false;
+    }
+
+    final Function funcExpr = expr.getFunctionCall();
+    if (funcExpr != null) {
+      if (funcExpr.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        return expressionOutsideGroupByList(funcExpr.getOperands().get(0), groupByExprs);
+      }
+      // Expression is invalid if any of its child is invalid
+      return funcExpr.getOperands().stream().anyMatch(e -> expressionOutsideGroupByList(e, groupByExprs));
+    }
+    return true;
   }
 
   private static boolean isAggregateExpression(Expression expression) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -448,6 +448,7 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testGroupbys() {
+
     PinotQuery pinotQuery;
     try {
       pinotQuery = CalciteSqlParser.compileToPinotQuery(
@@ -504,6 +505,24 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "*");
+    Assert.assertEquals(10, pinotQuery.getLimit());
+
+    // nested functions in group by
+    try {
+      pinotQuery = CalciteSqlParser.compileToPinotQuery("select concat(upper(playerName), lower(teamID), '-') playerTeam, "
+          + "upper(league) leagueUpper, count(playerName) cnt from baseballStats group by playerTeam, lower(teamID), leagueUpper "
+          + "having cnt > 1 order by cnt desc limit 10");
+    } catch (SqlCompilationException e) {
+      throw e;
+    }
+    Assert.assertTrue(pinotQuery.isSetGroupByList());
+    Assert.assertEquals(pinotQuery.getGroupByList().size(), 3);
+    Assert.assertTrue(pinotQuery.isSetLimit());
+    Assert.assertTrue(pinotQuery.isSetOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "COUNT");
     Assert.assertEquals(10, pinotQuery.getLimit());
   }
 


### PR DESCRIPTION


## Description
The current validation rule for select-inside-groupby currently only consider exact match and Alias function.
There are many cases where composite functions are used in select-groupby too e.g. `select concat(foo,bar,'-'), count(*) ... group by foo, bar` is a valid query.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
