### PR TITLE
Add upsert to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Pinot was originally built at LinkedIn to power rich interactive real-time analy
 
 * **Query with SQL:** SQL-like language that supports selection, aggregation, filtering, group by, order by, distinct queries on data.
 
+* **Upsert during real-time ingestion**: update the data at-scale with consistency
+
 * **Multi-valued fields:** support for multi-valued fields, allowing you to query fields as comma separated values.
 
 * **Cloud-native on Kubernetes**: Helm chart provides a horizontally scalable and fault-tolerant clustered deployment that is easy to manage using Kubernetes.


### PR DESCRIPTION
## Description
With all the PRs for https://github.com/apache/incubator-pinot/issues/4261 in, we can officially state the upsert support in readme since v0.6. And we can close Issue 4261. The upcoming work will be the partial update support.

## Release Notes
If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

The full upsert is supported. A record with the same primary key can be updated by a later record with a greater timestamp.

## Documentation
Documentation is at https://docs.pinot.apache.org/basics/data-import/upsert
