### PR TITLE
[TE]frontend - Refactor detection-health and stats component

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
@@ -94,31 +94,12 @@
               }}
             </div>
 
-            <!-- Detection Health -->
-            <div class="te-horizontal-cards te-content-block__detection-health">
-              <h4 class="te-self-serve__block-title">
-                <label for="select-dimension" class="control-label te-label">
-                  Detection health
-                  <span>
-                    <i class="glyphicon glyphicon-question-sign"></i>
-                    {{#tooltip-on-element class="te-tooltip"}}
-                      See how your detection configuration is performing in detail
-                      by clicking 'view details' below{{#if showRules}},
-                      and select different rules above the graph
-                      to see their respective regression errors{{/if}}.
-                    {{/tooltip-on-element}}
-                  </span>
-                </label>
-              </h4>
-              {{detection-health
-                health=detectionHealth
-                selectedRule=selectedRule
-              }}
-            </div>
+            {{detection-health
+              health=detectionHealth
+              selectedRule=selectedRule
+            }}
           </div>
-
           {{else}}
-
             <!-- Anomalies, Response Rate, Precision, Recall -->
             <div class="te-horizontal-cards te-content-block">
               <h4 class="te-self-serve__block-title">

--- a/thirdeye/thirdeye-frontend/app/pods/components/detection-health/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/detection-health/component.js
@@ -14,21 +14,24 @@ import { get, computed } from '@ember/object';
 import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import moment from 'moment';
 
+const LABEL_MAP = {
+  GOOD: '--good',
+  MODERATE: '--average',
+  BAD: '--poor'
+};
+
+const STATUS_MAP = {
+  GOOD: 'Good',
+  MODERATE: 'Average',
+  BAD: 'Poor',
+  UNKNOWN: 'Unknown'
+};
+
 export default Component.extend({
   selectedRule: null, // passed in by parent when relevant
-  classNames: ['te-horizontal-cards__container'],
-  labelMap: {
-    GOOD: '--good',
-    MODERATE: '--average',
-    BAD: '--poor'
-  },
-  statusMap: {
-    GOOD: 'Good',
-    MODERATE: 'Average',
-    BAD: 'Poor',
-    UNKNOWN: 'Unknown'
-  },
-
+  tagName: '',
+  labelMap: LABEL_MAP,
+  statusMap: STATUS_MAP,
   /**
    * Changes the color of text in Detection Health
    * @type {String}
@@ -115,9 +118,9 @@ export default Component.extend({
       const lastTaskExecutionTimestamp = get(this, 'health').detectionTaskStatus.lastTaskExecutionTime;
       if (lastTaskExecutionTimestamp > 0) {
         const executionDateTime = new Date(lastTaskExecutionTimestamp);
-        return executionDateTime.toDateString() + ", " +  executionDateTime.toLocaleTimeString() + " (" + moment().tz(moment.tz.guess()).format('z') + ")"
+        return executionDateTime.toDateString() + ", " +  executionDateTime.toLocaleTimeString() + " (" + moment().tz(moment.tz.guess()).format('z') + ")";
       }
-      return "-"
+      return "-";
     }
   ),
 
@@ -159,7 +162,7 @@ export default Component.extend({
       const info = {};
       info.mape = floatToPercent(NaN); // set default to Nan
       let rule = selectedRule ? selectedRule.detectorName : null;
-      info.status = 'Unknown'
+      info.status = 'Unknown';
       // 3 possibilities: selectedRule, no selectedRule and rules available, no rules available
       if (health && health.regressionStatus && typeof health.regressionStatus === 'object') {
         const regressionStatus = health.regressionStatus;

--- a/thirdeye/thirdeye-frontend/app/pods/components/detection-health/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/detection-health/template.hbs
@@ -1,84 +1,102 @@
-<ul class="te-horizontal-cards__single-card">
-  <li class="te-horizontal-cards__card-title">
-    <label for="select-dimension" class="control-label te-label--no-bottom">
-      30-day status
+<section class="te-horizontal-cards te-content-block__detection-health">
+  <h4 class="te-self-serve__block-title">
+    <label for="select-dimension" class="control-label te-label">
+      Detection health
       <span>
         <i class="glyphicon glyphicon-question-sign"></i>
-        {{#tooltip-on-element class="te-tooltip"}}
-          The overall health status of your detection configuration is based on
-          the most recent 30 days.
-        {{/tooltip-on-element}}
+          {{#tooltip-on-element class="te-tooltip"}}
+            See how your detection configuration is performing in detail
+            by clicking 'view details' below{{#if showRules}},
+            and select different rules above the graph
+            to see their respective regression errors{{/if}}.
+          {{/tooltip-on-element}}
       </span>
     </label>
-  </li>
-  <li class="te-horizontal-cards__card-number{{overall.label}}">
-    {{overall.status}}
-  </li>
-  <a role="button" tabindex="0" class=".te-button--link">
-    view details
-    {{#bs-popover placement="bottom" title="Detection health"}}
-      <p>Overall health of the metrics that monitor detection performance.</p>
+  </h4>
+  <section class="te-horizontal-cards__container">
+    <ul class="te-horizontal-cards__single-card">
+      <li class="te-horizontal-cards__card-title">
+        <label for="select-dimension" class="control-label te-label--no-bottom">
+          30-day status
+          <span>
+            <i class="glyphicon glyphicon-question-sign"></i>
+            {{#tooltip-on-element class="te-tooltip"}}
+              The overall health status of your detection configuration is based on
+              the most recent 30 days.
+            {{/tooltip-on-element}}
+          </span>
+        </label>
+      </li>
+      <li class="te-horizontal-cards__card-number{{overall.label}}">
+        {{overall.status}}
+      </li>
+      <a role="button" tabindex="0">
+        view details
+        {{#bs-popover placement="bottom" title="Detection health"}}
+          <p>Overall health of the metrics that monitor detection performance.</p>
 
-      <label class="control-label te-label">
-        Detection task status
-      </label>
+          <label class="control-label te-label">
+            Detection task status
+          </label>
 
-      <div class="te-horizontal-metrics__container">
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number">{{executionTime}}</li>
-          <li class="te-horizontal-metrics__title">Last success detection task finish time</li>
-        </ul>
-      </div>
+          <div class="te-horizontal-metrics__container">
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number">{{executionTime}}</li>
+              <li class="te-horizontal-metrics__title">Last success detection task finish time</li>
+            </ul>
+          </div>
 
-      <div class="te-horizontal-metrics__container">
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number{{detection.label}}">{{detection.status}}</li>
-          <li class="te-horizontal-metrics__title">Status</li>
-        </ul>
+          <div class="te-horizontal-metrics__container">
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number{{detection.label}}">{{detection.status}}</li>
+              <li class="te-horizontal-metrics__title">Status</li>
+            </ul>
 
-        {{#each tasks as |task|}}
-          <ul class="te-horizontal-metrics__metric">
-            <li class="te-horizontal-metrics__number{{task.label}}">{{task.number}}</li>
-            <li class="te-horizontal-metrics__title">{{task.title}}</li>
-          </ul>
-        {{/each}}
-      </div>
+            {{#each tasks as |task|}}
+              <ul class="te-horizontal-metrics__metric">
+                <li class="te-horizontal-metrics__number{{task.label}}">{{task.number}}</li>
+                <li class="te-horizontal-metrics__title">{{task.title}}</li>
+              </ul>
+            {{/each}}
+          </div>
 
-      <label class="control-label te-label">
-        Anomaly coverage ratio
-      </label>
+          <label class="control-label te-label">
+            Anomaly coverage ratio
+          </label>
 
-      <div class="te-horizontal-metrics__container">
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number{{anomalyCoverage.label}}">{{anomalyCoverage.status}}</li>
-          <li class="te-horizontal-metrics__title">Status</li>
-        </ul>
+          <div class="te-horizontal-metrics__container">
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number{{anomalyCoverage.label}}">{{anomalyCoverage.status}}</li>
+              <li class="te-horizontal-metrics__title">Status</li>
+            </ul>
 
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number">{{anomalyCoverage.ratio}}%</li>
-          <li class="te-horizontal-metrics__title">The percentage of anomalous duration over the past 30 days</li>
-        </ul>
-      </div>
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number">{{anomalyCoverage.ratio}}%</li>
+              <li class="te-horizontal-metrics__title">The percentage of anomalous duration over the past 30 days</li>
+            </ul>
+          </div>
 
-      <p>To improve this, adjust alert sensitivity using preview.</p>
+          <p>To improve this, adjust alert sensitivity using preview.</p>
 
-      <label class="control-label te-label">
-        Regression error{{#if regressionInfo.rule}} for {{regressionInfo.rule}}{{/if}}
-      </label>
+          <label class="control-label te-label">
+            Regression error{{#if regressionInfo.rule}} for {{regressionInfo.rule}}{{/if}}
+          </label>
 
-      <div class="te-horizontal-metrics__container">
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number{{regressionInfo.label}}">{{regressionInfo.status}}</li>
-          <li class="te-horizontal-metrics__title">Status</li>
-        </ul>
+          <div class="te-horizontal-metrics__container">
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number{{regressionInfo.label}}">{{regressionInfo.status}}</li>
+              <li class="te-horizontal-metrics__title">Status</li>
+            </ul>
 
-        <ul class="te-horizontal-metrics__metric">
-          <li class="te-horizontal-metrics__number">{{regressionInfo.mape}}%</li>
-          <li class="te-horizontal-metrics__title">The average prediction error (MAPE) of the baseline</li>
-        </ul>
-      </div>
+            <ul class="te-horizontal-metrics__metric">
+              <li class="te-horizontal-metrics__number">{{regressionInfo.mape}}%</li>
+              <li class="te-horizontal-metrics__title">The average prediction error (MAPE) of the baseline</li>
+            </ul>
+          </div>
 
-      <p>To improve this, tune the detection rules using preview.</p>
-    {{/bs-popover}}
-  </a>
-</ul>
+          <p>To improve this, tune the detection rules using preview.</p>
+        {{/bs-popover}}
+      </a>
+    </ul>
+  </section>  
+</section>

--- a/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/template.hbs
@@ -1,95 +1,45 @@
-{{#if oneCardOnly}}
-
-  {{#each statsTransformed as |card|}}
-    <ul class="te-horizontal-cards__single-card">
-      <li class="te-horizontal-cards__card-title">
-        <label for="select-dimension" class="control-label te-label">
-          {{card.title}}
-          <span>
-            <i class="glyphicon glyphicon-question-sign"></i>
+{{#each statsTransformed as |card|}}
+  <ul class={{if oneCardOnly "te-horizontal-cards__single-card" "te-horizontal-cards__card"}}>
+    <li class="te-horizontal-cards__card-title">
+      <label for="select-dimension" class="control-label te-label">
+        {{card.title}}
+        <span>
+          <i class="glyphicon glyphicon-question-sign"></i>
             {{#tooltip-on-element class="te-tooltip"}}
               {{card.description}}
             {{/tooltip-on-element}}
-          </span>
-        </label>
-      </li>
-      <li class="te-horizontal-cards__card-value">
-        {{#if (eq card.title 'Anomalies')}}
-          {{#if areTwoSetsOfAnomalies}}
-            <!-- Two different anomaly counts -->
-            <div class="te-horizontal-cards__val-group">
-              <div class="te-horizontal-cards__card-subt">{{#if isEditMode}}Current{{else}}Old{{/if}}</div>
-              <li class="te-horizontal-cards__card-number">
-                {{card.old}}
-              </li>
-            </div>
-            <div class="te-horizontal-cards__val-group__margin-left">
-              <div class="te-horizontal-cards__card-subt">New</div>
-              <li class="te-horizontal-cards__card-number">
-                {{card.new}}
-              </li>
-            </div>
-          {{else}}
-            <!-- Only one anomaly count -->
+        </span>
+      </label>
+    </li>
+    <li class="te-horizontal-cards__card-value">
+      {{#if (eq card.title 'Anomalies')}}
+        {{#if areTwoSetsOfAnomalies}}
+          <!-- Two different anomaly counts -->
+          <div class="te-horizontal-cards__val-group">
+            <div class="te-horizontal-cards__card-subt">{{#if isEditMode}}Current{{else}}Old{{/if}}</div>
             <li class="te-horizontal-cards__card-number">
-              {{card.value}}{{#if (eq card.unit 'percent')}}%{{/if}}
+              {{card.old}}
             </li>
-          {{/if}}
+          </div>
+          <div class="te-horizontal-cards__val-group__margin-left">
+            <div class="te-horizontal-cards__card-subt">New</div>
+            <li class="te-horizontal-cards__card-number">
+              {{card.new}}
+            </li>
+          </div>
         {{else}}
-          <!-- Not Anomalies -->
+          <!-- Only one anomaly count -->
           <li class="te-horizontal-cards__card-number">
             {{card.value}}{{#if (eq card.unit 'percent')}}%{{/if}}
           </li>
         {{/if}}
-      </li>
-    </ul>
-  {{/each}}
-
-{{else}}
-
-  {{#each statsTransformed as |card|}}
-    <ul class="te-horizontal-cards__card">
-      <li class="te-horizontal-cards__card-title">
-        <label for="select-dimension" class="control-label te-label">
-          {{card.title}}
-          <span>
-            <i class="glyphicon glyphicon-question-sign"></i>
-            {{#tooltip-on-element class="te-tooltip"}}
-              {{card.description}}
-            {{/tooltip-on-element}}
-          </span>
-        </label>
-      </li>
-      <li class="te-horizontal-cards__card-value">
-        {{#if (eq card.title 'Anomalies')}}
-          {{#if areTwoSetsOfAnomalies}}
-            <!-- Two different anomaly counts -->
-            <div class="te-horizontal-cards__val-group">
-              <div class="te-horizontal-cards__card-subt">{{#if isEditMode}}Current{{else}}Old{{/if}}</div>
-              <li class="te-horizontal-cards__card-number">
-                {{card.old}}
-              </li>
-            </div>
-            <div class="te-horizontal-cards__val-group__margin-left">
-              <div class="te-horizontal-cards__card-subt">New</div>
-              <li class="te-horizontal-cards__card-number">
-                {{card.new}}
-              </li>
-            </div>
-          {{else}}
-            <!-- Only one anomaly count -->
-            <li class="te-horizontal-cards__card-number">
-              {{card.value}}{{#if (eq card.unit 'percent')}}%{{/if}}
-            </li>
-          {{/if}}
-        {{else}}
-          <!-- Not Anomalies -->
-          <li class="te-horizontal-cards__card-number">
-            {{card.value}}{{#if (eq card.unit 'percent')}}%{{/if}}
-          </li>
-        {{/if}}
-      </li>
-    </ul>
-  {{/each}}
-
-{{/if}}
+      {{else}}
+        <!-- Not Anomalies -->
+        <li class="te-horizontal-cards__card-number">
+          {{card.value}}{{#if (eq card.unit 'percent')}}%{{/if}}
+        </li>
+      {{/if}}
+    </li>
+  </ul>
+{{/each}}
+ 


### PR DESCRIPTION
Currently the `detection-health` component does not have the hosting container and tooltips. As a result it is individually configured in the calling component. Figured that part should remain the same regardless of which component instantiates the detection-health component. As a result, moving that static html inside the component.

The `stats-cards` component has duplicated code which could be removed by using the `if` template helper. We would be doing another round of refactoring here once the `performance-api` is ready.
