### PR TITLE
add quick-start example

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -311,6 +311,17 @@
               </jvmSettings>
             </program>
             <program>
+              <mainClass>org.apache.pinot.tools.UpsertQuickStart</mainClass>
+              <name>quick-start-upsert-streaming</name>
+              <jvmSettings>
+                <initialMemorySize>1G</initialMemorySize>
+                <maxMemorySize>1G</maxMemorySize>
+                <extraArguments>
+                  <extraArgument>-Dlog4j2.configurationFile=conf/quickstart-log4j2.xml</extraArgument>
+                </extraArguments>
+              </jvmSettings>
+            </program>
+            <program>
               <mainClass>org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand</mainClass>
               <name>pinot-ingestion-job</name>
               <jvmSettings>


### PR DESCRIPTION
## Description
Part of a series of PRs for #4261
Check this [doc](https://docs.google.com/document/d/1qljEMndPMxbbKtjlVn9mn2toz7Qrk0TGQsHLfI--7h8/edit#heading=h.lsfmyoyyxtgt) out for the new design


Users can use `bin/quick-start-upsert-streaming.sh` to launch the quick start example and try out the upsert table.