### PR TITLE
Perf optimization for SQL GROUP BY ORDER BY

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -65,7 +65,7 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   ENTRIES_SCANNED_POST_FILTER("documents", false),
 
   NUM_RESIZES("resizes", false),
-  RESIZE_TIME_MS("documents", false),
+  RESIZE_TIME_MS("resizeTimeMs", false),
 
   REQUEST_CONNECTION_TIMEOUTS("timeouts", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -64,6 +64,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   ENTRIES_SCANNED_IN_FILTER("documents", false),
   ENTRIES_SCANNED_POST_FILTER("documents", false),
 
+  NUM_RESIZES("resizes", false),
+  RESIZE_TIME_MS("documents", false),
+
   REQUEST_CONNECTION_TIMEOUTS("timeouts", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -64,6 +64,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REFRESH_FAILURES("segments", false),
   UNTAR_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FAILURES("segments", false),
+  NUM_RESIZES("numResizes", false),
+  RESIZE_TIME_MS("resizeTimeMs", false),
 
   // Netty connection metrics
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -173,6 +173,10 @@ public class CommonConstants {
     public static final int DEFAULT_MAX_REDUCE_THREADS_PER_QUERY =
         Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2)); // Same logic as CombineOperatorUtils
 
+    // used for SQL GROUP BY during broker reduce
+    public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
+    public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -42,6 +42,8 @@ public interface DataTable {
   String TIME_USED_MS_METADATA_KEY = "timeUsedMs";
   String TRACE_INFO_METADATA_KEY = "traceInfo";
   String REQUEST_ID_METADATA_KEY = "requestId";
+  String NUM_RESIZES_METADATA_KEY = "numResizes";
+  String RESIZE_TIME_MS_METADATA_KEY = "resizeTimeMs";
 
   void addException(ProcessingException processingException);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -142,7 +142,7 @@ public class TableResizer {
     int numRecordsToEvict = recordsMap.size() - trimToSize;
     if (numRecordsToEvict > 0) {
       // TODO: compare the performance of converting to IntermediateRecord vs keeping Record, in cases where we do not need to extract final results
-      if (numRecordsToEvict <= trimToSize) {
+      if (numRecordsToEvict < trimToSize) {
         // num records to evict is smaller than num records to retain
         // make PQ of records to evict
         PriorityQueue<IntermediateRecord> priorityQueue =

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -136,39 +138,48 @@ public class TableResizer {
    * Resize only if number of records is greater than trimToSize
    * The resizer smartly chooses to create PQ of records to evict or records to retain, based on the number of records and the number of records to evict
    */
-  public void resizeRecordsMap(Map<Key, Record> recordsMap, int trimToSize) {
+  public Map<Key, Record> resizeRecordsMap(Map<Key, Record> recordsMap, int trimToSize) {
     int numRecordsToEvict = recordsMap.size() - trimToSize;
-
     if (numRecordsToEvict > 0) {
       // TODO: compare the performance of converting to IntermediateRecord vs keeping Record, in cases where we do not need to extract final results
-
-      if (numRecordsToEvict < trimToSize) { // num records to evict is smaller than num records to retain
+      if (numRecordsToEvict <= trimToSize) {
+        // num records to evict is smaller than num records to retain
         // make PQ of records to evict
         PriorityQueue<IntermediateRecord> priorityQueue =
             convertToIntermediateRecordsPQ(recordsMap, numRecordsToEvict, _intermediateRecordComparator);
         for (IntermediateRecord evictRecord : priorityQueue) {
           recordsMap.remove(evictRecord._key);
         }
-      } else { // num records to retain is smaller than num records to evict
+        return recordsMap;
+      } else {
+        // num records to retain is smaller than num records to evict
         // make PQ of records to retain
+        // TODO - Consider reusing the same map by removing record from the map
+        // at the time it is evicted from PQ
+        Map<Key, Record> trimmedRecordsMap;
+        if (recordsMap instanceof ConcurrentMap) {
+          // invoked by ConcurrentIndexedTable
+          trimmedRecordsMap = new ConcurrentHashMap<>();
+        } else {
+          // invoked by SimpleIndexedTable
+          trimmedRecordsMap = new HashMap<>();
+        }
         Comparator<IntermediateRecord> comparator = _intermediateRecordComparator.reversed();
         PriorityQueue<IntermediateRecord> priorityQueue =
             convertToIntermediateRecordsPQ(recordsMap, trimToSize, comparator);
-        ObjectOpenHashSet<Key> keysToRetain = new ObjectOpenHashSet<>(priorityQueue.size());
-        for (IntermediateRecord retainRecord : priorityQueue) {
-          keysToRetain.add(retainRecord._key);
+        for (IntermediateRecord recordToRetain : priorityQueue) {
+          trimmedRecordsMap.put(recordToRetain._key, recordsMap.get(recordToRetain._key));
         }
-        recordsMap.keySet().retainAll(keysToRetain);
+        return trimmedRecordsMap;
       }
     }
+    return recordsMap;
   }
 
   private PriorityQueue<IntermediateRecord> convertToIntermediateRecordsPQ(Map<Key, Record> recordsMap, int size,
       Comparator<IntermediateRecord> comparator) {
     PriorityQueue<IntermediateRecord> priorityQueue = new PriorityQueue<>(size, comparator);
-
     for (Map.Entry<Key, Record> entry : recordsMap.entrySet()) {
-
       IntermediateRecord intermediateRecord = getIntermediateRecord(entry.getKey(), entry.getValue());
       if (priorityQueue.size() < size) {
         priorityQueue.offer(intermediateRecord);
@@ -183,62 +194,25 @@ public class TableResizer {
     return priorityQueue;
   }
 
-  private List<Record> sortRecordsMap(Map<Key, Record> recordsMap) {
-    int numRecords = recordsMap.size();
-    List<Record> sortedRecords = new ArrayList<>(numRecords);
-    List<IntermediateRecord> intermediateRecords = new ArrayList<>(numRecords);
-    for (Map.Entry<Key, Record> entry : recordsMap.entrySet()) {
-      intermediateRecords.add(getIntermediateRecord(entry.getKey(), entry.getValue()));
-    }
-    intermediateRecords.sort(_intermediateRecordComparator);
-    for (IntermediateRecord intermediateRecord : intermediateRecords) {
-      sortedRecords.add(recordsMap.get(intermediateRecord._key));
-    }
-    return sortedRecords;
-  }
-
   /**
-   * Resizes the recordsMap and returns a sorted list of records.
+   * Sorts the recordsMap using a priority queue and returns a sorted list of records
    * This method is to be called from IndexedTable::finish, if both resize and sort is needed
-   *
-   * If numRecordsToEvict > numRecordsToRetain, resize with PQ of records to evict, and then sort
-   * Else, resize with PQ of record to retain, then use the PQ to create sorted list
    */
-  public List<Record> resizeAndSortRecordsMap(Map<Key, Record> recordsMap, int trimToSize) {
+  public List<Record> sortRecordsMap(Map<Key, Record> recordsMap, int trimToSize) {
     int numRecords = recordsMap.size();
     if (numRecords == 0) {
       return Collections.emptyList();
     }
-
     int numRecordsToRetain = Math.min(numRecords, trimToSize);
-    int numRecordsToEvict = numRecords - numRecordsToRetain;
-
-    if (numRecordsToEvict < numRecordsToRetain) { // num records to evict is smaller than num records to retain
-      if (numRecordsToEvict > 0) {
-        // make PQ of records to evict
-        PriorityQueue<IntermediateRecord> priorityQueue =
-            convertToIntermediateRecordsPQ(recordsMap, numRecordsToEvict, _intermediateRecordComparator);
-        for (IntermediateRecord evictRecord : priorityQueue) {
-          recordsMap.remove(evictRecord._key);
-        }
-      }
-      return sortRecordsMap(recordsMap);
-    } else {
-      // make PQ of records to retain
-      PriorityQueue<IntermediateRecord> priorityQueue =
-          convertToIntermediateRecordsPQ(recordsMap, numRecordsToRetain, _intermediateRecordComparator.reversed());
-      // use PQ to get sorted list
-      Record[] sortedArray = new Record[numRecordsToRetain];
-      ObjectOpenHashSet<Key> keysToRetain = new ObjectOpenHashSet<>(numRecordsToRetain);
-      while (!priorityQueue.isEmpty()) {
-        IntermediateRecord intermediateRecord = priorityQueue.poll();
-        keysToRetain.add(intermediateRecord._key);
-        Record record = recordsMap.get(intermediateRecord._key);
-        sortedArray[--numRecordsToRetain] = record;
-      }
-      recordsMap.keySet().retainAll(keysToRetain);
-      return Arrays.asList(sortedArray);
+    // make PQ of sorted records to retain
+    PriorityQueue<IntermediateRecord> priorityQueue = convertToIntermediateRecordsPQ(recordsMap, numRecordsToRetain, _intermediateRecordComparator.reversed());
+    Record[] sortedArray = new Record[numRecordsToRetain];
+    while (!priorityQueue.isEmpty()) {
+      IntermediateRecord intermediateRecord = priorityQueue.poll();
+      Record record = recordsMap.get(intermediateRecord._key);
+      sortedArray[--numRecordsToRetain] = record;
     }
+    return Arrays.asList(sortedArray);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/UnboundedConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/UnboundedConcurrentIndexedTable.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import com.google.common.base.Preconditions;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+/**
+ * Another version of {@link ConcurrentIndexedTable} used for use cases
+ * configured to have infinite group by (num group limit to se 1B or higher).
+ * For such cases, there won't be any resizing/trimming during upsert since
+ * trimThreshold is very high. Thus, we can avoid the overhead of readLock's
+ * lock and unlock operations which are otherwise used in ConcurrentIndexedTable
+ * to prevent race conditions between 2 threads doing upsert and one of them ends
+ * up trimming from upsert. For use cases with very large number of groups, we had
+ * noticed that load-unlock overhead was > 1sec and this specialized concurrent
+ * indexed table avoids that by overriding just the upsert method
+ */
+public class UnboundedConcurrentIndexedTable extends ConcurrentIndexedTable {
+
+  public UnboundedConcurrentIndexedTable(DataSchema dataSchema,
+      QueryContext queryContext, int trimSize, int trimThreshold) {
+    super(dataSchema, queryContext, trimSize, trimThreshold);
+  }
+
+  @Override
+  public boolean upsert(Key key, Record newRecord) {
+    if (_noMoreNewRecords.get()) {
+      // allow only existing record updates
+      _lookupMap.computeIfPresent(key, (k, v) -> {
+        Object[] existingValues = v.getValues();
+        Object[] newValues = newRecord.getValues();
+        int aggNum = 0;
+        for (int i = _numKeyColumns; i < _numColumns; i++) {
+          existingValues[i] = _aggregationFunctions[aggNum++].merge(existingValues[i], newValues[i]);
+        }
+        return v;
+      });
+    } else {
+      // allow all records
+      _lookupMap.compute(key, (k, v) -> {
+        if (v == null) {
+          return newRecord;
+        } else {
+          Object[] existingValues = v.getValues();
+          Object[] newValues = newRecord.getValues();
+          int aggNum = 0;
+          for (int i = _numKeyColumns; i < _numColumns; i++) {
+            existingValues[i] = _aggregationFunctions[aggNum++].merge(existingValues[i], newValues[i]);
+          }
+          return v;
+        }
+      });
+
+      if (_lookupMap.size() >= _trimSize && !_hasOrderBy) {
+        // reached capacity and no order by. No more new records will be accepted
+        _noMoreNewRecords.set(true);
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -61,6 +61,8 @@ public class CombinePlanNode implements PlanNode {
   private final long _endTimeMs;
   private final int _numGroupsLimit;
   private final StreamObserver<Server.ServerResponse> _streamObserver;
+  // used for SQL GROUP BY during server combine
+  private final int _groupByTrimThreshold;
 
   /**
    * Constructor for the class.
@@ -71,15 +73,18 @@ public class CombinePlanNode implements PlanNode {
    * @param endTimeMs End time in milliseconds for the query
    * @param numGroupsLimit Limit of number of groups stored in each segment
    * @param streamObserver Optional stream observer for streaming query
+   * @param groupByTrimThreshold trim threshold to use for server combine for SQL GROUP BY
    */
   public CombinePlanNode(List<PlanNode> planNodes, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int numGroupsLimit, @Nullable StreamObserver<Server.ServerResponse> streamObserver) {
+      long endTimeMs, int numGroupsLimit, @Nullable StreamObserver<Server.ServerResponse> streamObserver,
+      int groupByTrimThreshold) {
     _planNodes = planNodes;
     _queryContext = queryContext;
     _executorService = executorService;
     _endTimeMs = endTimeMs;
     _numGroupsLimit = numGroupsLimit;
     _streamObserver = streamObserver;
+    _groupByTrimThreshold = groupByTrimThreshold;
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -175,7 +180,8 @@ public class CombinePlanNode implements PlanNode {
         // Aggregation group-by
         QueryOptions queryOptions = new QueryOptions(_queryContext.getQueryOptions());
         if (queryOptions.isGroupByModeSQL()) {
-          return new GroupByOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs);
+          return new GroupByOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
+              _groupByTrimThreshold);
         }
         return new GroupByCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _numGroupsLimit);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -66,10 +66,13 @@ public class BrokerReduceService {
 
   private final ExecutorService _reduceExecutorService;
   private final int _maxReduceThreadsPerQuery;
+  private final int _groupByTrimThreshold;
 
   public BrokerReduceService(PinotConfiguration config) {
     _maxReduceThreadsPerQuery = config.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY,
         CommonConstants.Broker.DEFAULT_MAX_REDUCE_THREADS_PER_QUERY);
+    _groupByTrimThreshold = config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD,
+        CommonConstants.Broker.DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD);
 
     int numThreadsInExecutorService = Runtime.getRuntime().availableProcessors();
     LOGGER.info("Initializing BrokerReduceService with {} threads, and {} max reduce threads.",
@@ -225,8 +228,9 @@ public class BrokerReduceService {
 
     QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
     DataTableReducer dataTableReducer = ResultReducerFactory.getResultReducer(queryContext);
-    dataTableReducer.reduceAndSetResults(tableName, cachedDataSchema, dataTableMap, brokerResponseNative,
-        new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs), brokerMetrics);
+    dataTableReducer.reduceAndSetResults(rawTableName, cachedDataSchema, dataTableMap, brokerResponseNative,
+        new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
+            _groupByTrimThreshold), brokerMetrics);
     updateAlias(queryContext, brokerResponseNative);
     return brokerResponseNative;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
@@ -38,13 +38,14 @@ public class DataTableReducerContext {
    * @param executorService Executor service to use for DataTableReducer
    * @param maxReduceThreadsPerQuery Max number of threads to use for reduce phase
    * @param reduceTimeOutMs Reduce Phase timeOut in ms
+   * @param groupByTrimThreshold trim threshold for SQL group by
    */
   public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs,
-      int sqlGroupByTrimThreshold) {
+      int groupByTrimThreshold) {
     _executorService = executorService;
     _maxReduceThreadsPerQuery = maxReduceThreadsPerQuery;
     _reduceTimeOutMs = reduceTimeOutMs;
-    _groupByTrimThreshold = sqlGroupByTrimThreshold;
+    _groupByTrimThreshold = groupByTrimThreshold;
   }
 
   public ExecutorService getExecutorService() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
@@ -29,6 +29,8 @@ public class DataTableReducerContext {
   private final ExecutorService _executorService;
   private final int _maxReduceThreadsPerQuery;
   private final long _reduceTimeOutMs;
+  // used for SQL GROUP BY
+  private final int _groupByTrimThreshold;
 
   /**
    * Constructor for the class.
@@ -37,10 +39,12 @@ public class DataTableReducerContext {
    * @param maxReduceThreadsPerQuery Max number of threads to use for reduce phase
    * @param reduceTimeOutMs Reduce Phase timeOut in ms
    */
-  public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs) {
+  public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs,
+      int sqlGroupByTrimThreshold) {
     _executorService = executorService;
     _maxReduceThreadsPerQuery = maxReduceThreadsPerQuery;
     _reduceTimeOutMs = reduceTimeOutMs;
+    _groupByTrimThreshold = sqlGroupByTrimThreshold;
   }
 
   public ExecutorService getExecutorService() {
@@ -53,5 +57,9 @@ public class DataTableReducerContext {
 
   public long getReduceTimeOutMs() {
     return _reduceTimeOutMs;
+  }
+
+  public int getGroupByTrimThreshold() {
+    return _groupByTrimThreshold;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -60,6 +60,8 @@ public abstract class QueryScheduler {
   private static final String INVALID_NUM_SCANNED = "-1";
   private static final String INVALID_SEGMENTS_COUNT = "-1";
   private static final String INVALID_FRESHNESS_MS = "-1";
+  private static final String INVALID_NUM_RESIZES = "-1";
+  private static final String INVALID_RESIZE_TIME_MS = "-1";
   private static final String QUERY_LOG_MAX_RATE_KEY = "query.log.maxRatePerSecond";
   private static final double DEFAULT_QUERY_LOG_MAX_RATE = 10_000d;
 
@@ -183,6 +185,8 @@ public abstract class QueryScheduler {
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.NUM_CONSUMING_SEGMENTS_PROCESSED, INVALID_SEGMENTS_COUNT));
     long minConsumingFreshnessMs =
         Long.parseLong(dataTableMetadata.getOrDefault(DataTable.MIN_CONSUMING_FRESHNESS_TIME_MS, INVALID_FRESHNESS_MS));
+    int numResizes = Integer.parseInt(dataTableMetadata.getOrDefault(DataTable.NUM_RESIZES_METADATA_KEY, INVALID_NUM_RESIZES));
+    long resizeTimeMs = Long.parseLong(dataTableMetadata.getOrDefault(DataTable.RESIZE_TIME_MS_METADATA_KEY, INVALID_RESIZE_TIME_MS));
 
     if (numDocsScanned > 0) {
       serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
@@ -194,6 +198,12 @@ public abstract class QueryScheduler {
     if (numEntriesScannedPostFilter > 0) {
       serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_ENTRIES_SCANNED_POST_FILTER,
           numEntriesScannedPostFilter);
+    }
+    if (numResizes > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_RESIZES, numResizes);
+    }
+    if (resizeTimeMs > 0) {
+      serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.RESIZE_TIME_MS, resizeTimeMs);
     }
 
     TimerContext timerContext = queryRequest.getTimerContext();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -175,7 +175,7 @@ public class TableResizerTest {
     tableResizer =
         new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d1"));
     recordsMap = new HashMap<>(_recordsMap);
-    tableResizer.resizeRecordsMap(recordsMap, trimToSize);
+    recordsMap = tableResizer.resizeRecordsMap(recordsMap, trimToSize);
     assertEquals(recordsMap.size(), trimToSize);
     assertTrue(recordsMap.containsKey(_keys.get(0))); // a, b
     assertTrue(recordsMap.containsKey(_keys.get(1)));
@@ -184,7 +184,7 @@ public class TableResizerTest {
     tableResizer =
         new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "AVG(m4)"));
     recordsMap = new HashMap<>(_recordsMap);
-    tableResizer.resizeRecordsMap(recordsMap, trimToSize);
+    recordsMap = tableResizer.resizeRecordsMap(recordsMap, trimToSize);
     assertEquals(recordsMap.size(), trimToSize);
     assertTrue(recordsMap.containsKey(_keys.get(4))); // 2, 3
     assertTrue(recordsMap.containsKey(_keys.get(3)));
@@ -193,7 +193,7 @@ public class TableResizerTest {
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "DISTINCTCOUNT(m3) DESC, d1"));
     recordsMap = new HashMap<>(_recordsMap);
-    tableResizer.resizeRecordsMap(recordsMap, trimToSize);
+    recordsMap = tableResizer.resizeRecordsMap(recordsMap, trimToSize);
     assertEquals(recordsMap.size(), trimToSize);
     assertTrue(recordsMap.containsKey(_keys.get(4))); // 4, 3
     assertTrue(recordsMap.containsKey(_keys.get(3)));
@@ -202,7 +202,7 @@ public class TableResizerTest {
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d2 / (DISTINCTCOUNT(m3) + 1), d1 DESC"));
     recordsMap = new HashMap<>(_recordsMap);
-    tableResizer.resizeRecordsMap(recordsMap, trimToSize);
+    recordsMap = tableResizer.resizeRecordsMap(recordsMap, trimToSize);
     assertEquals(recordsMap.size(), trimToSize);
     assertTrue(recordsMap.containsKey(_keys.get(1))); // 3.33, 12.5
     assertTrue(recordsMap.containsKey(_keys.get(0)));
@@ -217,21 +217,21 @@ public class TableResizerTest {
     TableResizer tableResizer =
         new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d1"));
     Map<Key, Record> recordsMap = new HashMap<>(_recordsMap);
-    List<Record> sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    List<Record> sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a, b
     assertEquals(sortedRecords.get(1), _records.get(1));
 
     // d1 asc - trim to 1
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, 1);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, 1);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a
 
     // d1 asc, d3 desc (tie breaking with 2nd comparator)
     tableResizer =
         new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d1, d3 DESC"));
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a, b, c (300)
     assertEquals(sortedRecords.get(1), _records.get(1));
@@ -239,7 +239,7 @@ public class TableResizerTest {
 
     // d1 asc, d3 desc (tie breaking with 2nd comparator) - trim to 1
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, 1);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, 1);
     assertEquals(sortedRecords.size(), 1);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a
 
@@ -247,7 +247,7 @@ public class TableResizerTest {
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d1, SUM(m1) DESC, max(m2) DESC"));
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a, b, c (30, 300)
     assertEquals(sortedRecords.get(1), _records.get(1));
@@ -255,7 +255,7 @@ public class TableResizerTest {
 
     // d1 asc, sum(m1) desc, max(m2) desc - trim to 1
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, 1);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, 1);
     assertEquals(sortedRecords.size(), 1);
     assertEquals(sortedRecords.get(0), _records.get(0));  // a
 
@@ -263,7 +263,7 @@ public class TableResizerTest {
     tableResizer =
         new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "AVG(m4)"));
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(4));  // 2, 3, 3.33
     assertEquals(sortedRecords.get(1), _records.get(3));
@@ -273,7 +273,7 @@ public class TableResizerTest {
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "DISTINCTCOUNT(m3) DESC, d1"));
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(4));  // 4, 3, 2 (b)
     assertEquals(sortedRecords.get(1), _records.get(3));
@@ -283,7 +283,7 @@ public class TableResizerTest {
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContextFromSQL(QUERY_PREFIX + "d2 / (DISTINCTCOUNT(m3) + 1), d1 DESC"));
     recordsMap = new HashMap<>(_recordsMap);
-    sortedRecords = tableResizer.resizeAndSortRecordsMap(recordsMap, TRIM_TO_SIZE);
+    sortedRecords = tableResizer.sortRecordsMap(recordsMap, TRIM_TO_SIZE);
     assertEquals(sortedRecords.size(), TRIM_TO_SIZE);
     assertEquals(sortedRecords.get(0), _records.get(1));  // 3.33, 12.5, 5
     assertEquals(sortedRecords.get(1), _records.get(0));

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -94,7 +94,7 @@ public class CombineSlowOperatorsTest {
     List<Operator> operators = getOperators();
     GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromPQL("SELECT COUNT(*) FROM table GROUP BY column"),
-        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     testCombineOperator(operators, combineOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -94,7 +94,7 @@ public class CombineSlowOperatorsTest {
     List<Operator> operators = getOperators();
     GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromPQL("SELECT COUNT(*) FROM table GROUP BY column"),
-        _executorService, TIMEOUT_MS);
+        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
     testCombineOperator(operators, combineOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -230,7 +230,8 @@ public class SelectionCombineOperatorTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     return combinePlanNode.run().nextBlock();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -58,7 +58,8 @@ public class CombinePlanNodeTest {
       }
       CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
           System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null);
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
+          InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
       combinePlanNode.run();
       Assert.assertEquals(numPlans, count.get());
     }
@@ -83,7 +84,8 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode =
         new CombinePlanNode(planNodes, _queryContext, _executorService, System.currentTimeMillis() + 100,
-            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null);
+            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {
@@ -105,7 +107,8 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
 import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
@@ -130,10 +131,11 @@ public class BenchmarkCombineGroupBy {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void concurrentIndexedTableForCombineGroupBy()
       throws InterruptedException, ExecutionException, TimeoutException {
-    int capacity = GroupByUtils.getTableCapacity(_queryContext);
+    int trimSize = GroupByUtils.getTableCapacity(_queryContext);
 
     // make 1 concurrent table
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, capacity);
+    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, trimSize,
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
 
     List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -135,7 +135,7 @@ public class BenchmarkCombineGroupBy {
 
     // make 1 concurrent table
     IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, trimSize,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
 
     List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -56,7 +56,8 @@ import org.openjdk.jmh.runner.options.TimeValue;
 
 @State(Scope.Benchmark)
 public class BenchmarkIndexedTable {
-  private static final int CAPACITY = 800;
+  private static final int TRIM_SIZE = 800;
+  private static final int TRIM_THRESHOLD_FOR_UPSERT = TRIM_SIZE * 4;
   private static final int NUM_RECORDS = 1000;
   private static final Random RANDOM = new Random();
 
@@ -113,7 +114,7 @@ public class BenchmarkIndexedTable {
     int numSegments = 10;
 
     // make 1 concurrent table
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, CAPACITY);
+    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD_FOR_UPSERT);
 
     // 10 parallel threads putting 10k records into the table
 
@@ -161,7 +162,7 @@ public class BenchmarkIndexedTable {
     for (int i = 0; i < numSegments; i++) {
 
       // make 10 indexed tables
-      IndexedTable simpleIndexedTable = new SimpleIndexedTable(_dataSchema, _queryContext, CAPACITY);
+      IndexedTable simpleIndexedTable = new SimpleIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD_FOR_UPSERT);
       simpleIndexedTables.add(simpleIndexedTable);
 
       // put 10k records in each indexed table, in parallel

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -57,7 +57,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 @State(Scope.Benchmark)
 public class BenchmarkIndexedTable {
   private static final int TRIM_SIZE = 800;
-  private static final int TRIM_THRESHOLD_FOR_UPSERT = TRIM_SIZE * 4;
+  private static final int TRIM_THRESHOLD = TRIM_SIZE * 4;
   private static final int NUM_RECORDS = 1000;
   private static final Random RANDOM = new Random();
 
@@ -114,7 +114,7 @@ public class BenchmarkIndexedTable {
     int numSegments = 10;
 
     // make 1 concurrent table
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD_FOR_UPSERT);
+    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
 
     // 10 parallel threads putting 10k records into the table
 
@@ -162,7 +162,7 @@ public class BenchmarkIndexedTable {
     for (int i = 0; i < numSegments; i++) {
 
       // make 10 indexed tables
-      IndexedTable simpleIndexedTable = new SimpleIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD_FOR_UPSERT);
+      IndexedTable simpleIndexedTable = new SimpleIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
       simpleIndexedTables.add(simpleIndexedTable);
 
       // put 10k records in each indexed table, in parallel


### PR DESCRIPTION
This PR optimizes the performance of SQL GROUP BY ORDER BY.

**Problem:**

We recently observed that GROUP BY ORDER BY queries having a large (we are having as high as 166million) numDocsScanned are 5x-6x slower as compared to PQL. Removing ORDER BY from the queries made the performance on par or even faster than PQL in some cases. So ORDER BY code was the reason for degradation during server-combine and broker-reduce phases since segment level execution between PQL and SQL is the same for GROUP BY ORDER BY.

Couple of factors in the order by code are contributing to degradation:

- More resizes: Resizes are essentially not the internal resize of the ConcurrentHashMap used by IndexedTable. The resize here is the trimming operation done by TableResizer everytime the map reaches the trimThreshold. The resize requires inserting items in PQ (sorting) and evicting the `trimThreshold - trimSize` number of items from the map. 

- retainAll() - The TableResizer's resizeRecordsMap() method is invoked under 2 circumstances (1) resize during upsert, (2) resize during finish(false) from server combine. If TableResizer builds a PQ to retain the records, it then invokes retainAll() method on hashmap which we have seen to take > 1sec

- readLock.lock and readLock.unlock - The upsert method takes a readlock to prevent the race condition that might arise due to another thread concurrently trimming (under write lock). The overhead of this operation is non-negligible for very high number of records. The total cumulative time spent in lock and unlock operations was just under 1sec
`

  | PQL | SQL | SQL optimized
-- | -- | -- | --
**Server Combine**
trimSize for server combine | max(TOP * 5, 5000) | max(LIMIT * 5, 5000) | max(LIMIT * 5, 5000)
trimThreshold for segment combine | trimSize * 4 | trimSize <= 100_000 trimThreshold = 1m else trimThreshold = trimSize * 1.2 | trimThreshold is configurable
Num resizes/sort during segment execution | 0 | 0 | 0
Num resizes/sort during server combine | At most once - when the server combine is done, if numGroups > trimThreshold, trim to trimSize. | During upsert every time we hit trimThreshold, trim to trimSize.During finish, we trim again to trimSize | During upsert, no trimming. During finish, if numGroups > trimThreshold, trim to trimSize. Finish is called when the server combine is over.
**Broker Reduce**
trimSize for broker reduce | TOP | max(LIMIT * 5, 5000) | LIMIT
trimThreshold for broker reduce | N.A | trimSize <= 100_000 trimThreshold = 1m else trimThreshold = trimSize * 1.2 | N.A
Num resizes/sort during broker combine | Exactly once - after adding results from all DataTables to the finalMap, trim to TOP | We upsert rows from each DataTable into IndexedTable. During upsert every time we hit trimThreshold, trim to trimSize. During finish, we resize again to trimSize Finally use LIMIT number of rows from the trimmed set as the final result set | During upsert, no trimming. Exactly once - when finish is called after upserting rows from each DataTable into indexed table. Trimmed to LIMIT

`

For a given SQL query with LIMIT 50000 and numDocsScanned 160million:

- trimSize -> max (50000 * 5, 5000) -> 250000
- trimThreshold -> trimSize * 1.2 -> 300000
- num resizes(trims) during server combine - ~20
- cumulative resize/trim time during server combine - 3000ms
- num resizes (trims) during broker reduce - ~10
- cumulative resize/trim time during broker reduce - 1600ms
- readLock.lock, unlock - 900ms
- retainAll -  1100ms

Total SQL query time ~7000ms
Total PQL query time ~1800ms

**Solution**

The solution is aimed at bringing the resize/trim code on par with PQL to get similar performance for such use cases

- To better control the frequency of trimming (and accuracy, latency), introduce a new server side and broker side config for trimThreshold. To be used for SQL group by. 

- trimThreshold = configuredTrimThreshold

- trimSize = limit N * 5 (same as PQL, not changed by this PR)

- trimSize = min (trimSize, trimThreshold / 2) - to protect the server with queries having high LIMIT N

- If the configured value is infinite (1B), we use a sub-class of ConcurrentIndexedTable that doesn't use any locks in upsert() method since we know that trimThreshold being infinite wouldn't require any trimming in upsert. 

- Instead of retainAll(), build a new result map with the records to be retained just like it is done in PQL. 

- During server combine, trim at most once when indexedTable.finish (false) is called by combiner if numGroups > trimThreshold. Trim to trimSize

- During broker reduce, trim exactly once when indexedTable.finish(true) is called. Trim to LIMIT N

For the same query, with the above changes

SQL - 2200ms (multiple runs also give < 2secs)
PQL - 1800ms