### PR TITLE
[TE] Remove maven-shade-plugin and switch from org.reflections to io.classgraph

### DIFF
--- a/.travis/.travis_set_deploy_build_opts.sh
+++ b/.travis/.travis_set_deploy_build_opts.sh
@@ -18,10 +18,10 @@
 # under the License.
 #
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+# if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   export DEV_VERSION="-dev-${TRAVIS_BUILD_NUMBER}"
   export DEPLOY_BUILD_OPTS="-Dsha1=-dev-${TRAVIS_BUILD_NUMBER}"
   npm install -g npm-login-noninteractive
-else
-  export DEPLOY_BUILD_OPTS=""
-fi
+# else
+#   export DEPLOY_BUILD_OPTS=""
+# fi

--- a/.travis/.travis_set_deploy_build_opts.sh
+++ b/.travis/.travis_set_deploy_build_opts.sh
@@ -18,10 +18,10 @@
 # under the License.
 #
 
-# if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   export DEV_VERSION="-dev-${TRAVIS_BUILD_NUMBER}"
   export DEPLOY_BUILD_OPTS="-Dsha1=-dev-${TRAVIS_BUILD_NUMBER}"
   npm install -g npm-login-noninteractive
-# else
-#   export DEPLOY_BUILD_OPTS=""
-# fi
+else
+  export DEPLOY_BUILD_OPTS=""
+fi

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -151,6 +151,18 @@
           </configuration>
         </plugin>
         <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.2</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M1</version>

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -59,7 +59,7 @@
     <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
     <commons-conf2.version>2.7</commons-conf2.version>
     <commons-collection4.version>4.1</commons-collection4.version>
-    <reflections.version>0.9.11</reflections.version>
+    <classgraph.version>4.8.84</classgraph.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>
@@ -445,11 +445,10 @@
         <version>${jsonpath.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections</artifactId>
-        <version>${reflections.version}</version>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>${classgraph.version}</version>
       </dependency>
-
       <!-- UI dependencies -->
       <dependency>
         <groupId>com.github.jknack</groupId>

--- a/thirdeye/thirdeye-dashboard/pom.xml
+++ b/thirdeye/thirdeye-dashboard/pom.xml
@@ -40,16 +40,6 @@
       <groupId>org.apache.pinot.thirdeye</groupId>
       <artifactId>thirdeye-pinot</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- test dependencies -->

--- a/thirdeye/thirdeye-dashboard/pom.xml
+++ b/thirdeye/thirdeye-dashboard/pom.xml
@@ -81,40 +81,6 @@
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <createDependencyReducedPom>true</createDependencyReducedPom>
-          <transformers>
-            <transformer
-              implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-            <transformer
-              implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>${mainClass}</mainClass>
-            </transformer>
-          </transformers>
-          <!-- exclude signed Manifests -->
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
-              </excludes>
-            </filter>
-          </filters>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.4</version>
         <configuration>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -142,8 +142,8 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
     </dependency>
     <dependency>
       <!-- TODO: replace code dependencies and remove -->

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>thirdeye-pinot</artifactId>
   <url>http://maven.apache.org</url>
   <properties>
-
+    <mainClass>org.apache.pinot.thirdeye.anomaly.ThirdEyeAnomalyApplication</mainClass>
   </properties>
 
   <dependencies>
@@ -367,26 +367,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.1.2</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.0</version>
         <configuration>
@@ -411,6 +391,18 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <threadCount>1</threadCount>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>${mainClass}</mainClass>
+            </manifest>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionAlertRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionAlertRegistry.java
@@ -78,6 +78,7 @@ public class DetectionAlertRegistry {
         for (Annotation annotation : clazz.getAnnotations()) {
           if (annotation instanceof AlertFilter) {
             ALERT_FILTER_MAP.put(((AlertFilter) annotation).type(), clazz.getName());
+            LOG.info("Registered Alter Filter {}", clazz.getName());
           }
         }
       }
@@ -89,6 +90,7 @@ public class DetectionAlertRegistry {
         for (Annotation annotation : clazz.getAnnotations()) {
           if (annotation instanceof AlertScheme) {
             ALERT_SCHEME_MAP.put(((AlertScheme) annotation).type(), clazz.getName());
+            LOG.info("Registered Alter Scheme {}", clazz.getName());
           }
         }
       }
@@ -100,6 +102,7 @@ public class DetectionAlertRegistry {
         for (Annotation annotation : clazz.getAnnotations()) {
           if (annotation instanceof AlertSuppressor) {
             ALERT_SUPPRESSOR_MAP.put(((AlertSuppressor) annotation).type(), clazz.getName());
+            LOG.info("Registered Alter AlertSuppressor {}", clazz.getName());
           }
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionAlertRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionAlertRegistry.java
@@ -20,6 +20,11 @@
 package org.apache.pinot.thirdeye.detection.annotation.registry;
 
 import com.google.common.base.Preconditions;
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 import org.apache.pinot.thirdeye.detection.alert.DetectionAlertFilter;
 import org.apache.pinot.thirdeye.detection.alert.scheme.DetectionAlertScheme;
 import org.apache.pinot.thirdeye.detection.alert.suppress.DetectionAlertSuppressor;
@@ -29,8 +34,6 @@ import org.apache.pinot.thirdeye.detection.annotation.AlertSuppressor;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,41 +71,39 @@ public class DetectionAlertRegistry {
    * Read all the alert schemes and suppressors and initialize the registry.
    */
   private static void init() {
-    try {
-      Reflections reflections = new Reflections();
-
+    try (ScanResult scanResult = new ClassGraph().enableAnnotationInfo().enableClassInfo().scan()) {
       // register alert filters
-      Set<Class<? extends DetectionAlertFilter>> alertFilterClasses =
-          reflections.getSubTypesOf(DetectionAlertFilter.class);
-      for (Class clazz : alertFilterClasses) {
-        for (Annotation annotation : clazz.getAnnotations()) {
-          if (annotation instanceof AlertFilter) {
-            ALERT_FILTER_MAP.put(((AlertFilter) annotation).type(), clazz.getName());
-            LOG.info("Registered Alter Filter {}", clazz.getName());
+      ClassInfoList alertFilterClassClasses = scanResult.getSubclasses(DetectionAlertFilter.class.getName());
+      for (ClassInfo classInfo : alertFilterClassClasses) {
+        for (AnnotationInfo annotationInfo : classInfo.getAnnotationInfo()) {
+          if (annotationInfo.getName().equals(AlertFilter.class.getName())) {
+            Annotation annotation = annotationInfo.loadClassAndInstantiate();
+            ALERT_FILTER_MAP.put(((AlertFilter) annotation).type(), classInfo.getName());
+            LOG.info("Registered Alter Filter {}", classInfo.getName());
           }
         }
       }
 
       // register alert schemes
-      Set<Class<? extends DetectionAlertScheme>> alertSchemeClasses =
-          reflections.getSubTypesOf(DetectionAlertScheme.class);
-      for (Class clazz : alertSchemeClasses) {
-        for (Annotation annotation : clazz.getAnnotations()) {
-          if (annotation instanceof AlertScheme) {
-            ALERT_SCHEME_MAP.put(((AlertScheme) annotation).type(), clazz.getName());
-            LOG.info("Registered Alter Scheme {}", clazz.getName());
+      ClassInfoList alertSchemeClasses = scanResult.getSubclasses(DetectionAlertScheme.class.getName());
+      for (ClassInfo classInfo : alertSchemeClasses) {
+        for (AnnotationInfo annotationInfo : classInfo.getAnnotationInfo()) {
+          if (annotationInfo.getName().equals(AlertScheme.class.getName())) {
+            Annotation annotation = annotationInfo.loadClassAndInstantiate();
+            ALERT_SCHEME_MAP.put(((AlertScheme) annotation).type(), classInfo.getName());
+            LOG.info("Registered Alter Scheme {}", classInfo.getName());
           }
         }
       }
 
       // register alert suppressors
-      Set<Class<? extends DetectionAlertSuppressor>> alertSuppressorClasses =
-          reflections.getSubTypesOf(DetectionAlertSuppressor.class);
-      for (Class clazz : alertSuppressorClasses) {
-        for (Annotation annotation : clazz.getAnnotations()) {
-          if (annotation instanceof AlertSuppressor) {
-            ALERT_SUPPRESSOR_MAP.put(((AlertSuppressor) annotation).type(), clazz.getName());
-            LOG.info("Registered Alter AlertSuppressor {}", clazz.getName());
+      ClassInfoList alertSuppressorClasses = scanResult.getSubclasses(DetectionAlertSuppressor.class.getName());
+      for (ClassInfo classInfo : alertSuppressorClasses) {
+        for  (AnnotationInfo annotationInfo : classInfo.getAnnotationInfo()) {
+          if (annotationInfo.getName().equals( AlertSuppressor.class.getName())) {
+            Annotation annotation = annotationInfo.loadClassAndInstantiate();
+            ALERT_SUPPRESSOR_MAP.put(((AlertSuppressor) annotation).type(), classInfo.getName());
+            LOG.info("Registered Alter AlertSuppressor {}", classInfo.getName());
           }
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
@@ -21,6 +21,11 @@ package org.apache.pinot.thirdeye.detection.annotation.registry;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 import org.apache.pinot.thirdeye.detection.annotation.Components;
 import org.apache.pinot.thirdeye.detection.annotation.Tune;
 import org.apache.pinot.thirdeye.detection.spi.components.BaseComponent;
@@ -30,9 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.collections4.MapUtils;
-import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,18 +73,18 @@ public class DetectionRegistry {
    * Read all the components, tune, and yaml annotations and initialize the registry.
    */
   private static void init() {
-    try {
-      Reflections reflections = new Reflections();
+    try (ScanResult scanResult = new ClassGraph().enableAnnotationInfo().enableClassInfo().scan()) {
       // register components
-      Set<Class<? extends BaseComponent>> classes = reflections.getSubTypesOf(BaseComponent.class);
-      for (Class<? extends BaseComponent> clazz : classes) {
-        String className = clazz.getName();
-        for (Annotation annotation : clazz.getAnnotations()) {
+      ClassInfoList classes = scanResult.getClassesImplementing(BaseComponent.class.getName());
+      for (ClassInfo classInfo : classes) {
+        String className = classInfo.getName();
+        for (AnnotationInfo annotationInfo : classInfo.getAnnotationInfo()) {
+          Annotation annotation = annotationInfo.loadClassAndInstantiate();
           if (annotation instanceof Components) {
             Components componentsAnnotation = (Components) annotation;
             REGISTRY_MAP.put(componentsAnnotation.type(),
                 ImmutableMap.of(KEY_CLASS_NAME, className, KEY_ANNOTATION, componentsAnnotation,
-                    KEY_IS_BASELINE_PROVIDER, isBaselineProvider(clazz)));
+                    KEY_IS_BASELINE_PROVIDER, isBaselineProvider(Class.forName(className))));
             LOG.info("Registered component {} - {}", componentsAnnotation.type(), className);
           }
           if (annotation instanceof Tune) {
@@ -189,7 +192,7 @@ public class DetectionRegistry {
     return String.join(", ", YAML_MAP.keySet());
   }
 
-  private static boolean isBaselineProvider(Class<? extends BaseComponent> clazz) {
+  private static boolean isBaselineProvider(Class<?> clazz) {
     return BaselineProvider.class.isAssignableFrom(clazz);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/detection/annotation/registry/DetectionRegistry.java
@@ -90,7 +90,7 @@ public class DetectionRegistry {
           if (annotation instanceof Tune) {
             Tune tunableAnnotation = (Tune) annotation;
             TUNE_MAP.put(className, tunableAnnotation);
-            LOG.info("Registered tuner {}", className);
+            LOG.info("Registered tuner {} - {}", className, tunableAnnotation.tunable());
           }
         }
       }

--- a/thirdeye/thirdeye-spi/pom.xml
+++ b/thirdeye/thirdeye-spi/pom.xml
@@ -97,15 +97,10 @@
       <artifactId>commons-math</artifactId>
       <scope>compile</scope>
     </dependency>
-
     <dependency>
       <groupId>org.modelmapper</groupId>
       <artifactId>modelmapper</artifactId>
       <version>0.7.6</version>
     </dependency>
-
   </dependencies>
-
-  <build>
-  </build>
 </project>


### PR DESCRIPTION
This PR is achieve following items:

- Remove `maven-shade-plugin` from `thirdeye-dashboard` module
- Switch  from `org.reflections` to `io.classgraph` to reflect detection and alert components in `DetectionRegistry` and  `DetectionAlertRegistry`
- Remove `ch.qos.logback` from exclusion in the `pom.xml` of `thirdeye-dashboard`