### PR TITLE
add upsert metadata metric

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -284,6 +284,22 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Sets the value of a table partition gauge.
+   *
+   * @param tableName The table name
+   * @param partitionId The partition name
+   * @param gauge The gauge to use
+   * @param value The value to set the gauge to
+   */
+  public void setValueOfPartitionGauge(final String tableName, final int partitionId, final G gauge, final long value) {
+    final String fullGaugeName;
+    String gaugeName = gauge.getGaugeName();
+    fullGaugeName = gaugeName + "." + getTableName(tableName) + "." + partitionId;
+
+    setValueOfGauge(value, fullGaugeName);
+  }
+
+  /**
    * Sets the value of a custom global gauge.
    *
    * @param suffix The suffix to attach to the gauge name

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -40,7 +40,10 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS("seconds", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   REALTIME_SEGMENT_NUM_PARTITIONS("realtimeSegmentNumPartitions", false),
-  LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true);
+  LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
+
+  // Upsert metrics
+  UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -158,7 +158,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (isUpsertEnabled()) {
       Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _tableNameWithType);
-      _tableUpsertMetadataManager = new TableUpsertMetadataManager();
+      _tableUpsertMetadataManager = new TableUpsertMetadataManager(_tableNameWithType, _serverMetrics);
       _primaryKeyColumns = schema.getPrimaryKeyColumns();
       Preconditions.checkState(!CollectionUtils.isEmpty(_primaryKeyColumns),
           "Primary key columns must be configured for upsert");

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
@@ -97,6 +97,7 @@ public class PartitionUpsertMetadataManager {
               // committing a consuming segment, or reloading a completed segment.
 
               // Update the record location when the new timestamp is greater than or equal to the current timestamp.
+              // Update the record location when there is a tie because the record locations should point to the new
               // segment instead of the old segment being replaced. Also, do not update the valid doc ids for the old
               // segment because it has not been replaced yet.
               if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
@@ -53,12 +53,12 @@ import org.slf4j.LoggerFactory;
 public class PartitionUpsertMetadataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionUpsertMetadataManager.class);
 
-  private final String _tableName;
+  private final String _tableNameWithType;
   private final int _partitionId;
   private final ServerMetrics _serverMetrics;
 
-  public PartitionUpsertMetadataManager(String tableName, int partitionId, ServerMetrics serverMetrics) {
-    _tableName = tableName;
+  public PartitionUpsertMetadataManager(String tableNameWithType, int partitionId, ServerMetrics serverMetrics) {
+    _tableNameWithType = tableNameWithType;
     _partitionId = partitionId;
     _serverMetrics = serverMetrics;
   }
@@ -97,7 +97,7 @@ public class PartitionUpsertMetadataManager {
               // committing a consuming segment, or reloading a completed segment.
 
               // Update the record location when the new timestamp is greater than or equal to the current timestamp.
-               // segment instead of the old segment being replaced. Also, do not update the valid doc ids for the old
+              // segment instead of the old segment being replaced. Also, do not update the valid doc ids for the old
               // segment because it has not been replaced yet.
               if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {
                 validDocIds.add(recordInfo._docId);
@@ -124,8 +124,8 @@ public class PartitionUpsertMetadataManager {
         }
       });
     }
-    // update metrics
-    _serverMetrics.setValueOfPartitionGauge(_tableName, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+    // Update metrics
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
     return validDocIds;
   }
@@ -152,6 +152,9 @@ public class PartitionUpsertMetadataManager {
         return new RecordLocation(segmentName, recordInfo._docId, recordInfo._timestamp, validDocIds);
       }
     });
+    // Update metrics
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+        _primaryKeyToRecordLocationMap.size());
   }
 
   /**
@@ -170,8 +173,8 @@ public class PartitionUpsertMetadataManager {
         }
       });
     }
-    // update metrics
-    _serverMetrics.setValueOfPartitionGauge(_tableName, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+    // Update metrics
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/TableUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/TableUpsertMetadataManager.java
@@ -30,16 +30,16 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 @ThreadSafe
 public class TableUpsertMetadataManager {
   private final Map<Integer, PartitionUpsertMetadataManager> _partitionMetadataManagerMap = new ConcurrentHashMap<>();
-  private final String _tableName;
+  private final String _tableNameWithType;
   private final ServerMetrics _serverMetrics;
 
-  public TableUpsertMetadataManager(String tableName, ServerMetrics serverMetrics) {
-    _tableName = tableName;
+  public TableUpsertMetadataManager(String tableNameWithType, ServerMetrics serverMetrics) {
+    _tableNameWithType = tableNameWithType;
     _serverMetrics = serverMetrics;
   }
 
   public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap
-        .computeIfAbsent(partitionId, k -> new PartitionUpsertMetadataManager(_tableName, partitionId, _serverMetrics));
+    return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
+        k -> new PartitionUpsertMetadataManager(_tableNameWithType, k, _serverMetrics));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/TableUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/TableUpsertMetadataManager.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.upsert;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.common.metrics.ServerMetrics;
 
 
 /**
@@ -29,8 +30,16 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class TableUpsertMetadataManager {
   private final Map<Integer, PartitionUpsertMetadataManager> _partitionMetadataManagerMap = new ConcurrentHashMap<>();
+  private final String _tableName;
+  private final ServerMetrics _serverMetrics;
+
+  public TableUpsertMetadataManager(String tableName, ServerMetrics serverMetrics) {
+    _tableName = tableName;
+    _serverMetrics = serverMetrics;
+  }
 
   public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
-    return _partitionMetadataManagerMap.computeIfAbsent(partitionId, k -> new PartitionUpsertMetadataManager());
+    return _partitionMetadataManagerMap
+        .computeIfAbsent(partitionId, k -> new PartitionUpsertMetadataManager(_tableName, partitionId, _serverMetrics));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -53,6 +53,7 @@ import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.util.TestUtils;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -800,7 +801,8 @@ public class LLRealtimeSegmentDataManagerTest {
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics, new PartitionUpsertMetadataManager());
+          semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics,
+          new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class)));
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -53,7 +53,6 @@ import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.util.TestUtils;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -802,7 +801,7 @@ public class LLRealtimeSegmentDataManagerTest {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
           semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics,
-          new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class)));
+          new PartitionUpsertMetadataManager("testTable", 0, serverMetrics));
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -801,7 +801,7 @@ public class LLRealtimeSegmentDataManagerTest {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
           semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics,
-          new PartitionUpsertMetadataManager("testTable", 0, serverMetrics));
+          new PartitionUpsertMetadataManager("testTable_REALTIME", 0, serverMetrics));
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.indexsegment.mutable;
 import java.io.File;
 import java.net.URL;
 import java.util.Collections;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.recordtransformer.CompositeTransformer;
 import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.core.upsert.TableUpsertMetadataManager;
@@ -33,6 +34,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mockito;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -58,7 +60,8 @@ public class MutableSegmentImplUpsertTest {
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    _partitionUpsertMetadataManager = new TableUpsertMetadataManager().getOrCreatePartitionManager(0);
+    _partitionUpsertMetadataManager =
+        new TableUpsertMetadataManager("testTable", Mockito.mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
             false, true, new UpsertConfig(UpsertConfig.Mode.FULL), "secondsSinceEpoch",

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -61,7 +61,8 @@ public class MutableSegmentImplUpsertTest {
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
-        new TableUpsertMetadataManager("testTable", Mockito.mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
+        new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class))
+            .getOrCreatePartitionManager(0);
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
             false, true, new UpsertConfig(UpsertConfig.Mode.FULL), "secondsSinceEpoch",

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
@@ -49,6 +50,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -70,11 +72,13 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
   private IndexSegment _indexSegment;
   private IndexSegment _upsertIndexSegment;
+  private ServerMetrics _serverMetrics;
 
   @BeforeTest
   public void buildSegment()
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
+    _serverMetrics = Mockito.mock(ServerMetrics.class);
 
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
@@ -121,7 +125,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment)
-        .enableUpsert(new PartitionUpsertMetadataManager(), new ThreadSafeMutableRoaringBitmap());
+        .enableUpsert(new PartitionUpsertMetadataManager("testTable", 0, _serverMetrics),
+            new ThreadSafeMutableRoaringBitmap());
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -124,7 +124,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment)
-        .enableUpsert(new PartitionUpsertMetadataManager("testTable", 0, serverMetrics),
+        .enableUpsert(new PartitionUpsertMetadataManager("testTable_REALTIME", 0, serverMetrics),
             new ThreadSafeMutableRoaringBitmap());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -72,13 +72,11 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
 
   private IndexSegment _indexSegment;
   private IndexSegment _upsertIndexSegment;
-  private ServerMetrics _serverMetrics;
 
   @BeforeTest
   public void buildSegment()
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
-    _serverMetrics = Mockito.mock(ServerMetrics.class);
 
     // Get resource file path.
     URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
@@ -123,9 +121,10 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void loadSegment()
       throws Exception {
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
+    ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment)
-        .enableUpsert(new PartitionUpsertMetadataManager("testTable", 0, _serverMetrics),
+        .enableUpsert(new PartitionUpsertMetadataManager("testTable", 0, serverMetrics),
             new ThreadSafeMutableRoaringBitmap());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
@@ -21,9 +21,11 @@ package org.apache.pinot.core.upsert;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.upsert.PartitionUpsertMetadataManager.RecordInfo;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -37,7 +39,8 @@ public class PartitionUpsertMetadataManagerTest {
 
   @Test
   public void testAddSegment() {
-    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    PartitionUpsertMetadataManager upsertMetadataManager =
+        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -121,7 +124,8 @@ public class PartitionUpsertMetadataManagerTest {
 
   @Test
   public void testUpdateRecord() {
-    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    PartitionUpsertMetadataManager upsertMetadataManager =
+        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -181,7 +185,8 @@ public class PartitionUpsertMetadataManagerTest {
 
   @Test
   public void testRemoveSegment() {
-    PartitionUpsertMetadataManager upsertMetadataManager = new PartitionUpsertMetadataManager();
+    PartitionUpsertMetadataManager upsertMetadataManager =
+        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add 2 segments

--- a/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
@@ -36,12 +36,12 @@ import static org.testng.Assert.assertSame;
 
 public class PartitionUpsertMetadataManagerTest {
   private static final String SEGMENT_PREFIX = "testSegment";
-  private static final String TEST_TABLE = "testTable";
+  private static final String REALTIME_TEST_TABLE = "testTable_REALTIME";
 
   @Test
   public void testAddSegment() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(REALTIME_TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -126,7 +126,7 @@ public class PartitionUpsertMetadataManagerTest {
   @Test
   public void testUpdateRecord() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(REALTIME_TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -187,7 +187,7 @@ public class PartitionUpsertMetadataManagerTest {
   @Test
   public void testRemoveSegment() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(REALTIME_TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add 2 segments

--- a/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManagerTest.java
@@ -36,11 +36,12 @@ import static org.testng.Assert.assertSame;
 
 public class PartitionUpsertMetadataManagerTest {
   private static final String SEGMENT_PREFIX = "testSegment";
+  private static final String TEST_TABLE = "testTable";
 
   @Test
   public void testAddSegment() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -125,7 +126,7 @@ public class PartitionUpsertMetadataManagerTest {
   @Test
   public void testUpdateRecord() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -186,7 +187,7 @@ public class PartitionUpsertMetadataManagerTest {
   @Test
   public void testRemoveSegment() {
     PartitionUpsertMetadataManager upsertMetadataManager =
-        new PartitionUpsertMetadataManager("testTable", 0, Mockito.mock(ServerMetrics.class));
+        new PartitionUpsertMetadataManager(TEST_TABLE, 0, Mockito.mock(ServerMetrics.class));
     Map<PrimaryKey, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add 2 segments


### PR DESCRIPTION
## Description

Part of a series of PRs for #4261
Check this [doc](https://docs.google.com/document/d/1qljEMndPMxbbKtjlVn9mn2toz7Qrk0TGQsHLfI--7h8/edit#heading=h.lsfmyoyyxtgt) out for the new design

add upsert metadata metric of the primary key counts per partition metadata manager

