### PR TITLE
showing Query Result as blank table and json format toggle even if query response has 0 records

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -118,6 +118,23 @@ const sqlFuntionsList = [
   'SUMMV', 'AVGMV', 'MINMAXRANGEMV', 'DISTINCTCOUNTMV', 'DISTINCTCOUNTBITMAPMV', 'DISTINCTCOUNTHLLMV',
   'DISTINCTCOUNTRAWHLLMV', 'DISTINCT', 'ST_UNION'];
 
+const responseStatCols = [
+  'timeUsedMs',
+  'numDocsScanned',
+  'totalDocs',
+  'numServersQueried',
+  'numServersResponded',
+  'numSegmentsQueried',
+  'numSegmentsProcessed',
+  'numSegmentsMatched',
+  'numConsumingSegmentsQueried',
+  'numEntriesScannedInFilter',
+  'numEntriesScannedPostFilter',
+  'numGroupsLimitReached',
+  'partialResponse',
+  'minConsumingFreshnessTimeMs'
+];
+
 const QueryPage = () => {
   const classes = useStyles();
   const [fetching, setFetching] = useState(true);
@@ -196,7 +213,7 @@ const QueryPage = () => {
     );
     setResultError(results.error || '');
     setResultData(results.result || { columns: [], records: [] });
-    setQueryStats(results.queryStats || { columns: [], records: [] });
+    setQueryStats(results.queryStats || { columns: responseStatCols, records: [] });
     setOutputResult(JSON.stringify(results.data, null, 2) || '');
     setQueryLoader(false);
   };
@@ -380,7 +397,7 @@ const QueryPage = () => {
                   </Alert>
                 ) : (
                   <>
-                    {queryStats.records.length ? (
+                    {queryStats.columns.length ? (
                       <Grid item xs style={{ backgroundColor: 'white' }}>
                         <CustomizedTables
                           title="Query Response Stats"
@@ -392,7 +409,7 @@ const QueryPage = () => {
                     ) : null}
 
                     <Grid item xs style={{ backgroundColor: 'white' }}>
-                      {resultData.records.length ? (
+                      {resultData.columns.length ? (
                         <>
                           <Grid container className={classes.actionBtns}>
                             <Button
@@ -454,7 +471,7 @@ const QueryPage = () => {
                               showSearchBox={true}
                               inAccordionFormat={true}
                             />
-                          ) : resultData.records.length ? (
+                          ) : resultData.columns.length ? (
                             <SimpleAccordion
                               headerTitle="Query Result (JSON Format)"
                               showSearchBox={false}

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -262,7 +262,7 @@ const getQueryResults = (params, url, checkedOptions) => {
       dataArray = queryResponse.resultTable.rows;
     }
 
-    const columnStats = [ 'timeUsedMs',
+    const columnStats = ['timeUsedMs',
       'numDocsScanned',
       'totalDocs',
       'numServersQueried',


### PR DESCRIPTION
## Description
Previously UI was hiding the `Query Response Stats` and `Query Result` widget if 0 rows were found in the query.

Fixed it to show both the widgets.
![image](https://user-images.githubusercontent.com/6761317/97963086-72be0b00-1ddc-11eb-87f9-7bdab952a386.png)
