### PR TITLE
Add submitJobStatus API in PinotTableRestletResource

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -64,7 +64,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false),
 
   // Percentage of segments we failed to get size for
-  TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false);
+  TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false),
+
+  JOB_EXECUTION_TIME("JobExecutionTime", false),
+
+  JOB_FAILED("JobFailed", false);
 
   private final String gaugeName;
   private final String unit;
@@ -94,5 +98,17 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   @Override
   public boolean isGlobal() {
     return global;
+  }
+
+  public static ControllerGauge getGauge(String gaugeName) {
+    if (gaugeName == null || gaugeName.isEmpty()) {
+      return null;
+    }
+    for (ControllerGauge gauge : ControllerGauge.values()) {
+      if (gauge.getGaugeName().equalsIgnoreCase(gaugeName)) {
+        return gauge;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Description
Currently there is no way to track the status of any job like segmentCreationJob, segmentPushJob in Hadoop or Spark, which are run outside Pinot cluster. 
This PR adds submitJobStatus API in PinotTableRestletResource, so that the job status can be tracked in Pinot controller, and some of the fields can be emitted as metrics.

After this API gets added, those jobs can make the API call to update the job status in Pinot cluster.

E.g.
```
$ curl 'http://localhost:9000/tables/testTable/jobStatus?details=jobName%3DsegmentCreationJob%3BjobExecutionTime%3D1000%3BjobFailed%3D1%3BerrorMessage%3DNullPointerException' \
  -X 'POST' 
{"status":"Successfully submitted job status for Table: testTable"}
```
The job execution time and job failed will be emitted as metrics as they appear in ControllerGauge.