### PR TITLE
[PQL] added hash functions(sha-1, sha-256, md5, etc)

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/HashFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/HashFunctions.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+/**
+ * Inbuilt Hash Transformation Functions
+ * The functions can be used as UDFs in Query when added in the FunctionRegistry.
+ * @ScalarFunction annotation is used with each method for the registration
+ *
+ * Example usage:
+ * <code> SELECT SHA(bytesColumn) FROM baseballStats LIMIT 10 </code>
+ * <code> SELECT SHA256(bytesColumn) FROM baseballStats LIMIT 10 </code>
+ * <code> SELECT SHA512(bytesColumn) FROM baseballStats LIMIT 10 </code>
+ * <code> SELECT MD5(bytesColumn) FROM baseballStats LIMIT 10 </code>
+ */
+public class HashFunctions {
+  private HashFunctions() {
+  }
+
+  /**
+   * Return SHA-1 digest as hex string.
+   *
+   * @param input the byte array representing the data
+   * @return hash string in hex format
+   */
+  @ScalarFunction
+  public static String sha(byte[] input) {
+    return DigestUtils.shaHex(input);
+  }
+
+  /**
+   * Return SHA-256 digest as hex string.
+   *
+   * @param input the byte array representing the data
+   * @return hash string in hex format
+   */
+  @ScalarFunction
+  public static String sha256(byte[] input) {
+    return DigestUtils.sha256Hex(input);
+  }
+
+  /**
+   * Return SHA-512 digest as hex string.
+   *
+   * @param input the byte array representing the data
+   * @return hash string in hex format
+   */
+  @ScalarFunction
+  public static String sha512(byte[] input) {
+    return DigestUtils.sha512Hex(input);
+  }
+
+  /**
+   * Return MD5 digest as hex string.
+   *
+   * @param input the byte array representing the data
+   * @return hash string in hex format
+   */
+  @ScalarFunction
+  public static String md5(byte[] input) {
+    return DigestUtils.md5Hex(input);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -70,6 +70,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String FLOAT_SV_COLUMN = "floatSV";
   protected static final String DOUBLE_SV_COLUMN = "doubleSV";
   protected static final String STRING_SV_COLUMN = "stringSV";
+  protected static final String BYTES_SV_COLUMN = "bytesSV";
   protected static final String STRING_ALPHANUM_SV_COLUMN = "stringAlphaNumSV";
   protected static final String INT_MV_COLUMN = "intMV";
   protected static final String TIME_COLUMN = "time";
@@ -80,6 +81,7 @@ public abstract class BaseTransformFunctionTest {
   protected final double[] _doubleSVValues = new double[NUM_ROWS];
   protected final String[] _stringSVValues = new String[NUM_ROWS];
   protected final String[] _stringAlphaNumericSVValues = new String[NUM_ROWS];
+  protected final byte[][] _bytesSVValues = new byte[NUM_ROWS][];
   protected final int[][] _intMVValues = new int[NUM_ROWS][];
   protected final long[] _timeValues = new long[NUM_ROWS];
   protected final String[] _jsonValues = new String[NUM_ROWS];
@@ -101,6 +103,7 @@ public abstract class BaseTransformFunctionTest {
       _doubleSVValues[i] = _intSVValues[i] * RANDOM.nextDouble();
       _stringSVValues[i] = df.format(_intSVValues[i] * RANDOM.nextDouble());
       _stringAlphaNumericSVValues[i] = RandomStringUtils.randomAlphanumeric(26);
+      _bytesSVValues[i] = RandomStringUtils.randomAlphanumeric(26).getBytes();
 
       int numValues = 1 + RANDOM.nextInt(MAX_NUM_MULTI_VALUES);
       _intMVValues[i] = new int[numValues];
@@ -121,6 +124,7 @@ public abstract class BaseTransformFunctionTest {
       map.put(DOUBLE_SV_COLUMN, _doubleSVValues[i]);
       map.put(STRING_SV_COLUMN, _stringSVValues[i]);
       map.put(STRING_ALPHANUM_SV_COLUMN, _stringAlphaNumericSVValues[i]);
+      map.put(BYTES_SV_COLUMN, _bytesSVValues[i]);
       map.put(INT_MV_COLUMN, ArrayUtils.toObject(_intMVValues[i]));
       map.put(TIME_COLUMN, _timeValues[i]);
       _jsonValues[i] = JsonUtils.objectToJsonNode(map).toString();
@@ -136,6 +140,7 @@ public abstract class BaseTransformFunctionTest {
         .addSingleValueDimension(DOUBLE_SV_COLUMN, FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(STRING_ALPHANUM_SV_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
         .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.STRING)
         .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COLUMN), null).build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.Assert;
@@ -171,5 +173,57 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     Assert.assertEquals(transformFunction.getName(), "trim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
+  }
+
+  @Test
+  public void testShaTransformFunction() {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("sha(%s)", BYTES_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    Assert.assertEquals(transformFunction.getName(), "sha");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = DigestUtils.shaHex(_bytesSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSha256TransformFunction() {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("sha256(%s)", BYTES_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    Assert.assertEquals(transformFunction.getName(), "sha256");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = DigestUtils.sha256Hex(_bytesSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSha512TransformFunction() {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("sha512(%s)", BYTES_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    Assert.assertEquals(transformFunction.getName(), "sha512");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = DigestUtils.sha512Hex(_bytesSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testMd5TransformFunction() {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("md5(%s)", BYTES_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    Assert.assertEquals(transformFunction.getName(), "md5");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = DigestUtils.md5Hex(_bytesSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 }


### PR DESCRIPTION
## Description
This PR added hash transform functions(sha-1, sha-256, md5, etc). This only works with bytes column.
Use case: digital forensic 


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
