### PR TITLE
add controls for verbosity and query dialect

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -72,6 +72,10 @@ public class PerfBenchmarkDriverConf {
 
   String resultsOutputDirectory;
 
+  boolean verbose = false;
+
+  String dialect = "pql";
+
   public String getClusterName() {
     return clusterName;
   }
@@ -262,5 +266,21 @@ public class PerfBenchmarkDriverConf {
 
   public void setSchemaFileNamePath(String schemaFileNamePath) {
     this.schemaFileNamePath = schemaFileNamePath;
+  }
+
+  public boolean isVerbose() {
+    return verbose;
+  }
+
+  public void setVerbose(boolean verbose) {
+    this.verbose = verbose;
+  }
+
+  public String getDialect() {
+    return dialect;
+  }
+
+  public void setDialect(String dialect) {
+    this.dialect = dialect;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -79,6 +79,10 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
   private int _queueDepth = 64;
   @Option(name = "-timeout", required = false, metaVar = "<long>", usage = "Timeout in milliseconds for completing all queries (default: unlimited).")
   private long _timeout = 0;
+  @Option(name = "-verbose", required = false, usage = "Enable verbose query logging (default: false).")
+  private boolean _verbose = false;
+  @Option(name = "-dialect", required = false, metaVar = "<String>", usage = "Query dialect to use (pql|sql).")
+  private String _dialect = "pql";
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help;
 
@@ -144,6 +148,8 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     conf.setStartController(false);
     conf.setStartBroker(false);
     conf.setStartServer(false);
+    conf.setVerbose(_verbose);
+    conf.setDialect(_dialect);
 
     Stream<String> queries = makeQueries(
             IOUtils.readLines(new FileInputStream(_queryFile)),


### PR DESCRIPTION
## Description
Add controls for verbosity and query dialect to query runner. All changes backwards-compatible.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
