### PR TITLE
Add StrictReplicaGroupInstanceSelector

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;
@@ -179,7 +181,6 @@ abstract class BaseInstanceSelector implements InstanceSelector {
       if (!onlineSegments.contains(segment)) {
         continue;
       }
-      // NOTE: Instances will be sorted here because 'instanceStateMap' is a TreeMap.
       Map<String, String> instanceStateMap = entry.getValue();
       List<String> onlineInstances = new ArrayList<>(instanceStateMap.size());
       List<String> offlineInstances = new ArrayList<>();
@@ -198,6 +199,9 @@ abstract class BaseInstanceSelector implements InstanceSelector {
           }
         }
       }
+      // Sort the online instances for replica-group routing to work. For multiple segments with the same online
+      // instances, if the list is sorted, the same index in the list will always point to the same instance.
+      onlineInstances.sort(null);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -31,12 +32,11 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface InstanceSelector {
 
   /**
-   * Initializes the instance selector with the enabled instances, external view and online segments (segments with
-   * ONLINE/CONSUMING instances in ideal state). Should be called only once before calling other methods.
-   * <p>NOTE: {@code onlineSegments} is unused, but intentionally passed in as argument in case it is needed in the
-   * future.
+   * Initializes the instance selector with the enabled instances, external view, ideal state and online segments
+   * (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called
+   * only once before calling other methods.
    */
-  void init(Set<String> enabledInstances, ExternalView externalView, Set<String> onlineSegments);
+  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
    * Processes the instances change. Changed instances are pre-computed based on the current and previous enabled
@@ -45,12 +45,10 @@ public interface InstanceSelector {
   void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances);
 
   /**
-   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
-   * ideal state).
-   * <p>NOTE: {@code onlineSegments} is unused, but intentionally passed in as argument in case it is needed in the
-   * future.
+   * Processes the external view change based on the given ideal state and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
    * Selects the server instances for the given segments queried by the given broker request, returns a map from segment

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -38,14 +38,20 @@ public class InstanceSelectorFactory {
   public static InstanceSelector getInstanceSelector(TableConfig tableConfig, BrokerMetrics brokerMetrics) {
     String tableNameWithType = tableConfig.getTableName();
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
-    if (routingConfig != null && (
-        RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(routingConfig.getInstanceSelectorType())
-            || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_OFFLINE_ROUTING
-            .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())) || (
-            tableConfig.getTableType() == TableType.REALTIME && LEGACY_REPLICA_GROUP_REALTIME_ROUTING
-                .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())))) {
-      LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
-      return new ReplicaGroupInstanceSelector(tableNameWithType, brokerMetrics);
+    if (routingConfig != null) {
+      if (RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(routingConfig.getInstanceSelectorType())
+          || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_OFFLINE_ROUTING
+          .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName())) || (
+          tableConfig.getTableType() == TableType.REALTIME && LEGACY_REPLICA_GROUP_REALTIME_ROUTING
+              .equalsIgnoreCase(routingConfig.getRoutingTableBuilderName()))) {
+        LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
+        return new ReplicaGroupInstanceSelector(tableNameWithType, brokerMetrics);
+      }
+      if (RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE
+          .equalsIgnoreCase(routingConfig.getInstanceSelectorType())) {
+        LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
+        return new StrictReplicaGroupInstanceSelector(tableNameWithType, brokerMetrics);
+      }
     }
     return new BalancedInstanceSelector(tableNameWithType, brokerMetrics);
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.instanceselector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.common.utils.HashUtil;
+
+
+/**
+ * Instance selector for strict replica-group routing strategy.
+ *
+ * <pre>
+ * The strict replica-group routing strategy always routes the query to the instances within the same replica-group.
+ * (Note that the replica-group information is derived from the ideal state of the table, where the instances are sorted
+ * alphabetically in the instance state map, so the replica-groups in the instance selector might not match the
+ * replica-groups in the instance partitions.) The instances in a replica-group should have all the online segments
+ * (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector) available
+ * (ONLINE/CONSUMING in the external view) in order to serve queries. If any segment is unavailable in the
+ * replica-group, we mark the whole replica-group down and not serve queries with this replica-group.
+ *
+ * The selection algorithm is the same as {@link ReplicaGroupInstanceSelector}, and will always evenly distribute the
+ * traffic to all replica-groups that have all online segments available.
+ *
+ * The algorithm relies on the mirror segment assignment from replica-group segment assignment strategy. With mirror
+ * segment assignment, any server in one replica-group will always have a corresponding server in other replica-groups
+ * that have the same segments assigned. For example, if S1 is a server in replica-group 1, and it has mirror server
+ * S2 in replica-group 2 and S3 in replica-group 3. All segments assigned to S1 will also be assigned to S2 and S3. In
+ * stable scenario (external view matches ideal state), all segments assigned to S1 will have the same enabled instances
+ * of [S1, S2, S3] sorted (in alphabetical order). If we always pick the same index of enabled instances for all
+ * segments, only one of S1, S2, S3 will be picked, and all the segments are processed by the same server. In
+ * transitioning/error scenario (external view does not match ideal state), if a segment is down on S1, we mark all
+ * segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
+ * replica-group.
+ * </pre>
+ */
+public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSelector {
+
+  public StrictReplicaGroupInstanceSelector(String tableNameWithType, BrokerMetrics brokerMetrics) {
+    super(tableNameWithType, brokerMetrics);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <pre>
+   * The maps are calculated in the following steps to meet the strict replica-group guarantee:
+   *   1. Create a map from online segment to set of instances hosting the segment based on the ideal state
+   *   2. Gather the online and offline instances for each online segment from the external view
+   *   3. Compare the instances from the ideal state and the external view and gather the unavailable instances for each
+   *      set of instances
+   *   4. Exclude the unavailable instances from the online instances map
+   * </pre>
+   */
+  @Override
+  void updateSegmentMaps(ExternalView externalView, IdealState idealState, Set<String> onlineSegments,
+      Map<String, List<String>> segmentToOnlineInstancesMap, Map<String, List<String>> segmentToOfflineInstancesMap,
+      Map<String, List<String>> instanceToSegmentsMap) {
+    // Iterate over the ideal state to fill up 'idealStateSegmentToInstancesMap' which is a map from segment to set of
+    // instances hosting the segment in the ideal state
+    int segmentMapCapacity = HashUtil.getHashMapCapacity(onlineSegments.size());
+    Map<String, Set<String>> idealStateSegmentToInstancesMap = new HashMap<>(segmentMapCapacity);
+    for (Map.Entry<String, Map<String, String>> entry : idealState.getRecord().getMapFields().entrySet()) {
+      String segment = entry.getKey();
+      // Only track online segments
+      if (!onlineSegments.contains(segment)) {
+        continue;
+      }
+      idealStateSegmentToInstancesMap.put(segment, entry.getValue().keySet());
+    }
+
+    // Iterate over the external view to fill up 'tempSegmentToOnlineInstancesMap' and 'segmentToOfflineInstancesMap'.
+    // 'tempSegmentToOnlineInstancesMap' is a temporary map from segment to set of instances that are in the ideal state
+    // and also ONLINE/CONSUMING in the external view. This map does not have the strict replica-group guarantee, and
+    // will be used to calculate the final 'segmentToOnlineInstancesMap'.
+    Map<String, Set<String>> tempSegmentToOnlineInstancesMap = new HashMap<>(segmentMapCapacity);
+    for (Map.Entry<String, Map<String, String>> entry : externalView.getRecord().getMapFields().entrySet()) {
+      String segment = entry.getKey();
+      Set<String> instancesInIdealState = idealStateSegmentToInstancesMap.get(segment);
+      // Only track online segments
+      if (instancesInIdealState == null) {
+        continue;
+      }
+      // NOTE: Instances will be sorted here because 'instanceStateMap' is a TreeMap.
+      Map<String, String> instanceStateMap = entry.getValue();
+      Set<String> tempOnlineInstances = new TreeSet<>();
+      List<String> offlineInstances = new ArrayList<>();
+      tempSegmentToOnlineInstancesMap.put(segment, tempOnlineInstances);
+      segmentToOfflineInstancesMap.put(segment, offlineInstances);
+      for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
+        String instance = instanceStateEntry.getKey();
+        // Only track instances within the ideal state
+        if (!instancesInIdealState.contains(instance)) {
+          continue;
+        }
+        String state = instanceStateEntry.getValue();
+        if (state.equals(SegmentStateModel.ONLINE) || state.equals(SegmentStateModel.CONSUMING)) {
+          tempOnlineInstances.add(instance);
+        } else if (state.equals(SegmentStateModel.OFFLINE)) {
+          offlineInstances.add(instance);
+          instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+        }
+      }
+    }
+
+    // Iterate over the 'tempSegmentToOnlineInstancesMap' to gather the unavailable instances for each set of instances
+    Map<Set<String>, Set<String>> unavailableInstancesMap = new HashMap<>();
+    for (Map.Entry<String, Set<String>> entry : tempSegmentToOnlineInstancesMap.entrySet()) {
+      String segment = entry.getKey();
+      Set<String> tempOnlineInstances = entry.getValue();
+      Set<String> instancesInIdealState = idealStateSegmentToInstancesMap.get(segment);
+      // NOTE: When a segment is unavailable on all the instances, do not count all the instances as unavailable because
+      //       this segment is unavailable and won't be included in the routing table, thus not breaking the requirement
+      //       of routing to the same replica-group. This is normal for new added segments, and we don't want to mark
+      //       all instances down on all segments with the same assignment.
+      if (tempOnlineInstances.size() == instancesInIdealState.size() || tempOnlineInstances.isEmpty()) {
+        continue;
+      }
+      Set<String> unavailableInstances =
+          unavailableInstancesMap.computeIfAbsent(instancesInIdealState, k -> new TreeSet<>());
+      for (String instance : instancesInIdealState) {
+        if (!tempOnlineInstances.contains(instance)) {
+          unavailableInstances.add(instance);
+        }
+      }
+    }
+
+    // Iterate over the 'tempSegmentToOnlineInstancesMap' again to fill up the 'segmentToOnlineInstancesMap' which has
+    // the strict replica-group guarantee
+    for (Map.Entry<String, Set<String>> entry : tempSegmentToOnlineInstancesMap.entrySet()) {
+      String segment = entry.getKey();
+      Set<String> tempOnlineInstances = entry.getValue();
+      List<String> onlineInstances = new ArrayList<>(tempOnlineInstances.size());
+      segmentToOnlineInstancesMap.put(segment, onlineInstances);
+
+      Set<String> instancesInIdealState = idealStateSegmentToInstancesMap.get(segment);
+      Set<String> unavailableInstances = unavailableInstancesMap.get(instancesInIdealState);
+      if (unavailableInstances == null) {
+        // No unavailable instance, add all instances as online instance
+        for (String instance : tempOnlineInstances) {
+          onlineInstances.add(instance);
+          instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+        }
+      } else {
+        // Some instances are unavailable, add the remaining instances as online instance
+        for (String instance : tempOnlineInstances) {
+          if (!unavailableInstances.contains(instance)) {
+            onlineInstances.add(instance);
+            instanceToSegmentsMap.computeIfAbsent(instance, k -> new ArrayList<>()).add(segment);
+          }
+        }
+      }
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -105,7 +105,6 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       if (instancesInIdealState == null) {
         continue;
       }
-      // NOTE: Instances will be sorted here because 'instanceStateMap' is a TreeMap.
       Map<String, String> instanceStateMap = entry.getValue();
       Set<String> tempOnlineInstances = new TreeSet<>();
       List<String> offlineInstances = new ArrayList<>();
@@ -154,6 +153,9 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     for (Map.Entry<String, Set<String>> entry : tempSegmentToOnlineInstancesMap.entrySet()) {
       String segment = entry.getKey();
       Set<String> tempOnlineInstances = entry.getValue();
+      // NOTE: Instances will be sorted here because 'tempOnlineInstances' is a TreeSet. We need the online instances to
+      //       be sorted for replica-group routing to work. For multiple segments with the same online instances, if the
+      //       list is sorted, the same index in the list will always point to the same instance.
       List<String> onlineInstances = new ArrayList<>(tempOnlineInstances.size());
       segmentToOnlineInstancesMap.put(segment, onlineInstances);
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentselector;
+package org.apache.pinot.broker.routing.segmentpreselector;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelector.java
@@ -16,20 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentselector;
+package org.apache.pinot.broker.routing.segmentpreselector;
 
-import org.apache.helix.ZNRecord;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.pinot.spi.config.table.TableConfig;
+import java.util.Set;
 
 
-public class SegmentPreSelectorFactory {
-  private SegmentPreSelectorFactory() {
-  }
+/**
+ * The segment pre-selector filters the unnecessary online segments for the query.
+ * <p>Segment pre-selector examples:
+ * <ul>
+ *   <li>
+ *     For table with segment merge/rollup enabled, select the merged segments over the original segments with the same
+ *     data
+ *   </li>
+ * </ul>
+ */
+public interface SegmentPreSelector {
 
-  public static SegmentPreSelector getSegmentPreSelector(TableConfig tableConfig,
-      ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    String tableNameWithType = tableConfig.getTableName();
-    return new SegmentLineageBasedSegmentPreSelector(tableNameWithType, propertyStore);
-  }
+  /**
+   * Pre-selects the online segments to filter out the unnecessary segments. This method might modify the online segment
+   * set passed in.
+   */
+  Set<String> preSelect(Set<String> onlineSegments);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorFactory.java
@@ -16,26 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentselector;
+package org.apache.pinot.broker.routing.segmentpreselector;
 
-import java.util.Set;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.spi.config.table.TableConfig;
 
 
-/**
- * The segment pre-selector filters the unnecessary online segments for the query.
- * <p>Segment pre-selector examples:
- * <ul>
- *   <li>
- *     For table with segment merge/rollup enabled, select the merged segments over the original segments with the same
- *     data
- *   </li>
- * </ul>
- */
-public interface SegmentPreSelector {
+public class SegmentPreSelectorFactory {
+  private SegmentPreSelectorFactory() {
+  }
 
-  /**
-   * Process pre-selection for online segments to filter out unnecessary online segments. It is safe to modify the input
-   * online segments.
-   */
-  Set<String> preSelect(Set<String> onlineSegments);
+  public static SegmentPreSelector getSegmentPreSelector(TableConfig tableConfig,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    String tableNameWithType = tableConfig.getTableName();
+    return new SegmentLineageBasedSegmentPreSelector(tableNameWithType, propertyStore);
+  }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
@@ -64,7 +65,7 @@ public class PartitionSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public void init(ExternalView externalView, Set<String> onlineSegments) {
+  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
     // Bulk load partition info for all online segments
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(onlineSegments);
@@ -124,7 +125,8 @@ public class PartitionSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public synchronized void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<String> onlineSegments) {
     // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
     //       ones. The refreshed segment ZK metadata change won't be picked up.
     for (String segment : onlineSegments) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentpruner;
 import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -30,20 +31,17 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface SegmentPruner {
 
   /**
-   * Initializes the segment pruner with the external view and online segments (segments with ONLINE/CONSUMING instances
-   * in ideal state). Should be called only once before calling other methods.
-   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
-   * future.
+   * Initializes the segment pruner with the external view, ideal state and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
+   * calling other methods.
    */
-  void init(ExternalView externalView, Set<String> onlineSegments);
+  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
-   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
-   * ideal state).
-   * <p>NOTE: {@code externalView} is unused, but intentionally passed in as argument in case it is needed in the
-   * future.
+   * Processes the external view change based on the given ideal state and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
    * Refreshes the metadata for the given segment (called when segment is getting refreshed).

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -33,12 +34,12 @@ public class OfflineSegmentSelector implements SegmentSelector {
   private volatile List<String> _segments;
 
   @Override
-  public void init(ExternalView externalView, Set<String> onlineSegments) {
-    onExternalViewChange(externalView, onlineSegments);
+  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+    onExternalViewChange(externalView, idealState, onlineSegments);
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.common.utils.HLCSegmentName;
@@ -55,12 +56,12 @@ public class RealtimeSegmentSelector implements SegmentSelector {
   private volatile List<String> _llcSegments;
 
   @Override
-  public void init(ExternalView externalView, Set<String> onlineSegments) {
-    onExternalViewChange(externalView, onlineSegments);
+  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+    onExternalViewChange(externalView, idealState, onlineSegments);
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
     // Group HLC segments by their group id
     // NOTE: Use TreeMap so that group ids are sorted and the result is deterministic
     Map<String, List<String>> groupIdToHLCSegmentsMap = new TreeMap<>();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentselector;
 import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -43,16 +44,17 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface SegmentSelector {
 
   /**
-   * Initializes the segment selector with the external view and online segments (segments with ONLINE/CONSUMING
-   * instances in ideal state). Should be called only once before calling other methods.
+   * Initializes the segment selector with the external view, ideal state and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
+   * calling other methods.
    */
-  void init(ExternalView externalView, Set<String> onlineSegments);
+  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
-   * Processes the external view change based on the given online segments (segments with ONLINE/CONSUMING instances in
-   * ideal state).
+   * Processes the external view change based on the given ideal state and online segments (segments with
+   * ONLINE/CONSUMING instances in ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
 
   /**
    * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentselector;
+package org.apache.pinot.broker.routing.segmentpreselector;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,7 +49,7 @@ public class SegmentPreSelectorTest {
     Set<String> onlineSegments = new HashSet<>();
 
     int numOfflineSegments = 5;
-    for (int i = 0 ; i< numOfflineSegments; i++ ) {
+    for (int i = 0; i < numOfflineSegments; i++) {
       String segmentName = "segment_" + i;
       externalView.setStateMap(segmentName, onlineInstanceStateMap);
       onlineSegments.add(segmentName);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -61,10 +62,12 @@ public class SegmentSelectorTest {
     Map<String, String> onlineInstanceStateMap = Collections.singletonMap("server", ONLINE);
     Map<String, String> consumingInstanceStateMap = Collections.singletonMap("server", CONSUMING);
     Set<String> onlineSegments = new HashSet<>();
+    // NOTE: Ideal state is not used in the current implementation.
+    IdealState idealState = mock(IdealState.class);
 
     // Should return an empty list when there is no segment
     RealtimeSegmentSelector segmentSelector = new RealtimeSegmentSelector();
-    segmentSelector.init(externalView, onlineSegments);
+    segmentSelector.init(externalView, idealState, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
     assertTrue(segmentSelector.select(brokerRequest).isEmpty());
 
@@ -83,7 +86,7 @@ public class SegmentSelectorTest {
       }
       hlcSegments[i] = hlcSegmentsForGroup;
     }
-    segmentSelector.onExternalViewChange(externalView, onlineSegments);
+    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
 
     // Only HLC segments exist, should select the HLC segments from the first group
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[0]);
@@ -107,7 +110,7 @@ public class SegmentSelectorTest {
         }
       }
     }
-    segmentSelector.onExternalViewChange(externalView, onlineSegments);
+    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
 
     // Both HLC and LLC segments exist, should select the LLC segments
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
@@ -122,7 +125,7 @@ public class SegmentSelectorTest {
         onlineSegments.remove(hlcSegment);
       }
     }
-    segmentSelector.onExternalViewChange(externalView, onlineSegments);
+    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -242,7 +242,7 @@ public final class TableConfigUtils {
    * Validates the upsert-related configurations
    *  - check table type is realtime
    *  - the primary key exists on the schema
-   *  - replica group is configured for routing type
+   *  - strict replica-group is configured for routing type
    *  - consumer type must be low-level
    */
   protected static void validateUpsertConfig(TableConfig tableConfig, Schema schema) {
@@ -265,9 +265,9 @@ public final class TableConfigUtils {
         "Upsert table must use low-level streaming consumer type");
     // replica group is configured for routing
     Preconditions.checkState(
-        tableConfig.getRoutingConfig() != null && RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE
+        tableConfig.getRoutingConfig() != null && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE
             .equalsIgnoreCase(tableConfig.getRoutingConfig().getInstanceSelectorType()),
-        "Upsert table must use replica-group (i.e. replicaGroup) based routing");
+        "Upsert table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     // no startree index
     Preconditions.checkState(
         CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs()) && !tableConfig

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -159,8 +159,7 @@ public class TableConfigUtilsTest {
 
     // empty timeColumnName - valid
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
-    tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName("").build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName("").build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid
@@ -506,8 +505,9 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setInvertedIndexColumns(Arrays.asList("")).build();
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setInvertedIndexColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -519,8 +519,9 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("")).build();
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -532,8 +533,9 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setOnHeapDictionaryColumns(Arrays.asList("")).build();
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setOnHeapDictionaryColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -742,11 +744,13 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Upsert table must use replica-group (i.e. replicaGroup) based routing");
+      Assert.assertEquals(e.getMessage(),
+          "Upsert table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     }
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
-        .setRoutingConfig(new RoutingConfig(null, null, "replicaGroup")).setStreamConfigs(streamConfigs).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
     } catch (Exception e) {
@@ -756,7 +760,7 @@ public class TableConfigUtilsTest {
         .singletonList(new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
         .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
-        .setRoutingConfig(new RoutingConfig(null, null, "replicaGroup"))
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
@@ -20,15 +20,15 @@ package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.pinot.spi.config.BaseJsonConfig;
-
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class RoutingConfig extends BaseJsonConfig {
   public static final String PARTITION_SEGMENT_PRUNER_TYPE = "partition";
   public static final String REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "replicaGroup";
+  public static final String STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "strictReplicaGroup";
 
   // Replaced by _segmentPrunerTypes and _instanceSelectorType
   @Deprecated

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/upsert_meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/upsert_meetupRsvp_realtime_table_config.json
@@ -31,7 +31,7 @@
     "customConfigs": {}
   },
   "routing": {
-    "instanceSelectorType": "replicaGroup"
+    "instanceSelectorType": "strictReplicaGroup"
   },
   "upsertConfig": {
     "mode": "FULL"


### PR DESCRIPTION
## Description
Recently we have introduced some features which require all the segments from the same partition to be processed by the same server. For example, upsert (#4261) feature requires all the segments for a partition loaded on a single server before starting serving queries to ensure result correctness. The [Strict Replica-Group Routing](https://docs.google.com/document/d/1B5SghG0x5JHfZrKMBjiv_m3Dd969hfyWgc1joKZpJIU/edit?usp=sharing) is designed to meet this requirement.

This PR is the routing side change of the Strict Replica-Group Routing, which is handled in the `StrictReplicaGroupInstanceSelector` class.
The new algorithm relies on the ideal state of the table, so this PR added the ideal state to the routing interfaces.