### PR TITLE
Adding validation for jsonExtractKey and jsonExtractScalar functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -903,9 +903,45 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
+    validateFunction(functionName, operands);
     Expression functionExpression = RequestUtils.getFunctionExpression(functionName);
     functionExpression.getFunctionCall().setOperands(operands);
     return functionExpression;
+  }
+
+  private static void validateFunction(String functionName, List<Expression> operands) {
+    switch (functionName.toUpperCase()) {
+      case "JSONEXTRACTSCALAR":
+        validateJsonExtractScalarFunction(functionName, operands);
+        break;
+      case "JSONEXTRACTKEY":
+        validateJsonExtractKeyFunction(functionName, operands);
+        break;
+    }
+  }
+
+  private static void validateJsonExtractScalarFunction(String functionName, List<Expression> operands) {
+    // Check that there are exactly 3 or 4 arguments
+    if (operands.size() < 3 || operands.size() > 4) {
+      throw new SqlCompilationException(
+          "Expected 3/4 arguments for transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue'])");
+    }
+    if (!operands.get(1).isSetLiteral() || !operands.get(2).isSetLiteral()) {
+      throw new SqlCompilationException(
+          "Expected the second or third argument for transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue']) to be a single-quoted literal value.");
+    }
+  }
+
+  private static void validateJsonExtractKeyFunction(String functionName, List<Expression> operands) {
+    // Check that there are exactly 3 or 4 arguments
+    if (operands.size() != 2) {
+      throw new SqlCompilationException(
+          "Exactly 2 arguments are required for transform function: jsonExtractKey(jsonFieldName, 'jsonPath')");
+    }
+    if (!operands.get(1).isSetLiteral() || !operands.get(2).isSetLiteral()) {
+      throw new SqlCompilationException(
+          "Expected the second argument for transform function: jsonExtractKey(jsonFieldName, 'jsonPath') to be a single-quoted literal value.");
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -922,25 +922,26 @@ public class CalciteSqlParser {
 
   private static void validateJsonExtractScalarFunction(String functionName, List<Expression> operands) {
     // Check that there are exactly 3 or 4 arguments
-    if (operands.size() < 3 || operands.size() > 4) {
+    if (operands.size() != 3 && operands.size() != 4) {
       throw new SqlCompilationException(
-          "Expected 3/4 arguments for transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue'])");
+          "Expect 3 or 4 arguments for transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue'])");
     }
-    if (!operands.get(1).isSetLiteral() || !operands.get(2).isSetLiteral()) {
+    if (!operands.get(1).isSetLiteral() || !operands.get(2).isSetLiteral() || (operands.size() == 4 && !operands.get(3)
+        .isSetLiteral())) {
       throw new SqlCompilationException(
-          "Expected the second or third argument for transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue']) to be a single-quoted literal value.");
+          "Expect the 2nd/3rd/4th argument of transform function: jsonExtractScalar(jsonFieldName, 'jsonPath', 'resultsType', ['defaultValue']) to be a single-quoted literal value.");
     }
   }
 
   private static void validateJsonExtractKeyFunction(String functionName, List<Expression> operands) {
-    // Check that there are exactly 3 or 4 arguments
+    // Check that there are exactly 2 arguments
     if (operands.size() != 2) {
       throw new SqlCompilationException(
-          "Exactly 2 arguments are required for transform function: jsonExtractKey(jsonFieldName, 'jsonPath')");
+          "Expect 2 arguments are required for transform function: jsonExtractKey(jsonFieldName, 'jsonPath')");
     }
-    if (!operands.get(1).isSetLiteral() || !operands.get(2).isSetLiteral()) {
+    if (!operands.get(1).isSetLiteral()) {
       throw new SqlCompilationException(
-          "Expected the second argument for transform function: jsonExtractKey(jsonFieldName, 'jsonPath') to be a single-quoted literal value.");
+          "Expect the 2nd argument for transform function: jsonExtractKey(jsonFieldName, 'jsonPath') to be a single-quoted literal value.");
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Random;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
@@ -99,7 +100,13 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @DataProvider(name = "testJsonPathTransformFunctionArguments")
   public Object[][] testJsonPathTransformFunctionArguments() {
-    return new Object[][]{new Object[]{"jsonExtractScalar(json,'$.intSV','INT')", FieldSpec.DataType.INT, true}, new Object[]{"jsonExtractScalar(json,'$.intMV','INT_ARRAY')", FieldSpec.DataType.INT, false}, new Object[]{"jsonExtractScalar(json,'$.longSV','LONG')", FieldSpec.DataType.LONG, true}, new Object[]{"jsonExtractScalar(json,'$.floatSV','FLOAT')", FieldSpec.DataType.FLOAT, true}, new Object[]{"jsonExtractScalar(json,'$.doubleSV','DOUBLE')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"jsonExtractScalar(json,'$.stringSV','STRING')", FieldSpec.DataType.STRING, true},};
+    if (new Random(System.currentTimeMillis()).nextBoolean()) {
+      return new Object[][]{new Object[]{"jsonExtractScalar(json,'$.intSV','INT')", FieldSpec.DataType.INT, true}, new Object[]{"jsonExtractScalar(json,'$.intMV','INT_ARRAY')", FieldSpec.DataType.INT, false}, new Object[]{"jsonExtractScalar(json,'$.longSV','LONG')", FieldSpec.DataType.LONG, true}, new Object[]{"jsonExtractScalar(json,'$.floatSV','FLOAT')", FieldSpec.DataType.FLOAT, true}, new Object[]{"jsonExtractScalar(json,'$.doubleSV','DOUBLE')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"jsonExtractScalar(json,'$.stringSV','STRING')", FieldSpec.DataType.STRING, true},};
+    }
+    if (new Random(System.currentTimeMillis()).nextBoolean()) {
+      return new Object[][]{new Object[]{"json_extract_scalar(json,'$.intSV','INT', '0')", FieldSpec.DataType.INT, true}, new Object[]{"json_extract_scalar(json,'$.intMV','INT_ARRAY', ['0'])", FieldSpec.DataType.INT, false}, new Object[]{"json_extract_scalar(json,'$.longSV','LONG', '0')", FieldSpec.DataType.LONG, true}, new Object[]{"json_extract_scalar(json,'$.floatSV','FLOAT', '0.0')", FieldSpec.DataType.FLOAT, true}, new Object[]{"json_extract_scalar(json,'$.doubleSV','DOUBLE', '0.0')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"json_extract_scalar(json,'$.stringSV','STRING', 'null')", FieldSpec.DataType.STRING, true},};
+    }
+    return new Object[][]{new Object[]{"json_extract_scalar(json,'$.intSV','INT')", FieldSpec.DataType.INT, true}, new Object[]{"json_extract_scalar(json,'$.intMV','INT_ARRAY')", FieldSpec.DataType.INT, false}, new Object[]{"json_extract_scalar(json,'$.longSV','LONG')", FieldSpec.DataType.LONG, true}, new Object[]{"json_extract_scalar(json,'$.floatSV','FLOAT')", FieldSpec.DataType.FLOAT, true}, new Object[]{"json_extract_scalar(json,'$.doubleSV','DOUBLE')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"json_extract_scalar(json,'$.stringSV','STRING')", FieldSpec.DataType.STRING, true},};
   }
 
   @Test
@@ -203,7 +210,9 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test
   public void testJsonPathKeyTransformFunction() {
-    ExpressionContext expression = QueryContextConverterUtils.getExpression("jsonExtractKey(json,'$.*')");
+    ExpressionContext expression = (new Random(System.currentTimeMillis()).nextBoolean()) ? QueryContextConverterUtils
+        .getExpression("jsonExtractKey(json,'$.*')")
+        : QueryContextConverterUtils.getExpression("json_extract_key(json,'$.*')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractKeyTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractKeyTransformFunction.FUNCTION_NAME);
@@ -243,9 +252,10 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @DataProvider(name = "testParsingIllegalQueries")
   public Object[][] testParsingIllegalQueries() {
-    return new Object[][]{ new Object[]{String.format(
-        "jsonExtractScalar(%s, \"$.store.book[0].author\", 'String')", JSON_COLUMN, INT_SV_COLUMN)}, new Object[]{String.format(
-        "jsonExtractScalar(%s, '$.store.book[0].author', \"String\")", JSON_COLUMN, INT_SV_COLUMN)}, new Object[]{String.format(
-        "jsonExtractScalar(%s, \"$.store.book[0].author\", 'String','abc')", JSON_COLUMN, INT_SV_COLUMN)}};
+    return new Object[][]{new Object[]{String.format("jsonExtractScalar(%s, \"$.store.book[0].author\", 'String')",
+        JSON_COLUMN, INT_SV_COLUMN)}, new Object[]{String.format(
+        "jsonExtractScalar(%s, '$.store.book[0].author', \"String\")", JSON_COLUMN,
+        INT_SV_COLUMN)}, new Object[]{String.format("jsonExtractScalar(%s, \"$.store.book[0].author\", 'String','abc')",
+        JSON_COLUMN, INT_SV_COLUMN)}};
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.query.request.context.ExpressionContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -225,6 +226,11 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
+  @Test(dataProvider = "testParsingIllegalQueries", expectedExceptions = {SqlCompilationException.class})
+  public void testParsingIllegalQueries(String expressionStr) {
+    QueryContextConverterUtils.getQueryContextFromSQL(String.format("SELECT %s FROM myTable", expressionStr));
+  }
+
   @DataProvider(name = "testIllegalArguments")
   public Object[][] testIllegalArguments() {
     return new Object[][]{new Object[]{String.format("jsonExtractScalar(%s)",
@@ -233,5 +239,13 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
         "jsonExtractScalar(%s,'$.store.book[0].author')", STRING_SV_COLUMN)}, new Object[]{String.format(
         "jsonExtractScalar(%s,'$.store.book[0].author', 'STRINGARRAY')", STRING_SV_COLUMN)}, new Object[]{String.format(
         "jsonExtractScalar(%s,%s,'$.store.book[0].author', 'String','abc')", JSON_COLUMN, INT_SV_COLUMN)}};
+  }
+
+  @DataProvider(name = "testParsingIllegalQueries")
+  public Object[][] testParsingIllegalQueries() {
+    return new Object[][]{ new Object[]{String.format(
+        "jsonExtractScalar(%s, \"$.store.book[0].author\", 'String')", JSON_COLUMN, INT_SV_COLUMN)}, new Object[]{String.format(
+        "jsonExtractScalar(%s, '$.store.book[0].author', \"String\")", JSON_COLUMN, INT_SV_COLUMN)}, new Object[]{String.format(
+        "jsonExtractScalar(%s, \"$.store.book[0].author\", 'String','abc')", JSON_COLUMN, INT_SV_COLUMN)}};
   }
 }


### PR DESCRIPTION
##  Description
Adding validation for json_extract_key and json_extract_scalar functions during sql compilation phase to avoid empty response

If user mistakenly put double quote on a the json key argument, say `jsonExtractScalar(myMapStr,"$.k1", 'STRING')`, then query parser recognizes the second argument `$.k1` as an identifier.  Then during segment pruning phase, the DataSchemaSegmentPruner prunes all the segments as there is no column matches `$.k1`. Then user will get an empty results.

This also means that we cannot error out this inside the corresponding functions, as these function won't be initialized at all.

Adding a function validation method during compilation time will allow us to find out the expression type mismatch then error out earlier and direct more comprehensive errors and guides to users.

Sample output would be:
![image](https://user-images.githubusercontent.com/1202120/98339705-00f2e680-1fc1-11eb-9295-1d9595639d67.png)
