### PR TITLE
Add profile release-sign-artifacts for pinot-spark-connector

### DIFF
--- a/pinot-connectors/pinot-spark-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-connector/pom.xml
@@ -186,6 +186,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- GPG signing. It's due to the fact that maven-source-plugin and scala-maven-plugin
+                         have separate lifecycles, and the gpg files created by the former get deleted by the latter.
+                         Thus, explicitly adding this plugin to a new profile to sign the files at the end all at once. -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
## Description
Currently the signature file for `pinot-connectors/pinot-spark-connector/target/pinot-spark-connector-0.6.0-javadoc.jar` is missing, because this file is overriden by `scala-maven-plugin` in `pinot-spark-connector` module, which is run right after the default gpg plugin signed the files.

This PR adds profile release-sign-artifacts for pinot-spark-connector module, so that the correct asc file could be generated after scala plugin overwrote the javadoc file. 

By default this profile won't be executed, unless we need to cut a OSS release and need to run the following command to prepare the OSS release:
```
$ mvn -Darguments=-DskipTests release:prepare -Pscala-2.12,release-sign-artifacts
```