### PR TITLE
Make sure DatetimeFormatter always uses UTC

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -235,7 +235,7 @@ public class SegmentGeneratorConfig {
   public void setSimpleDateFormat(String simpleDateFormat) {
     _timeColumnType = TimeColumnType.SIMPLE_DATE;
     try {
-      DateTimeFormat.forPattern(simpleDateFormat).withZoneUTC();
+      DateTimeFormat.forPattern(simpleDateFormat);
     } catch (Exception e) {
       throw new RuntimeException("Illegal simple date format specification", e);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -235,7 +235,7 @@ public class SegmentGeneratorConfig {
   public void setSimpleDateFormat(String simpleDateFormat) {
     _timeColumnType = TimeColumnType.SIMPLE_DATE;
     try {
-      DateTimeFormat.forPattern(simpleDateFormat);
+      DateTimeFormat.forPattern(simpleDateFormat).withZoneUTC();
     } catch (Exception e) {
       throw new RuntimeException("Illegal simple date format specification", e);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -439,7 +439,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
           if (config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
             // For TimeColumnType.SIMPLE_DATE_FORMAT, convert time value into millis since epoch
-            DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat());
+            DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(config.getSimpleDateFormat()).withZoneUTC();
             startTime = dateTimeFormatter.parseMillis(startTimeStr);
             endTime = dateTimeFormatter.parseMillis(endTimeStr);
             timeUnit = TimeUnit.MILLISECONDS;

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -258,7 +258,7 @@ public class SegmentGenerationWithTimeColumnTest {
   }
 
   private long sdfToMillis(long value) {
-    DateTimeFormatter sdfFormatter = DateTimeFormat.forPattern(TIME_COL_FORMAT);
+    DateTimeFormatter sdfFormatter = DateTimeFormat.forPattern(TIME_COL_FORMAT).withZoneUTC();
     DateTime dateTime = DateTime.parse(Long.toString(value), sdfFormatter);
     return dateTime.getMillis();
   }


### PR DESCRIPTION
## Description
This PR fixes the bug when not running in UTC timezone, DateTimeFormatter.parseMillis will return wrong result. 
e.g. 
```
DateTimeFormat.forPattern("yyyyMMdd").parseMillis("19710101") -> 31509000000 (December 31, 1970 4:30:00 PM) -> wrong
DateTimeFormat.forPattern("yyyyMMdd").withZoneUTC().parseMillis("19710101") -> 31536000000 (January 1, 1971 12:00:00 AM) -> correct 
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
