### PR TITLE
add api for cluster manager to get table state

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -578,7 +578,6 @@ public class PinotTableRestletResource {
     String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     try {
       ObjectNode data = JsonUtils.newObjectNode();
-      data.put("tableName", tableNameWithType);
       data.put("state", _pinotHelixResourceManager.isTableEnabled(tableNameWithType) ? "enabled" : "disabled");
       return data.toString();
     } catch (TableNotFoundException e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1982,6 +1982,22 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Check if the table enabled
+   * @param tableNameWithType Table name with suffix
+   * @return boolean true for enable | false for disabled
+   * throws {@link TableNotFoundException}
+   */
+  public boolean isTableEnabled(String tableNameWithType)
+      throws TableNotFoundException {
+    IdealState idealState = getTableIdealState(tableNameWithType);
+    if (idealState == null) {
+      throw new TableNotFoundException("Failed to find ideal state for table: " + tableNameWithType);
+    }
+
+    return idealState.isEnabled();
+  }
+
+  /**
    * Gets the ideal state of the table
    * @param tableNameWithType Table name with suffix
    * @return IdealState of tableNameWithType

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -371,6 +371,50 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     Assert.assertEquals(deleteResponse, "{\"status\":\"Tables: [table3_OFFLINE] deleted\"}");
   }
 
+  @Test
+  public void testCheckTableState()
+      throws IOException {
+
+    // Create a valid REALTIME table
+    TableConfig realtimeTableConfig = _realtimeBuilder.setTableName("testTable").build();
+    String creationResponse = sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+    Assert.assertEquals(creationResponse, "{\"status\":\"Table testTable_REALTIME succesfully added\"}");
+
+    // Create a valid OFFLINE table
+    TableConfig offlineTableConfig = _offlineBuilder.setTableName("testTable").build();
+    creationResponse = sendPostRequest(_createTableUrl, offlineTableConfig.toJsonString());
+    Assert.assertEquals(creationResponse, "{\"status\":\"Table testTable_OFFLINE succesfully added\"}");
+
+    // Case 1: Check table state with specifying tableType as realtime should return 1 [enabled]
+    String realtimeStateResponse = sendGetRequest(StringUtil.join("/", this._controllerBaseApiUrl, "tables", "testTable", "state?type=realtime"));
+    Assert.assertEquals(realtimeStateResponse, "{\"state\":\"enabled\"}");
+
+    // Case 2: Check table state with specifying tableType as offline should return 1 [enabled]
+    String offlineStateResponse = sendGetRequest(StringUtil.join("/", this._controllerBaseApiUrl, "tables", "testTable", "state?type=offline"));
+    Assert.assertEquals(offlineStateResponse, "{\"state\":\"enabled\"}");
+
+    // Case 3: Request table state with invalid type should return bad request
+    try {
+      sendGetRequest(StringUtil.join("/", this._controllerBaseApiUrl, "tables", "testTable", "state?type=non_valid_type"));
+      Assert.fail("Requesting with invalid type should fail");
+    } catch (Exception e) {
+      // Expected 400 Bad Request
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
+    }
+
+    // Case 4: Request state for non-existent table should return not found
+    boolean notFoundException = false;
+    try {
+      sendGetRequest(StringUtil.join("/", this._controllerBaseApiUrl, "tables", "table_not_exist", "state?type=offline"));
+      Assert.fail("Requesting state for non-existent table should fail");
+    } catch (Exception e) {
+      // Expected 404 Not Found
+      notFoundException = true;
+    }
+
+    Assert.assertTrue(notFoundException);
+  }
+
   @AfterClass
   public void tearDown() {
     stopFakeInstances();


### PR DESCRIPTION

## Description
Add API endpoint for cluster manager to get the table current state. fixes [Issue 6169](https://github.com/apache/incubator-pinot/issues/6169).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
