### PR TITLE
Compute absolute docId in lucene collector

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneDocIdCollector.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/text/LuceneDocIdCollector.java
@@ -67,7 +67,9 @@ public class LuceneDocIdCollector implements Collector {
 
       @Override
       public void collect(int doc) throws IOException {
-        _docIds.add(_docIdTranslator.getPinotDocId(doc));
+        // Compute the absolute lucene docID across
+        // sub-indexes because that's how the lookup table in docIdTranslator is built
+        _docIds.add(_docIdTranslator.getPinotDocId(context.docBase + doc));
       }
     };
   }


### PR DESCRIPTION
The lookup table of lucene docId to pinot docId is built on absolute docIDs. We merge multiple sub-indexes into a single index (to also restrict the number of files) but the internal merge process ignores already pending/running merges. In any case, there could still be few sub-indexes. On the query path, we should compute the absolute docId across sub-indexes to get the correct corresponding pinot docId. 