### PR TITLE
Add stream and batch to ingestionConfig

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -33,12 +33,12 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.CommonConstants;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +84,7 @@ public class TimeBoundaryManager {
     // For HOURLY table with time unit other than DAYS, use (maxEndTime - 1 HOUR) as the time boundary; otherwise, use
     // (maxEndTime - 1 DAY)
     boolean isHourlyTable = CommonConstants.Table.PUSH_FREQUENCY_HOURLY
-        .equalsIgnoreCase(IngestionUtils.getBatchSegmentPushFrequency(tableConfig))
+        .equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig))
         && _timeFormatSpec.getColumnUnit() != TimeUnit.DAYS;
     _timeOffsetMs = isHourlyTable ? TimeUnit.HOURS.toMillis(1) : TimeUnit.DAYS.toMillis(1);
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -33,6 +33,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -83,7 +84,7 @@ public class TimeBoundaryManager {
     // For HOURLY table with time unit other than DAYS, use (maxEndTime - 1 HOUR) as the time boundary; otherwise, use
     // (maxEndTime - 1 DAY)
     boolean isHourlyTable = CommonConstants.Table.PUSH_FREQUENCY_HOURLY
-        .equalsIgnoreCase(tableConfig.getValidationConfig().getSegmentPushFrequency())
+        .equalsIgnoreCase(IngestionUtils.getBatchSegmentPushFrequency(tableConfig))
         && _timeFormatSpec.getColumnUnit() != TimeUnit.DAYS;
     _timeOffsetMs = isHourlyTable ? TimeUnit.HOURS.toMillis(1) : TimeUnit.DAYS.toMillis(1);
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.helix.ZNRecord;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils.config;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -267,9 +268,13 @@ public class TableConfigSerDeTest {
       batchConfigMap.put("batchType", "s3");
       Map<String, String> streamConfigMap = new HashMap<>();
       streamConfigMap.put("streamType", "kafka");
+      List<Map<String, String>> streamConfigs = new ArrayList<>();
+      streamConfigs.add(streamConfigMap);
+      List<Map<String, String>> batchConfigs = new ArrayList<>();
+      batchConfigs.add(batchConfigMap);
       IngestionConfig ingestionConfig =
-          new IngestionConfig(new Batch(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"),
-              new Stream(Lists.newArrayList(streamConfigMap)), new FilterConfig("filterFunc(foo)"), transformConfigs);
+          new IngestionConfig(new Batch(batchConfigs, "APPEND", "HOURLY"),
+              new Stream(streamConfigs), new FilterConfig("filterFunc(foo)"), transformConfigs);
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -31,7 +31,7 @@ import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.ingestion.Batch;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
@@ -50,7 +50,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
-import org.apache.pinot.spi.config.table.ingestion.Stream;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -268,13 +268,13 @@ public class TableConfigSerDeTest {
       batchConfigMap.put("batchType", "s3");
       Map<String, String> streamConfigMap = new HashMap<>();
       streamConfigMap.put("streamType", "kafka");
-      List<Map<String, String>> streamConfigs = new ArrayList<>();
-      streamConfigs.add(streamConfigMap);
-      List<Map<String, String>> batchConfigs = new ArrayList<>();
-      batchConfigs.add(batchConfigMap);
+      List<Map<String, String>> streamConfigMaps = new ArrayList<>();
+      streamConfigMaps.add(streamConfigMap);
+      List<Map<String, String>> batchConfigMaps = new ArrayList<>();
+      batchConfigMaps.add(batchConfigMap);
       IngestionConfig ingestionConfig =
-          new IngestionConfig(new Batch(batchConfigs, "APPEND", "HOURLY"),
-              new Stream(streamConfigs), new FilterConfig("filterFunc(foo)"), transformConfigs);
+          new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
+              new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs);
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);
@@ -413,16 +413,16 @@ public class TableConfigSerDeTest {
     assertEquals(transformConfigs.get(0).getTransformFunction(), "func(moo)");
     assertEquals(transformConfigs.get(1).getColumnName(), "zoo");
     assertEquals(transformConfigs.get(1).getTransformFunction(), "myfunc()");
-    assertNotNull(ingestionConfig.getBatch());
-    assertNotNull(ingestionConfig.getBatch().getBatchConfigs());
-    assertEquals(ingestionConfig.getBatch().getBatchConfigs().size(), 1);
-    assertEquals(ingestionConfig.getBatch().getBatchConfigs().get(0).get("batchType"), "s3");
-    assertEquals(ingestionConfig.getBatch().getSegmentPushType(), "APPEND");
-    assertEquals(ingestionConfig.getBatch().getSegmentPushFrequency(), "HOURLY");
-    assertNotNull(ingestionConfig.getStream());
-    assertNotNull(ingestionConfig.getStream().getStreamConfigs());
-    assertEquals(ingestionConfig.getStream().getStreamConfigs().size(), 1);
-    assertEquals(ingestionConfig.getStream().getStreamConfigs().get(0).get("streamType"), "kafka");
+    assertNotNull(ingestionConfig.getBatchIngestionConfig());
+    assertNotNull(ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps());
+    assertEquals(ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps().size(), 1);
+    assertEquals(ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps().get(0).get("batchType"), "s3");
+    assertEquals(ingestionConfig.getBatchIngestionConfig().getSegmentPushType(), "APPEND");
+    assertEquals(ingestionConfig.getBatchIngestionConfig().getSegmentPushFrequency(), "HOURLY");
+    assertNotNull(ingestionConfig.getStreamIngestionConfig());
+    assertNotNull(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps());
+    assertEquals(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps().size(), 1);
+    assertEquals(ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps().get(0).get("streamType"), "kafka");
   }
 
   private void checkTierConfigList(TableConfig tableConfig) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -108,7 +108,6 @@ import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
@@ -120,6 +119,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
@@ -1143,7 +1143,7 @@ public class PinotHelixResourceManager {
         break;
 
       case REALTIME:
-        checkForHLC(tableNameWithType, tableConfig);
+        verifyStreamConfig(tableNameWithType, tableConfig);
 
         // Ensure that realtime table is not created if schema is not present
         Schema schema =
@@ -1307,9 +1307,10 @@ public class PinotHelixResourceManager {
     _pinotLLCRealtimeSegmentManager = pinotLLCRealtimeSegmentManager;
   }
 
-  private void checkForHLC(String tableNameWithType, TableConfig tableConfig) {
+  private void verifyStreamConfig(String tableNameWithType, TableConfig tableConfig) {
     // Check if HLC table is allowed.
-    StreamConfig streamConfig = new StreamConfig(tableNameWithType, IngestionUtils.getStreamConfigsMap(tableConfig));
+    StreamConfig streamConfig =
+        new StreamConfig(tableNameWithType, IngestionConfigUtils.getStreamConfigMap(tableConfig));
     if (streamConfig.hasHighLevelConsumerType() && !_allowHLCTables) {
       throw new InvalidTableConfigException(
           "Creating HLC realtime table is not allowed for Table: " + tableNameWithType);
@@ -1319,7 +1320,7 @@ public class PinotHelixResourceManager {
   private void ensureRealtimeClusterIsSetUp(TableConfig realtimeTableConfig) {
     String realtimeTableName = realtimeTableConfig.getTableName();
     StreamConfig streamConfig = new StreamConfig(realtimeTableConfig.getTableName(),
-        IngestionUtils.getStreamConfigsMap(realtimeTableConfig));
+        IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig));
     IdealState idealState = getTableIdealState(realtimeTableName);
 
     if (streamConfig.hasHighLevelConsumerType()) {
@@ -1431,7 +1432,7 @@ public class PinotHelixResourceManager {
         break;
 
       case REALTIME:
-        checkForHLC(tableNameWithType, tableConfig);
+        verifyStreamConfig(tableNameWithType, tableConfig);
         ZKMetadataProvider
             .setRealtimeTableConfig(_propertyStore, tableNameWithType, TableConfigUtils.toZNRecord(tableConfig));
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -31,10 +31,10 @@ import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.PartitionCountFetcher;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,7 +89,7 @@ public class PinotTableIdealStateBuilder {
     }
     setupInstanceConfigForHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
         Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()),
-        IngestionUtils.getStreamConfigsMap(realtimeTableConfig), zkHelixPropertyStore, realtimeInstances);
+        IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig), zkHelixPropertyStore, realtimeInstances);
     return idealState;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.PartitionCountFetcher;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -88,7 +89,7 @@ public class PinotTableIdealStateBuilder {
     }
     setupInstanceConfigForHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
         Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()),
-        realtimeTableConfig.getIndexingConfig().getStreamConfigs(), zkHelixPropertyStore, realtimeInstances);
+        IngestionUtils.getStreamConfigsMap(realtimeTableConfig), zkHelixPropertyStore, realtimeInstances);
     return idealState;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -35,11 +35,11 @@ import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.RealtimeToOfflineSegmentsTask;
 import org.apache.pinot.core.minion.PinotTaskConfig;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,7 +101,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator implements PinotTaskGenerato
         LOGGER.warn("Skip generating task: {} for non-REALTIME table: {}", taskType, realtimeTableName);
         continue;
       }
-      StreamConfig streamConfig = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
+      StreamConfig streamConfig = new StreamConfig(realtimeTableName, IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (streamConfig.hasHighLevelConsumerType()) {
         LOGGER.warn("Skip generating task: {} for HLC REALTIME table: {}", taskType, realtimeTableName);
         continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -35,6 +35,7 @@ import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.RealtimeToOfflineSegmentsTask;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -100,8 +101,8 @@ public class RealtimeToOfflineSegmentsTaskGenerator implements PinotTaskGenerato
         LOGGER.warn("Skip generating task: {} for non-REALTIME table: {}", taskType, realtimeTableName);
         continue;
       }
-      if (new StreamConfig(realtimeTableName, tableConfig.getIndexingConfig().getStreamConfigs())
-          .hasHighLevelConsumerType()) {
+      StreamConfig streamConfig = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
+      if (streamConfig.hasHighLevelConsumerType()) {
         LOGGER.warn("Skip generating task: {} for HLC REALTIME table: {}", taskType, realtimeTableName);
         continue;
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -68,6 +68,7 @@ import org.apache.pinot.controller.helix.core.realtime.segment.FlushThresholdUpd
 import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -210,7 +211,7 @@ public class PinotLLCRealtimeSegmentManager {
     _flushThresholdUpdateManager.clearFlushThresholdUpdater(realtimeTableName);
 
     PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), tableConfig.getIndexingConfig().getStreamConfigs());
+        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig));
     InstancePartitions instancePartitions = getConsumingInstancePartitions(tableConfig);
     int numPartitions = getNumPartitions(streamConfig);
     int numReplicas = getNumReplicas(tableConfig, instancePartitions);
@@ -452,7 +453,7 @@ public class PinotLLCRealtimeSegmentManager {
     LLCSegmentName newLLCSegmentName =
         getNextLLCSegmentName(new LLCSegmentName(committingSegmentName), newSegmentCreationTimeMs);
     createNewSegmentZKMetadata(tableConfig,
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), tableConfig.getIndexingConfig().getStreamConfigs()),
+        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig)),
         newLLCSegmentName, newSegmentCreationTimeMs, committingSegmentDescriptor, committingSegmentZKMetadata,
         instancePartitions, numPartitions, numReplicas);
 
@@ -611,8 +612,8 @@ public class PinotLLCRealtimeSegmentManager {
       return commitTimeoutMS;
     }
     TableConfig tableConfig = getTableConfig(realtimeTableName);
-    final Map<String, String> streamConfigs = tableConfig.getIndexingConfig().getStreamConfigs();
-    if (streamConfigs != null && streamConfigs.containsKey(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
+    final Map<String, String> streamConfigs = IngestionUtils.getStreamConfigsMap(tableConfig);
+    if (streamConfigs.containsKey(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
       final String commitTimeoutSecondsStr = streamConfigs.get(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS);
       try {
         return TimeUnit.MILLISECONDS.convert(Integer.parseInt(commitTimeoutSecondsStr), TimeUnit.SECONDS);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -68,7 +68,6 @@ import org.apache.pinot.controller.helix.core.realtime.segment.FlushThresholdUpd
 import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -83,6 +82,7 @@ import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.zookeeper.data.Stat;
@@ -211,7 +211,7 @@ public class PinotLLCRealtimeSegmentManager {
     _flushThresholdUpdateManager.clearFlushThresholdUpdater(realtimeTableName);
 
     PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig));
+        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionConfigUtils.getStreamConfigMap(tableConfig));
     InstancePartitions instancePartitions = getConsumingInstancePartitions(tableConfig);
     int numPartitions = getNumPartitions(streamConfig);
     int numReplicas = getNumReplicas(tableConfig, instancePartitions);
@@ -453,7 +453,7 @@ public class PinotLLCRealtimeSegmentManager {
     LLCSegmentName newLLCSegmentName =
         getNextLLCSegmentName(new LLCSegmentName(committingSegmentName), newSegmentCreationTimeMs);
     createNewSegmentZKMetadata(tableConfig,
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig)),
+        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionConfigUtils.getStreamConfigMap(tableConfig)),
         newLLCSegmentName, newSegmentCreationTimeMs, committingSegmentDescriptor, committingSegmentZKMetadata,
         instancePartitions, numPartitions, numReplicas);
 
@@ -612,7 +612,7 @@ public class PinotLLCRealtimeSegmentManager {
       return commitTimeoutMS;
     }
     TableConfig tableConfig = getTableConfig(realtimeTableName);
-    final Map<String, String> streamConfigs = IngestionUtils.getStreamConfigsMap(tableConfig);
+    final Map<String, String> streamConfigs = IngestionConfigUtils.getStreamConfigMap(tableConfig);
     if (streamConfigs.containsKey(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
       final String commitTimeoutSecondsStr = streamConfigs.get(StreamConfigProperties.SEGMENT_COMMIT_TIMEOUT_SECONDS);
       try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -53,6 +53,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import org.apache.pinot.core.query.utils.Pair;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -130,12 +131,12 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         continue;
       }
 
-      StreamConfig metadata = new StreamConfig(realtimeTableName, tableConfig.getIndexingConfig().getStreamConfigs());
+      StreamConfig metadata = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
       if (metadata.hasHighLevelConsumerType()) {
         idealStateMap.put(realtimeTableName, _pinotHelixResourceManager.getHelixAdmin()
             .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), realtimeTableName));
       } else {
-        LOGGER.debug("Not considering table {} for realtime segment assignment");
+        LOGGER.debug("Not considering table {} for realtime segment assignment", realtimeTableName);
       }
     }
 
@@ -335,7 +336,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfigUtils.fromZNRecord(tableConfigZnRecord);
           StreamConfig metadata = new StreamConfig(tableConfig.getTableName(),
-              tableConfig.getIndexingConfig().getStreamConfigs());
+              IngestionUtils.getStreamConfigsMap(tableConfig));
           if (metadata.hasHighLevelConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -53,10 +53,10 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import org.apache.pinot.core.query.utils.Pair;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.zookeeper.data.Stat;
@@ -131,7 +131,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         continue;
       }
 
-      StreamConfig metadata = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
+      StreamConfig metadata = new StreamConfig(realtimeTableName, IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (metadata.hasHighLevelConsumerType()) {
         idealStateMap.put(realtimeTableName, _pinotHelixResourceManager.getHelixAdmin()
             .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), realtimeTableName));
@@ -336,7 +336,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfigUtils.fromZNRecord(tableConfigZnRecord);
           StreamConfig metadata = new StreamConfig(tableConfig.getTableName(),
-              IngestionUtils.getStreamConfigsMap(tableConfig));
+              IngestionConfigUtils.getStreamConfigMap(tableConfig));
           if (metadata.hasHighLevelConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
@@ -124,7 +125,7 @@ public class SegmentCompletionManager {
     final String rawTableName = llcSegmentName.getTableName();
     TableConfig tableConfig = _segmentManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName));
     PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), tableConfig.getIndexingConfig().getStreamConfigs());
+        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig));
     return StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -37,12 +37,12 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,8 +124,8 @@ public class SegmentCompletionManager {
   protected StreamPartitionMsgOffsetFactory getStreamPartitionMsgOffsetFactory(LLCSegmentName llcSegmentName) {
     final String rawTableName = llcSegmentName.getTableName();
     TableConfig tableConfig = _segmentManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName));
-    PartitionLevelStreamConfig streamConfig =
-        new PartitionLevelStreamConfig(tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(tableConfig));
+    PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableConfig.getTableName(),
+        IngestionConfigUtils.getStreamConfigMap(tableConfig));
     return StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -48,12 +48,12 @@ import org.apache.pinot.controller.helix.core.assignment.instance.InstanceAssign
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentFactory;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,7 +145,7 @@ public class TableRebalancer {
     try {
       // Do not allow rebalancing HLC real-time table
       if (tableConfig.getTableType() == TableType.REALTIME && new StreamConfig(tableNameWithType,
-          IngestionUtils.getStreamConfigsMap(tableConfig)).hasHighLevelConsumerType()) {
+          IngestionConfigUtils.getStreamConfigMap(tableConfig)).hasHighLevelConsumerType()) {
         LOGGER.warn("Cannot rebalance table: {} with high-level consumer, aborting the rebalance", tableNameWithType);
         return new RebalanceResult(RebalanceResult.Status.FAILED, "Cannot rebalance table with high-level consumer",
             null, null);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -48,6 +48,7 @@ import org.apache.pinot.controller.helix.core.assignment.instance.InstanceAssign
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentFactory;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -144,7 +145,7 @@ public class TableRebalancer {
     try {
       // Do not allow rebalancing HLC real-time table
       if (tableConfig.getTableType() == TableType.REALTIME && new StreamConfig(tableNameWithType,
-          tableConfig.getIndexingConfig().getStreamConfigs()).hasHighLevelConsumerType()) {
+          IngestionUtils.getStreamConfigsMap(tableConfig)).hasHighLevelConsumerType()) {
         LOGGER.warn("Cannot rebalance table: {} with high-level consumer, aborting the rebalance", tableNameWithType);
         return new RebalanceResult(RebalanceResult.Status.FAILED, "Cannot rebalance table with high-level consumer",
             null, null);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -32,10 +32,9 @@ import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTas
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.utils.TimeUtils;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +67,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
     // Segment relocation doesn't apply to HLC
     boolean isRealtimeTable = TableNameBuilder.isRealtimeTableResource(tableNameWithType);
-    if (isRealtimeTable && new StreamConfig(tableNameWithType, IngestionUtils.getStreamConfigsMap(tableConfig))
+    if (isRealtimeTable && new StreamConfig(tableNameWithType, IngestionConfigUtils.getStreamConfigMap(tableConfig))
         .hasHighLevelConsumerType()) {
       return;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -32,6 +32,7 @@ import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTas
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
@@ -67,7 +68,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
     // Segment relocation doesn't apply to HLC
     boolean isRealtimeTable = TableNameBuilder.isRealtimeTableResource(tableNameWithType);
-    if (isRealtimeTable && new StreamConfig(tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs())
+    if (isRealtimeTable && new StreamConfig(tableNameWithType, IngestionUtils.getStreamConfigsMap(tableConfig))
         .hasHighLevelConsumerType()) {
       return;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -42,6 +42,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.retention.strategy.RetentionStrategy;
 import org.apache.pinot.controller.helix.core.retention.strategy.TimeRetentionStrategy;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -100,7 +101,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
 
     // For offline tables, ensure that the segmentPushType is APPEND.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String segmentPushType = validationConfig.getSegmentPushType();
+    String segmentPushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
     if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND".equalsIgnoreCase(segmentPushType)) {
       LOGGER.info("Segment push type is not APPEND for table: {}, skip", tableNameWithType);
       return;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -42,10 +42,10 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.retention.strategy.RetentionStrategy;
 import org.apache.pinot.controller.helix.core.retention.strategy.TimeRetentionStrategy;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
@@ -101,7 +101,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
 
     // For offline tables, ensure that the segmentPushType is APPEND.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String segmentPushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
+    String segmentPushType = IngestionConfigUtils.getBatchSegmentPushType(tableConfig);
     if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND".equalsIgnoreCase(segmentPushType)) {
       LOGGER.info("Segment push type is not APPEND for table: {}, skip", tableNameWithType);
       return;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableRetentionValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableRetentionValidator.java
@@ -32,9 +32,9 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -109,7 +109,7 @@ public class TableRetentionValidator {
         LOGGER.error("Table: {}, \"segmentsConfig\" field is missing in table config", tableName);
         continue;
       }
-      String segmentPushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
+      String segmentPushType = IngestionConfigUtils.getBatchSegmentPushType(tableConfig);
       if (segmentPushType == null) {
         LOGGER.error("Table: {}, null push type", tableName);
         continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableRetentionValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableRetentionValidator.java
@@ -32,6 +32,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
@@ -102,12 +103,13 @@ public class TableRetentionValidator {
       }
 
       // Get the retention config
-      SegmentsValidationAndRetentionConfig retentionConfig = getTableConfig(tableName).getValidationConfig();
+      TableConfig tableConfig = getTableConfig(tableName);
+      SegmentsValidationAndRetentionConfig retentionConfig = tableConfig.getValidationConfig();
       if (retentionConfig == null) {
         LOGGER.error("Table: {}, \"segmentsConfig\" field is missing in table config", tableName);
         continue;
       }
-      String segmentPushType = retentionConfig.getSegmentPushType();
+      String segmentPushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
       if (segmentPushType == null) {
         LOGGER.error("Table: {}, null push type", tableName);
         continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -30,10 +30,10 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.util.SegmentIntervalUtils;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.Duration;
@@ -102,7 +102,7 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> 
             .warn("Table: {} has {} segments with invalid interval", offlineTableName, numSegmentsWithInvalidIntervals);
       }
       Duration frequency =
-          SegmentIntervalUtils.convertToDuration(IngestionUtils.getBatchSegmentPushFrequency(tableConfig));
+          SegmentIntervalUtils.convertToDuration(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig));
       numMissingSegments = computeNumMissingSegments(segmentIntervals, frequency);
     }
     // Update the gauge that contains the number of missing segments

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/OfflineSegmentIntervalChecker.java
@@ -30,6 +30,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.util.SegmentIntervalUtils;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -100,7 +101,8 @@ public class OfflineSegmentIntervalChecker extends ControllerPeriodicTask<Void> 
         LOGGER
             .warn("Table: {} has {} segments with invalid interval", offlineTableName, numSegmentsWithInvalidIntervals);
       }
-      Duration frequency = SegmentIntervalUtils.convertToDuration(validationConfig.getSegmentPushFrequency());
+      Duration frequency =
+          SegmentIntervalUtils.convertToDuration(IngestionUtils.getBatchSegmentPushFrequency(tableConfig));
       numMissingSegments = computeNumMissingSegments(segmentIntervals, frequency);
     }
     // Update the gauge that contains the number of missing segments

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -32,6 +32,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
@@ -96,7 +97,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
       }
 
       PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableConfig.getTableName(),
-          tableConfig.getIndexingConfig().getStreamConfigs());
+          IngestionUtils.getStreamConfigsMap(tableConfig));
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfig);
       }
@@ -108,7 +109,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     List<RealtimeSegmentZKMetadata> metadataList =
         _pinotHelixResourceManager.getRealtimeSegmentMetadata(realtimeTableName);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
-    StreamConfig streamConfig = new StreamConfig(realtimeTableName, tableConfig.getIndexingConfig().getStreamConfigs());
+    StreamConfig streamConfig = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
     if (streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType()) {
       countHLCSegments = false;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -32,11 +32,11 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +97,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
       }
 
       PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableConfig.getTableName(),
-          IngestionUtils.getStreamConfigsMap(tableConfig));
+          IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfig);
       }
@@ -109,7 +109,8 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     List<RealtimeSegmentZKMetadata> metadataList =
         _pinotHelixResourceManager.getRealtimeSegmentMetadata(realtimeTableName);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
-    StreamConfig streamConfig = new StreamConfig(realtimeTableName, IngestionUtils.getStreamConfigsMap(tableConfig));
+    StreamConfig streamConfig =
+        new StreamConfig(realtimeTableName, IngestionConfigUtils.getStreamConfigMap(tableConfig));
     if (streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType()) {
       countHLCSegments = false;
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -18,14 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.realtime;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
-
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,9 +30,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.assignment.InstancePartitions;
@@ -59,7 +50,6 @@ import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -69,6 +59,7 @@ import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
@@ -78,7 +69,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Preconditions;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
 
 
 public class PinotLLCRealtimeSegmentManagerTest {
@@ -843,8 +836,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
       _tableConfig =
           new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(_numReplicas)
               .setLLC(true).setStreamConfigs(streamConfigs).build();
-      _streamConfig =
-          new PartitionLevelStreamConfig(_tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(_tableConfig));
+      _streamConfig = new PartitionLevelStreamConfig(_tableConfig.getTableName(),
+          IngestionConfigUtils.getStreamConfigMap(_tableConfig));
     }
 
     void makeConsumingInstancePartitions() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -59,6 +59,7 @@ import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -842,8 +843,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
       _tableConfig =
           new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(_numReplicas)
               .setLLC(true).setStreamConfigs(streamConfigs).build();
-      _streamConfig = new PartitionLevelStreamConfig(_tableConfig.getTableName(),
-          _tableConfig.getIndexingConfig().getStreamConfigs());
+      _streamConfig =
+          new PartitionLevelStreamConfig(_tableConfig.getTableName(), IngestionUtils.getStreamConfigsMap(_tableConfig));
     }
 
     void makeConsumingInstancePartitions() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -155,7 +155,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     _varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
 
-    _streamConfig = new StreamConfig(_tableNameWithType, tableConfig.getIndexingConfig().getStreamConfigs());
+    _streamConfig = new StreamConfig(_tableNameWithType, IngestionUtils.getStreamConfigsMap(tableConfig));
 
     _segmentLogger = LoggerFactory.getLogger(
         HLRealtimeSegmentDataManager.class.getName() + "_" + _segmentName + "_" + _streamConfig.getTopicName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -56,6 +56,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -155,7 +156,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     _varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
 
-    _streamConfig = new StreamConfig(_tableNameWithType, IngestionUtils.getStreamConfigsMap(tableConfig));
+    _streamConfig = new StreamConfig(_tableNameWithType, IngestionConfigUtils.getStreamConfigMap(tableConfig));
 
     _segmentLogger = LoggerFactory.getLogger(
         HLRealtimeSegmentDataManager.class.getName() + "_" + _segmentName + "_" + _streamConfig.getTopicName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -83,6 +83,7 @@ import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
 import org.apache.pinot.spi.stream.TransientConsumerException;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -1103,7 +1104,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
     _partitionLevelStreamConfig =
-        new PartitionLevelStreamConfig(_tableNameWithType, IngestionUtils.getStreamConfigsMap(_tableConfig));
+        new PartitionLevelStreamConfig(_tableNameWithType, IngestionConfigUtils.getStreamConfigMap(_tableConfig));
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig);
     _streamPartitionMsgOffsetFactory =
         StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig).createStreamMsgOffsetFactory();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1102,7 +1102,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
-    _partitionLevelStreamConfig = new PartitionLevelStreamConfig(_tableNameWithType, indexingConfig.getStreamConfigs());
+    _partitionLevelStreamConfig =
+        new PartitionLevelStreamConfig(_tableNameWithType, IngestionUtils.getStreamConfigsMap(_tableConfig));
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig);
     _streamPartitionMsgOffsetFactory =
         StreamConsumerFactoryProvider.create(_partitionLevelStreamConfig).createStreamMsgOffsetFactory();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/IngestionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/IngestionUtils.java
@@ -18,26 +18,19 @@
  */
 package org.apache.pinot.core.util;
 
-import com.google.common.base.Preconditions;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.core.data.function.FunctionEvaluator;
 import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.config.table.ingestion.Batch;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.stream.StreamConfig;
 
 
 /**
@@ -121,69 +114,5 @@ public class IngestionUtils {
       }
     }
     return null;
-  }
-
-  /**
-   * Fetches the streamConfig from the given realtime table.
-   * First, the ingestionConfigs->stream->streamConfigs will be checked.
-   * If not found, the indexingConfig->streamConfigs will be checked (which is deprecated).
-   * @param tableConfig realtime table config
-   * @return streamConfigs map
-   */
-  public static Map<String, String> getStreamConfigsMap(TableConfig tableConfig) {
-    String tableNameWithType = tableConfig.getTableName();
-    Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
-        "Cannot fetch streamConfigs for OFFLINE table: %s", tableNameWithType);
-    Map<String, String> streamConfigsMap = null;
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getStream() != null) {
-      List<Map<String, String>> streamConfigs = tableConfig.getIngestionConfig().getStream().getStreamConfigs();
-      if (!CollectionUtils.isEmpty(streamConfigs)) {
-        Preconditions.checkState(streamConfigs.size() == 1, "Only 1 stream supported per table");
-        streamConfigsMap = streamConfigs.get(0);
-      }
-    }
-    if (streamConfigsMap == null && tableConfig.getIndexingConfig() != null) {
-      streamConfigsMap = tableConfig.getIndexingConfig().getStreamConfigs();
-    }
-    if (streamConfigsMap == null) {
-      throw new IllegalStateException("Could not find streamConfigs for REALTIME table: " + tableNameWithType);
-    }
-    return streamConfigsMap;
-  }
-
-  /**
-   * Fetches the configured segmentPushType (APPEND/REFRESH) from the table config
-   * First checks in the ingestionConfig. If not found, checks in the segmentsConfig (has been deprecated from here in favor of ingestion config)
-   */
-  public static String getBatchSegmentPushType(TableConfig tableConfig) {
-    String segmentPushType = null;
-    if (tableConfig.getIngestionConfig() != null) {
-      Batch batch = tableConfig.getIngestionConfig().getBatch();
-      if (batch != null) {
-        segmentPushType = batch.getSegmentPushType();
-      }
-    }
-    if (segmentPushType == null) {
-      segmentPushType = tableConfig.getValidationConfig().getSegmentPushType();
-    }
-    return segmentPushType;
-  }
-
-  /**
-   * Fetches the configured segmentPushFrequency from the table config
-   * First checks in the ingestionConfig. If not found, checks in the segmentsConfig (has been deprecated from here in favor of ingestion config)
-   */
-  public static String getBatchSegmentPushFrequency(TableConfig tableConfig) {
-    String segmentPushFrequency = null;
-    if (tableConfig.getIngestionConfig() != null) {
-      Batch batch = tableConfig.getIngestionConfig().getBatch();
-      if (batch != null) {
-        segmentPushFrequency = batch.getSegmentPushFrequency();
-      }
-    }
-    if (segmentPushFrequency == null) {
-      segmentPushFrequency = tableConfig.getValidationConfig().getSegmentPushFrequency();
-    }
-    return segmentPushFrequency;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
@@ -37,7 +37,7 @@ public class ReplicationUtils {
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
       StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
-          tableConfig.getIndexingConfig().getStreamConfigs());
+          IngestionUtils.getStreamConfigsMap(tableConfig));
       return streamConfig.hasHighLevelConsumerType();
     }
     return true;
@@ -51,7 +51,7 @@ public class ReplicationUtils {
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
       StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
-          tableConfig.getIndexingConfig().getStreamConfigs());
+          IngestionUtils.getStreamConfigsMap(tableConfig));
       return streamConfig.hasLowLevelConsumerType();
     }
     return false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ReplicationUtils.java
@@ -22,6 +22,7 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 /**
@@ -37,7 +38,7 @@ public class ReplicationUtils {
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
       StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
-          IngestionUtils.getStreamConfigsMap(tableConfig));
+          IngestionConfigUtils.getStreamConfigMap(tableConfig));
       return streamConfig.hasHighLevelConsumerType();
     }
     return true;
@@ -51,7 +52,7 @@ public class ReplicationUtils {
     TableType tableType = tableConfig.getTableType();
     if (tableType.equals(TableType.REALTIME)) {
       StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(),
-          IngestionUtils.getStreamConfigsMap(tableConfig));
+          IngestionConfigUtils.getStreamConfigMap(tableConfig));
       return streamConfig.hasLowLevelConsumerType();
     }
     return false;

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -191,10 +191,11 @@ public final class TableConfigUtils {
       // Batch
       if (ingestionConfig.getBatchIngestionConfig() != null) {
         List<Map<String, String>> batchConfigMaps = ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps();
-        Preconditions.checkState(batchConfigMaps.size() > 0, "Could not find batch config map");
         try {
-          // Validate that BatchConfig can be created
-          batchConfigMaps.forEach(b -> new BatchConfig(tableNameWithType, b));
+          if (CollectionUtils.isNotEmpty(batchConfigMaps)) {
+            // Validate that BatchConfig can be created
+            batchConfigMaps.forEach(b -> new BatchConfig(tableNameWithType, b));
+          }
         } catch (Exception e) {
           throw new IllegalStateException("Could not create BatchConfig using the batchConfig map", e);
         }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
@@ -60,7 +60,7 @@ public class ExpressionTransformerTest {
     transformConfigs.add(new TransformConfig("map2_values", "Groovy({map2.sort()*.value}, map2)"));
     transformConfigs.add(new TransformConfig("hoursSinceEpoch", "Groovy({timestamp/(1000*60*60)}, timestamp)"));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTransformFunctions")
-        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, transformConfigs)).build();
 
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
     DataTypeTransformer dataTypeTransformer = new DataTypeTransformer(pinotSchema);
@@ -148,7 +148,7 @@ public class ExpressionTransformerTest {
     transformConfigs.add(new TransformConfig("fullName", "Groovy({firstName+' '+lastName}, firstName, lastName)"));
     transformConfigs.add(new TransformConfig("hoursSinceEpoch", "Groovy({timestamp/(1000*60*60)}, timestamp)"));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTransformFunctions")
-        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, transformConfigs)).build();
 
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
 
@@ -202,7 +202,7 @@ public class ExpressionTransformerTest {
     List<TransformConfig> transformConfigs = new ArrayList<>();
     transformConfigs.add(new TransformConfig("fullName", "Groovy({firstName + ' ' + lastName}, firstName, lastName)"));
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testValueExists")
-        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, transformConfigs)).build();
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
 
     GenericRow genericRow = new GenericRow();
@@ -218,7 +218,7 @@ public class ExpressionTransformerTest {
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
             new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "outgoing")).build();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testValueExists")
-        .setIngestionConfig(new IngestionConfig(null, null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, null)).build();
     expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
 
     genericRow = new GenericRow();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.data.recordtransformer;
 
 import java.util.Collections;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
@@ -79,28 +79,30 @@ public class RecordTransformerTest {
 
     // expression false, not filtered
     GenericRow genericRow = getRecord();
-    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svInt > 123}, svInt)"), null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy({svInt > 123}, svInt)"), null));
     RecordTransformer transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // expression true, filtered
     genericRow = getRecord();
-    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svInt <= 123}, svInt)"), null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy({svInt <= 123}, svInt)"), null));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // value not found
     genericRow = getRecord();
-    tableConfig
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({notPresent == 123}, notPresent)"), null));
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(null, null, new FilterConfig("Groovy({notPresent == 123}, notPresent)"), null));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // invalid function
-    tableConfig.setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy(svInt == 123)"), null));
+    tableConfig.setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy(svInt == 123)"), null));
     try {
       new FilterTransformer(tableConfig);
       Assert.fail("Should have failed constructing FilterTransformer");
@@ -110,8 +112,8 @@ public class RecordTransformerTest {
 
     // multi value column
     genericRow = getRecord();
-    tableConfig
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)"), null));
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(null, null, new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)"), null));
     transformer = new FilterTransformer(tableConfig);
     transformer.transform(genericRow);
     Assert.assertTrue(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithFilterRecordsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithFilterRecordsTest.java
@@ -29,7 +29,7 @@ import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
@@ -65,9 +65,11 @@ public class SegmentGenerationWithFilterRecordsTest {
 
   @BeforeClass
   public void setup() {
-    String filterFunction = "Groovy({((col2 < 1589007600000L) &&  (col3.max() < 4)) || col1 == \"B\"}, col1, col2, col3)";
-    IngestionConfig ingestionConfig = new IngestionConfig(new FilterConfig(filterFunction), null);
-    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setIngestionConfig(ingestionConfig).build();
+    String filterFunction =
+        "Groovy({((col2 < 1589007600000L) &&  (col3.max() < 4)) || col1 == \"B\"}, col1, col2, col3)";
+    IngestionConfig ingestionConfig = new IngestionConfig(null, null, new FilterConfig(filterFunction), null);
+    _tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setIngestionConfig(ingestionConfig).build();
     _schema = new Schema.SchemaBuilder().addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
         .addMetric(LONG_COLUMN, FieldSpec.DataType.LONG).addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
         .build();

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/IngestionUtilsTest.java
@@ -22,27 +22,17 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.spi.config.table.IndexingConfig;
-import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
-import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
-import org.apache.pinot.spi.utils.IngestionConfigUtils;
-import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -209,120 +199,5 @@ public class IngestionUtilsTest {
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(ingestionConfig, schema));
     Assert.assertEquals(extract.size(), 6);
     Assert.assertTrue(extract.containsAll(Lists.newArrayList("d1", "d2", "m1", "dateColumn", "xy", "timestampColumn")));
-  }
-
-  @Test
-  public void testGetStreamConfigMap() {
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    try {
-      IngestionConfigUtils.getStreamConfigMap(tableConfig);
-      Assert.fail("Should fail for OFFLINE table");
-    } catch (IllegalStateException e) {
-      // expected
-    }
-
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").setTimeColumnName("timeColumn").build();
-
-    // get from ingestion config (when not present in indexing config)
-    Map<String, String> streamConfigMap = new HashMap<>();
-    streamConfigMap.put("streamType", "kafka");
-    tableConfig.setIngestionConfig(
-        new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(streamConfigMap)), null, null));
-    Map<String, String> actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
-    Assert.assertEquals(actualStreamConfigsMap.size(), 1);
-    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "kafka");
-
-    // get from ingestion config (even if present in indexing config)
-    Map<String, String> deprecatedStreamConfigMap = new HashMap<>();
-    deprecatedStreamConfigMap.put("streamType", "foo");
-    deprecatedStreamConfigMap.put("customProp", "foo");
-    IndexingConfig indexingConfig = new IndexingConfig();
-    indexingConfig.setStreamConfigs(deprecatedStreamConfigMap);
-    tableConfig.setIndexingConfig(indexingConfig);
-    actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
-    Assert.assertEquals(actualStreamConfigsMap.size(), 1);
-    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "kafka");
-
-    // fail if multiple found
-    tableConfig.setIngestionConfig(new IngestionConfig(null,
-        new StreamIngestionConfig(Lists.newArrayList(streamConfigMap, deprecatedStreamConfigMap)), null, null));
-    try {
-      IngestionConfigUtils.getStreamConfigMap(tableConfig);
-      Assert.fail("Should fail for multiple stream configs");
-    } catch (IllegalStateException e) {
-      // expected
-    }
-
-    // get from indexing config
-    tableConfig.setIngestionConfig(null);
-    actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
-    Assert.assertEquals(actualStreamConfigsMap.size(), 2);
-    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "foo");
-
-    // fail if found nowhere
-    tableConfig.setIndexingConfig(null);
-    try {
-      IngestionConfigUtils.getStreamConfigMap(tableConfig);
-      Assert.fail("Should fail for no stream config found");
-    } catch (IllegalStateException e) {
-      // expected
-    }
-  }
-
-  @Test
-  public void testGetPushFrequency() {
-    // get from ingestion config, when not present in segmentsConfig
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put("batchType", "s3");
-    tableConfig.setIngestionConfig(
-        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null,
-            null, null));
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "HOURLY");
-
-    // get from ingestion config, even if present in segmentsConfig
-    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
-        new SegmentsValidationAndRetentionConfig();
-    segmentsValidationAndRetentionConfig.setSegmentPushFrequency("DAILY");
-    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "HOURLY");
-
-    // get from segmentsConfig
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "DAILY");
-
-    // present nowhere
-    segmentsValidationAndRetentionConfig.setSegmentPushFrequency(null);
-    Assert.assertNull(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig));
-  }
-
-  @Test
-  public void testGetPushType() {
-    // get from ingestion config, when not present in segmentsConfig
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put("batchType", "s3");
-    tableConfig.setIngestionConfig(
-        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null, null,
-            null));
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "APPEND");
-
-    // get from ingestion config, even if present in segmentsConfig
-    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
-        new SegmentsValidationAndRetentionConfig();
-    segmentsValidationAndRetentionConfig.setSegmentPushType("REFRESH");
-    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "APPEND");
-
-    // get from segmentsConfig
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
-    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "REFRESH");
-
-    // present nowhere
-    segmentsValidationAndRetentionConfig.setSegmentPushType(null);
-    Assert.assertNull(IngestionConfigUtils.getBatchSegmentPushType(tableConfig));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
@@ -90,7 +90,7 @@ public class SchemaUtilsTest {
     // schema doesn't have destination columns from transformConfigs
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("colA", "round(colB, 1000)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("colA", "round(colB, 1000)")))).build();
     try {
       SchemaUtils.validate(schema, Lists.newArrayList(tableConfig));
       Assert.fail("Should fail schema validation, as colA is not present in schema");
@@ -138,7 +138,7 @@ public class SchemaUtilsTest {
         .addDateTime(TIME_COLUMN, DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS").build();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
         .setIngestionConfig(
-            new IngestionConfig(null, Lists.newArrayList(new TransformConfig("colA", "round(colB, 1000)")))).build();
+            new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("colA", "round(colB, 1000)")))).build();
     try {
       SchemaUtils.validate(schema, Lists.newArrayList(tableConfig));
       Assert.fail("Should fail schema validation, as colA is not present in schema");

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -30,7 +30,7 @@ import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.ingestion.Batch;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -40,12 +40,11 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
-import org.apache.pinot.spi.config.table.ingestion.Stream;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
-import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
@@ -348,7 +347,7 @@ public class TableConfigUtilsTest {
   public void ingestionStreamConfigsTest() {
     Map<String, String> fakeMap = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     IngestionConfig ingestionConfig =
-        new IngestionConfig(null, new Stream(Lists.newArrayList(fakeMap, fakeMap)), null, null);
+        new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(fakeMap, fakeMap)), null, null);
 
     // only 1 stream config allowed
     try {
@@ -359,7 +358,7 @@ public class TableConfigUtilsTest {
     }
 
     // stream config should be valid
-    ingestionConfig = new IngestionConfig(null, new Stream(Lists.newArrayList(fakeMap)), null, null);
+    ingestionConfig = new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(fakeMap)), null, null);
     TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
 
     fakeMap.remove(StreamConfigProperties.STREAM_TYPE);
@@ -386,7 +385,7 @@ public class TableConfigUtilsTest {
         "org.foo.Reader");
 
     IngestionConfig ingestionConfig =
-        new IngestionConfig(new Batch(Lists.newArrayList(batchConfigMap, batchConfigMap), null, null), null, null,
+        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), null, null), null, null,
             null);
     TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -24,13 +24,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.common.function.AggregationFunctionType;
 import org.apache.pinot.common.tier.TierFactory;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.core.startree.v2.AggregationFunctionColumnPair;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.Batch;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -39,13 +40,16 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+import org.apache.pinot.spi.config.table.ingestion.Stream;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.testng.collections.Sets;
 
 
 /**
@@ -180,27 +184,27 @@ public class TableConfigUtilsTest {
 
     // null filter config, transform config
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(null, null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, null)).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // null filter function
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(new FilterConfig(null), null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig(null), null)).build();
+    TableConfigUtils.validate(tableConfig, schema);
+
+    // valid filterFunction
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
+        new IngestionConfig(null, null, new FilterConfig("startsWith(columnX, \"myPrefix\")"), null)).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid filterFunction
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("startsWith(columnX, \"myPrefix\")"), null)).build();
-    TableConfigUtils.validate(tableConfig, schema);
-
-    // valid filterFunction
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy({x == 10}, x)"), null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy({x == 10}, x)"), null)).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid filter function
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("Groovy(badExpr)"), null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy(badExpr)"), null)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail on invalid filter function string");
@@ -209,7 +213,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(new FilterConfig("fakeFunction(xx)"), null)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("fakeFunction(xx)"), null)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid filter function");
@@ -219,12 +223,13 @@ public class TableConfigUtilsTest {
 
     // empty transform configs
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(null, Collections.emptyList())).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, Collections.emptyList())).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // transformed column not in schema
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)"))))
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for transformedColumn not present in schema");
@@ -237,7 +242,8 @@ public class TableConfigUtilsTest {
             .build();
     // valid transform configs
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)"))))
+        .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     schema =
@@ -245,13 +251,14 @@ public class TableConfigUtilsTest {
             .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
     // valid transform configs
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)"),
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "reverse(anotherCol)"),
             new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // null transform column name
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig(null, "reverse(anotherCol)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig(null, "reverse(anotherCol)"))))
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for null column name in transform config");
@@ -260,8 +267,8 @@ public class TableConfigUtilsTest {
     }
 
     // null transform function string
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIngestionConfig(new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", null)))).build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", null)))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for null transform function in transform config");
@@ -271,7 +278,8 @@ public class TableConfigUtilsTest {
 
     // invalid function
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "fakeFunction(col)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "fakeFunction(col)"))))
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid transform function in transform config");
@@ -281,7 +289,8 @@ public class TableConfigUtilsTest {
 
     // invalid function
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "Groovy(badExpr)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "Groovy(badExpr)"))))
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid transform function in transform config");
@@ -291,7 +300,8 @@ public class TableConfigUtilsTest {
 
     // input field name used as destination field
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, Lists.newArrayList(new TransformConfig("myCol", "reverse(myCol)")))).build();
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("myCol", "reverse(myCol)"))))
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to use of myCol as arguments and columnName");
@@ -301,7 +311,7 @@ public class TableConfigUtilsTest {
 
     // input field name used as destination field
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null,
+        new IngestionConfig(null, null, null,
             Lists.newArrayList(new TransformConfig("myCol", "Groovy({x + y + myCol}, x, myCol, y)")))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -312,7 +322,7 @@ public class TableConfigUtilsTest {
 
     // duplicate transform config
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null,
+        new IngestionConfig(null, null, null,
             Lists.newArrayList(new TransformConfig("myCol", "reverse(x)"), new TransformConfig("myCol", "lower(y)"))))
         .build();
     try {
@@ -324,11 +334,66 @@ public class TableConfigUtilsTest {
 
     // chained transform functions
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null,
+        new IngestionConfig(null, null, null,
             Lists.newArrayList(new TransformConfig("a", "reverse(x)"), new TransformConfig("b", "lower(a)")))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to using transformed column 'a' as argument for transform function of column 'b'");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void ingestionStreamConfigsTest() {
+    Map<String, String> fakeMap = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
+    IngestionConfig ingestionConfig =
+        new IngestionConfig(null, new Stream(Lists.newArrayList(fakeMap, fakeMap)), null, null);
+
+    // only 1 stream config allowed
+    try {
+      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      Assert.fail("Should fail for more than 1 stream config");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // stream config should be valid
+    ingestionConfig = new IngestionConfig(null, new Stream(Lists.newArrayList(fakeMap)), null, null);
+    TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+
+    fakeMap.remove(StreamConfigProperties.STREAM_TYPE);
+    try {
+      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      Assert.fail("Should fail for invalid stream configs map");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void ingestionBatchConfigsTest() {
+    Map<String, String> batchConfigMap = new HashMap<>();
+    batchConfigMap.put(BatchConfigProperties.BATCH_TYPE, "s3");
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.INPUT_DIR_URI), "s3://foo");
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.OUTPUT_DIR_URI), "s3://bar");
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.FS_CLASS), "org.foo.S3FS");
+    batchConfigMap.put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.INPUT_FORMAT), "avro");
+    batchConfigMap.put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.RECORD_READER_CLASS),
+        "org.foo.Reader");
+
+    IngestionConfig ingestionConfig =
+        new IngestionConfig(new Batch(Lists.newArrayList(batchConfigMap, batchConfigMap), null, null), null, null,
+            null);
+    TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+
+    batchConfigMap.remove(BatchConfigProperties.BATCH_TYPE);
+    try {
+      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      Assert.fail("Should fail for invalid batch config map");
     } catch (IllegalStateException e) {
       // expected
     }
@@ -723,7 +788,7 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "streamConfig must exist in the table config");
+      Assert.assertEquals(e.getMessage(), "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
     }
     Map<String, String> streamConfigs = new HashMap<>();
     streamConfigs.put("stream.kafka.consumer.type", "highLevel");

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -375,13 +375,13 @@ public class TableConfigUtilsTest {
     Map<String, String> batchConfigMap = new HashMap<>();
     batchConfigMap.put(BatchConfigProperties.BATCH_TYPE, "s3");
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.INPUT_DIR_URI), "s3://foo");
+        .put(BatchConfigProperties.constructBatchProperty("s3", BatchConfigProperties.INPUT_DIR_URI), "s3://foo");
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.OUTPUT_DIR_URI), "s3://bar");
+        .put(BatchConfigProperties.constructBatchProperty("s3", BatchConfigProperties.OUTPUT_DIR_URI), "s3://bar");
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.FS_CLASS), "org.foo.S3FS");
-    batchConfigMap.put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.INPUT_FORMAT), "avro");
-    batchConfigMap.put(BatchConfigProperties.constructStreamProperty("s3", BatchConfigProperties.RECORD_READER_CLASS),
+        .put(BatchConfigProperties.constructBatchProperty("s3", BatchConfigProperties.FS_CLASS), "org.foo.S3FS");
+    batchConfigMap.put(BatchConfigProperties.constructBatchProperty("s3", BatchConfigProperties.INPUT_FORMAT), "avro");
+    batchConfigMap.put(BatchConfigProperties.constructBatchProperty("s3", BatchConfigProperties.RECORD_READER_CLASS),
         "org.foo.Reader");
 
     IngestionConfig ingestionConfig =

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -348,10 +348,13 @@ public class TableConfigUtilsTest {
     Map<String, String> fakeMap = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     IngestionConfig ingestionConfig =
         new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(fakeMap, fakeMap)), null, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
 
     // only 1 stream config allowed
     try {
-      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for more than 1 stream config");
     } catch (IllegalStateException e) {
       // expected
@@ -359,11 +362,12 @@ public class TableConfigUtilsTest {
 
     // stream config should be valid
     ingestionConfig = new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(fakeMap)), null, null);
-    TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     fakeMap.remove(StreamConfigProperties.STREAM_TYPE);
     try {
-      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for invalid stream configs map");
     } catch (Exception e) {
       // expected
@@ -385,13 +389,16 @@ public class TableConfigUtilsTest {
         "org.foo.Reader");
 
     IngestionConfig ingestionConfig =
-        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), null, null), null, null,
-            null);
-    TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), null, null),
+            null, null, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable_OFFLINE").setIngestionConfig(ingestionConfig)
+            .build();
+    TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     batchConfigMap.remove(BatchConfigProperties.BATCH_TYPE);
     try {
-      TableConfigUtils.validateIngestionConfig("myTable_REALTIME", ingestionConfig, null);
+      TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for invalid batch config map");
     } catch (IllegalStateException e) {
       // expected
@@ -787,7 +794,8 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
+      Assert
+          .assertEquals(e.getMessage(), "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
     }
     Map<String, String> streamConfigs = new HashMap<>();
     streamConfigs.put("stream.kafka.consumer.type", "highLevel");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -39,11 +39,10 @@ import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -248,13 +247,6 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     return DEFAULT_NULL_HANDLING_ENABLED;
   }
 
-  @Nullable
-  protected StreamIngestionConfig getStreamIngestionConfig() {
-    List<Map<String, String>> streamConfigMaps = new ArrayList<>();
-    streamConfigMaps.add(getStreamConfigMap());
-    return new StreamIngestionConfig(streamConfigMaps);
-  }
-
   /**
    * The following methods are based on the getters. Override the getters for non-default settings before calling these
    * methods.
@@ -296,6 +288,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    */
   protected TableConfig getOfflineTableConfig() {
     return getOfflineTableConfig(getTableName());
+  }
+
+  protected Map<String, String> getStreamConfigs() {
+    return getStreamConfigMap();
   }
 
   protected Map<String, String> getStreamConfigMap() {
@@ -351,7 +347,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
         .setLoadMode(getLoadMode()).setTaskConfig(getTaskConfig()).setBrokerTenant(getBrokerTenant())
         .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setLLC(useLlc())
-        .setStreamConfigs(getStreamConfigMap()).setNullHandlingEnabled(getNullHandlingEnabled()).build();
+        .setStreamConfigs(getStreamConfigs()).setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -249,7 +249,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   @Nullable
-  protected StreamIngestionConfig getStream() {
+  protected StreamIngestionConfig getStreamIngestionConfig() {
     List<Map<String, String>> streamConfigMaps = new ArrayList<>();
     streamConfigMaps.add(getStreamConfigMap());
     return new StreamIngestionConfig(streamConfigMaps);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -43,7 +43,7 @@ import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.config.table.ingestion.Stream;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -249,10 +249,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   @Nullable
-  protected Stream getStream() {
-    List<Map<String, String>> streamConfigs = new ArrayList<>();
-    streamConfigs.add(getStreamConfigMap());
-    return new Stream(streamConfigs);
+  protected StreamIngestionConfig getStream() {
+    List<Map<String, String>> streamConfigMaps = new ArrayList<>();
+    streamConfigMaps.add(getStreamConfigMap());
+    return new StreamIngestionConfig(streamConfigMaps);
   }
 
   /**
@@ -299,44 +299,44 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected Map<String, String> getStreamConfigMap() {
-    Map<String, String> streamConfigs = new HashMap<>();
+    Map<String, String> streamConfigMap = new HashMap<>();
     String streamType = "kafka";
-    streamConfigs.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
     boolean useLlc = useLlc();
     if (useLlc) {
       // LLC
-      streamConfigs
+      streamConfigMap
           .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
               StreamConfig.ConsumerType.LOWLEVEL.toString());
-      streamConfigs.put(KafkaStreamConfigProperties
+      streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST),
           KafkaStarterUtils.DEFAULT_KAFKA_BROKER);
     } else {
       // HLC
-      streamConfigs
+      streamConfigMap
           .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
               StreamConfig.ConsumerType.HIGHLEVEL.toString());
-      streamConfigs.put(KafkaStreamConfigProperties
+      streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_ZK_CONNECTION_STRING),
           KafkaStarterUtils.DEFAULT_ZK_STR);
-      streamConfigs.put(KafkaStreamConfigProperties
+      streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_BOOTSTRAP_SERVER),
           KafkaStarterUtils.DEFAULT_KAFKA_BROKER);
     }
-    streamConfigs.put(StreamConfigProperties
+    streamConfigMap.put(StreamConfigProperties
             .constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
         getStreamConsumerFactoryClassName());
-    streamConfigs
+    streamConfigMap
         .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME),
             getKafkaTopic());
-    streamConfigs
+    streamConfigMap
         .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
             AvroFileSchemaKafkaAvroMessageDecoder.class.getName());
-    streamConfigs
+    streamConfigMap
         .put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, Integer.toString(getRealtimeSegmentFlushSize()));
-    streamConfigs.put(StreamConfigProperties
+    streamConfigMap.put(StreamConfigProperties
         .constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), "smallest");
-    return streamConfigs;
+    return streamConfigMap;
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
@@ -21,11 +21,8 @@ package org.apache.pinot.integration.tests;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nullable;
-import org.apache.pinot.controller.ControllerConf;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
@@ -66,7 +63,7 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
     transformConfigs.add(new TransformConfig("AmPm", "Groovy({DepTime < 1200 ? \"AM\": \"PM\"}, DepTime)"));
     transformConfigs.add(new TransformConfig("millisSinceEpoch", "fromEpochDays(DaysSinceEpoch)"));
     transformConfigs.add(new TransformConfig("lowerCaseDestCityName", "lower(DestCityName)"));
-    return new IngestionConfig(filterConfig, transformConfigs);
+    return new IngestionConfig(null, getStream(), filterConfig, transformConfigs);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
@@ -63,7 +63,7 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
     transformConfigs.add(new TransformConfig("AmPm", "Groovy({DepTime < 1200 ? \"AM\": \"PM\"}, DepTime)"));
     transformConfigs.add(new TransformConfig("millisSinceEpoch", "fromEpochDays(DaysSinceEpoch)"));
     transformConfigs.add(new TransformConfig("lowerCaseDestCityName", "lower(DestCityName)"));
-    return new IngestionConfig(null, getStream(), filterConfig, transformConfigs);
+    return new IngestionConfig(null, getStreamIngestionConfig(), filterConfig, transformConfigs);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -63,7 +65,15 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
     transformConfigs.add(new TransformConfig("AmPm", "Groovy({DepTime < 1200 ? \"AM\": \"PM\"}, DepTime)"));
     transformConfigs.add(new TransformConfig("millisSinceEpoch", "fromEpochDays(DaysSinceEpoch)"));
     transformConfigs.add(new TransformConfig("lowerCaseDestCityName", "lower(DestCityName)"));
-    return new IngestionConfig(null, getStreamIngestionConfig(), filterConfig, transformConfigs);
+
+    List<Map<String, String>> streamConfigMaps = new ArrayList<>();
+    streamConfigMaps.add(getStreamConfigMap());
+    return new IngestionConfig(null, new StreamIngestionConfig(streamConfigMaps), filterConfig, transformConfigs);
+  }
+
+  @Override
+  protected Map<String, String> getStreamConfigs() {
+    return null;
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.integration.tests;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,12 +32,10 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.util.SchemaUtils;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -87,7 +84,7 @@ public class MapTypeClusterIntegrationTest extends BaseClusterIntegrationTest {
         new TransformConfig(STRING_KEY_MAP_STR_FIELD_NAME, "toJsonMapStr(" + STRING_KEY_MAP_FIELD_NAME + ")"),
         new TransformConfig(INT_KEY_MAP_STR_FIELD_NAME, "toJsonMapStr(" + INT_KEY_MAP_FIELD_NAME + ")"));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
-        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, transformConfigs)).build();
     addTableConfig(tableConfig);
 
     // Create and upload segments

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/executor/RealtimeToOfflineSegmentsTaskExecutorTest.java
@@ -39,7 +39,7 @@ import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -101,11 +101,11 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
     TableConfig tableConfigEpochHours =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_EPOCH_HOURS).setTimeColumnName(T_TRX)
             .setSortedColumn(D1).setIngestionConfig(
-            new IngestionConfig(null, Lists.newArrayList(new TransformConfig(T_TRX, "toEpochHours(t)")))).build();
+            new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig(T_TRX, "toEpochHours(t)")))).build();
     TableConfig tableConfigSDF =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME_SDF).setTimeColumnName(T_TRX)
             .setSortedColumn(D1).setIngestionConfig(
-            new IngestionConfig(null, Lists.newArrayList(new TransformConfig(T_TRX, "toDateTime(t, 'yyyyMMddHH')"))))
+            new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig(T_TRX, "toDateTime(t, 'yyyyMMddHH')"))))
             .build();
     Schema schema =
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -140,7 +141,8 @@ public class SegmentGenerationTaskRunner implements Serializable {
         }
         return new NormalizedDateSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),
             Boolean.parseBoolean(segmentNameGeneratorConfigs.get(EXCLUDE_SEQUENCE_ID)),
-            validationConfig.getSegmentPushType(), validationConfig.getSegmentPushFrequency(), dateTimeFormatSpec);
+            IngestionUtils.getBatchSegmentPushType(tableConfig),
+            IngestionUtils.getBatchSegmentPushFrequency(tableConfig), dateTimeFormatSpec);
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -20,29 +20,25 @@ package org.apache.pinot.plugin.ingestion.batch.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationTaskSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -141,8 +137,8 @@ public class SegmentGenerationTaskRunner implements Serializable {
         }
         return new NormalizedDateSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),
             Boolean.parseBoolean(segmentNameGeneratorConfigs.get(EXCLUDE_SEQUENCE_ID)),
-            IngestionUtils.getBatchSegmentPushType(tableConfig),
-            IngestionUtils.getBatchSegmentPushFrequency(tableConfig), dateTimeFormatSpec);
+            IngestionConfigUtils.getBatchSegmentPushType(tableConfig),
+            IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), dateTimeFormatSpec);
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.pinot.common.utils.StringUtil;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.job.mappers.SegmentCreationMapper;
 import org.apache.pinot.hadoop.utils.PinotHadoopJobPreparationHelper;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
@@ -45,6 +44,7 @@ import org.apache.pinot.ingestion.jobs.SegmentCreationJob;
 import org.apache.pinot.ingestion.utils.JobPreparationHelper;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 public class HadoopSegmentCreationJob extends SegmentCreationJob {
@@ -143,7 +143,7 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
 
     // For APPEND use case, timeColumnName and timeType must be set
-    if (APPEND.equalsIgnoreCase(IngestionUtils.getBatchSegmentPushType(tableConfig))) {
+    if (APPEND.equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentPushType(tableConfig))) {
       Preconditions.checkState(validationConfig.getTimeColumnName() != null && validationConfig.getTimeType() != null,
           "For APPEND use case, time column and type must be set");
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.job.mappers.SegmentCreationMapper;
 import org.apache.pinot.hadoop.utils.PinotHadoopJobPreparationHelper;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
@@ -142,7 +143,7 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
 
     // For APPEND use case, timeColumnName and timeType must be set
-    if (APPEND.equalsIgnoreCase(validationConfig.getSegmentPushType())) {
+    if (APPEND.equalsIgnoreCase(IngestionUtils.getBatchSegmentPushType(tableConfig))) {
       Preconditions.checkState(validationConfig.getTimeColumnName() != null && validationConfig.getTimeType() != null,
           "For APPEND use case, time column and type must be set");
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.io.CombineAvroKeyInputFormat;
 import org.apache.pinot.hadoop.job.mappers.SegmentPreprocessingMapper;
 import org.apache.pinot.hadoop.job.partitioners.GenericPartitioner;
@@ -371,7 +372,7 @@ public class HadoopSegmentPreprocessingJob extends SegmentPreprocessingJob {
     // If the use case is an append use case, check that one time unit is contained in one file. If there is more than one,
     // the job should be disabled, as we should not resize for these use cases. Therefore, setting the time column name
     // and value
-    if (validationConfig.getSegmentPushType().equalsIgnoreCase("APPEND")) {
+    if (IngestionUtils.getBatchSegmentPushType(_tableConfig).equalsIgnoreCase("APPEND")) {
       job.getConfiguration().set(InternalConfigConstants.IS_APPEND, "true");
       String timeColumnName = validationConfig.getTimeColumnName();
       job.getConfiguration().set(InternalConfigConstants.TIME_COLUMN_CONFIG, timeColumnName);
@@ -387,8 +388,8 @@ public class HadoopSegmentPreprocessingJob extends SegmentPreprocessingJob {
               .set(InternalConfigConstants.SEGMENT_TIME_SDF_PATTERN, formatSpec.getSDFPattern());
         }
       }
-      job.getConfiguration()
-          .set(InternalConfigConstants.SEGMENT_PUSH_FREQUENCY, validationConfig.getSegmentPushFrequency());
+      job.getConfiguration().set(InternalConfigConstants.SEGMENT_PUSH_FREQUENCY,
+          IngestionUtils.getBatchSegmentPushFrequency(_tableConfig));
       try (DataFileStream<GenericRecord> dataStreamReader = getAvroReader(path)) {
         job.getConfiguration()
             .set(InternalConfigConstants.TIME_COLUMN_VALUE, dataStreamReader.next().get(timeColumnName).toString());

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.io.CombineAvroKeyInputFormat;
 import org.apache.pinot.hadoop.job.mappers.SegmentPreprocessingMapper;
 import org.apache.pinot.hadoop.job.partitioners.GenericPartitioner;
@@ -65,11 +64,8 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableCustomConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatPatternSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.TimeFieldSpec;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -372,7 +368,7 @@ public class HadoopSegmentPreprocessingJob extends SegmentPreprocessingJob {
     // If the use case is an append use case, check that one time unit is contained in one file. If there is more than one,
     // the job should be disabled, as we should not resize for these use cases. Therefore, setting the time column name
     // and value
-    if (IngestionUtils.getBatchSegmentPushType(_tableConfig).equalsIgnoreCase("APPEND")) {
+    if (IngestionConfigUtils.getBatchSegmentPushType(_tableConfig).equalsIgnoreCase("APPEND")) {
       job.getConfiguration().set(InternalConfigConstants.IS_APPEND, "true");
       String timeColumnName = validationConfig.getTimeColumnName();
       job.getConfiguration().set(InternalConfigConstants.TIME_COLUMN_CONFIG, timeColumnName);
@@ -389,7 +385,7 @@ public class HadoopSegmentPreprocessingJob extends SegmentPreprocessingJob {
         }
       }
       job.getConfiguration().set(InternalConfigConstants.SEGMENT_PUSH_FREQUENCY,
-          IngestionUtils.getBatchSegmentPushFrequency(_tableConfig));
+          IngestionConfigUtils.getBatchSegmentPushFrequency(_tableConfig));
       try (DataFileStream<GenericRecord> dataStreamReader = getAvroReader(path)) {
         job.getConfiguration()
             .set(InternalConfigConstants.TIME_COLUMN_VALUE, dataStreamReader.next().get(timeColumnName).toString());

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -41,7 +41,6 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.job.InternalConfigConstants;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.ingestion.jobs.SegmentCreationJob;
@@ -53,11 +52,12 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableCustomConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.IngestionSchemaValidator;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,8 +163,8 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
         _segmentNameGenerator =
             new NormalizedDateSegmentNameGenerator(_rawTableName, _jobConf.get(JobConfigConstants.SEGMENT_NAME_PREFIX),
                 _jobConf.getBoolean(JobConfigConstants.EXCLUDE_SEQUENCE_ID, false),
-                IngestionUtils.getBatchSegmentPushType(_tableConfig),
-                IngestionUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
+                IngestionConfigUtils.getBatchSegmentPushType(_tableConfig),
+                IngestionConfigUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.hadoop.job.InternalConfigConstants;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.ingestion.jobs.SegmentCreationJob;
@@ -162,7 +163,8 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
         _segmentNameGenerator =
             new NormalizedDateSegmentNameGenerator(_rawTableName, _jobConf.get(JobConfigConstants.SEGMENT_NAME_PREFIX),
                 _jobConf.getBoolean(JobConfigConstants.EXCLUDE_SEQUENCE_ID, false),
-                validationConfig.getSegmentPushType(), validationConfig.getSegmentPushFrequency(), dateTimeFormatSpec);
+                IngestionUtils.getBatchSegmentPushType(_tableConfig),
+                IngestionUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
@@ -38,7 +38,6 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReaderConfig;
@@ -51,6 +50,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,7 +131,8 @@ public class SparkSegmentCreationFunction implements Serializable {
         _segmentNameGenerator =
             new NormalizedDateSegmentNameGenerator(_rawTableName, _jobConf.get(JobConfigConstants.SEGMENT_NAME_PREFIX),
                 _jobConf.getBoolean(JobConfigConstants.EXCLUDE_SEQUENCE_ID, false),
-                IngestionUtils.getBatchSegmentPushType(_tableConfig), IngestionUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
+                IngestionConfigUtils.getBatchSegmentPushType(_tableConfig),
+                IngestionConfigUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
@@ -38,6 +38,7 @@ import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SegmentNameGenerator;
 import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReaderConfig;
@@ -130,7 +131,7 @@ public class SparkSegmentCreationFunction implements Serializable {
         _segmentNameGenerator =
             new NormalizedDateSegmentNameGenerator(_rawTableName, _jobConf.get(JobConfigConstants.SEGMENT_NAME_PREFIX),
                 _jobConf.getBoolean(JobConfigConstants.EXCLUDE_SEQUENCE_ID, false),
-                validationConfig.getSegmentPushType(), validationConfig.getSegmentPushFrequency(), dateTimeFormatSpec);
+                IngestionUtils.getBatchSegmentPushType(_tableConfig), IngestionUtils.getBatchSegmentPushFrequency(_tableConfig), dateTimeFormatSpec);
         break;
       default:
         throw new UnsupportedOperationException("Unsupported segment name generator type: " + segmentNameGeneratorType);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationJob.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.ingestion.jobs.SegmentCreationJob;
 import org.apache.pinot.ingestion.utils.JobPreparationHelper;
@@ -155,7 +156,7 @@ public class SparkSegmentCreationJob extends SegmentCreationJob {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
 
     // For APPEND use case, timeColumnName and timeType must be set
-    if (APPEND.equalsIgnoreCase(validationConfig.getSegmentPushType())) {
+    if (APPEND.equalsIgnoreCase(IngestionUtils.getBatchSegmentPushType(tableConfig))) {
       Preconditions.checkState(validationConfig.getTimeColumnName() != null && validationConfig.getTimeType() != null,
           "For APPEND use case, time column and type must be set");
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationJob.java
@@ -31,13 +31,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.ingestion.common.JobConfigConstants;
 import org.apache.pinot.ingestion.jobs.SegmentCreationJob;
 import org.apache.pinot.ingestion.utils.JobPreparationHelper;
 import org.apache.pinot.spark.utils.PinotSparkJobPreparationHelper;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -156,7 +156,7 @@ public class SparkSegmentCreationJob extends SegmentCreationJob {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
 
     // For APPEND use case, timeColumnName and timeType must be set
-    if (APPEND.equalsIgnoreCase(IngestionUtils.getBatchSegmentPushType(tableConfig))) {
+    if (APPEND.equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentPushType(tableConfig))) {
       Preconditions.checkState(validationConfig.getTimeColumnName() != null && validationConfig.getTimeType() != null,
           "For APPEND use case, time column and type must be set");
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -126,7 +126,7 @@ public class IndexingConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use <code>List<Map<String, String>> streamConfigs</code> from {@link IngestionConfig#getStream()}
+   * @deprecated Use <code>List<Map<String, String>> streamConfigs</code> from {@link IngestionConfig#getStreamIngestionConfig()}
    */
   @Nullable
   public Map<String, String> getStreamConfigs() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -34,7 +34,7 @@ public class IndexingConfig extends BaseJsonConfig {
   private List<String> _bloomFilterColumns;
   private Map<String, BloomFilterConfig> _bloomFilterConfigs;
   private String _loadMode;
-  @Deprecated // Moved to IngestionConfigs#Stream
+  @Deprecated // Moved to {@link IngestionConfig#getStreamIngestionConfig}
   private Map<String, String> _streamConfigs;
   private String _segmentFormatVersion;
   private String _columnMinMaxValueGeneratorMode;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 
 
 public class IndexingConfig extends BaseJsonConfig {
@@ -33,6 +34,7 @@ public class IndexingConfig extends BaseJsonConfig {
   private List<String> _bloomFilterColumns;
   private Map<String, BloomFilterConfig> _bloomFilterConfigs;
   private String _loadMode;
+  @Deprecated // Moved to IngestionConfigs#Stream
   private Map<String, String> _streamConfigs;
   private String _segmentFormatVersion;
   private String _columnMinMaxValueGeneratorMode;
@@ -123,6 +125,9 @@ public class IndexingConfig extends BaseJsonConfig {
     _loadMode = loadMode;
   }
 
+  /**
+   * @deprecated Use <code>List<Map<String, String>> streamConfigs</code> from {@link IngestionConfig#getStream()}
+   */
   @Nullable
   public Map<String, String> getStreamConfigs() {
     return _streamConfigs;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -95,7 +95,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use <code>segmentPushFrequency</code> from {@link IngestionConfig#getBatchIngestionConfig()}
+   * @deprecated Use {@code segmentPushFrequency} from {@link IngestionConfig#getBatchIngestionConfig()}
    */
   public String getSegmentPushFrequency() {
     return _segmentPushFrequency;
@@ -106,7 +106,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use <code>segmentPushType</code> from {@link IngestionConfig#getBatchIngestionConfig()}
+   * @deprecated Use {@code segmentPushType} from {@link IngestionConfig#getBatchIngestionConfig()}
    */
   public String getSegmentPushType() {
     return _segmentPushType;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
 
 
@@ -29,7 +30,9 @@ import org.apache.pinot.spi.utils.TimeUtils;
 public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
+  @Deprecated
   private String _segmentPushFrequency; // DO NOT REMOVE, this is used in internal segment generation management
+  @Deprecated
   private String _segmentPushType;
   private String _replication;
   // For high-level consumers, the number of replicas should be same as num server instances
@@ -91,6 +94,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _retentionTimeValue = retentionTimeValue;
   }
 
+  /**
+   * @deprecated Use <code>segmentPushFrequency</code> from {@link IngestionConfig#getBatch()}
+   */
   public String getSegmentPushFrequency() {
     return _segmentPushFrequency;
   }
@@ -99,6 +105,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _segmentPushFrequency = segmentPushFrequency;
   }
 
+  /**
+   * @deprecated Use <code>segmentPushType</code> from {@link IngestionConfig#getBatch()}
+   */
   public String getSegmentPushType() {
     return _segmentPushType;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -95,7 +95,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use <code>segmentPushFrequency</code> from {@link IngestionConfig#getBatch()}
+   * @deprecated Use <code>segmentPushFrequency</code> from {@link IngestionConfig#getBatchIngestionConfig()}
    */
   public String getSegmentPushFrequency() {
     return _segmentPushFrequency;
@@ -106,7 +106,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use <code>segmentPushType</code> from {@link IngestionConfig#getBatch()}
+   * @deprecated Use <code>segmentPushType</code> from {@link IngestionConfig#getBatchIngestionConfig()}
    */
   public String getSegmentPushType() {
     return _segmentPushType;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Batch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Batch.java
@@ -24,12 +24,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 /**
  * Contains all configs related to the batch sources for ingestion.
  */
-public class Batch {
+public class Batch extends BaseJsonConfig {
 
   @JsonPropertyDescription("Configs for all the batch sources to ingest from")
   private final List<Map<String, String>> _batchConfigs;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Batch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Batch.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table.ingestion;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+/**
+ * Contains all configs related to the batch sources for ingestion.
+ */
+public class Batch {
+
+  @JsonPropertyDescription("Configs for all the batch sources to ingest from")
+  private final List<Map<String, String>> _batchConfigs;
+
+  @JsonPropertyDescription("Push type APPEND or REFRESH")
+  private final String _segmentPushType;
+
+  @JsonPropertyDescription("Push frequency HOURLY or DAILY")
+  private final String _segmentPushFrequency;
+
+  @JsonCreator
+  public Batch(@JsonProperty("batchConfigs") @Nullable List<Map<String, String>> batchConfigs,
+      @JsonProperty("segmentPushType") @Nullable String segmentPushType,
+      @JsonProperty("segmentPushFrequency") @Nullable String segmentPushFrequency) {
+    _batchConfigs = batchConfigs;
+    _segmentPushType = segmentPushType;
+    _segmentPushFrequency = segmentPushFrequency;
+  }
+
+  @Nullable
+  public List<Map<String, String>> getBatchConfigs() {
+    return _batchConfigs;
+  }
+
+  @Nullable
+  public String getSegmentPushType() {
+    return _segmentPushType;
+  }
+
+  @Nullable
+  public String getSegmentPushFrequency() {
+    return _segmentPushFrequency;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
@@ -42,7 +42,7 @@ public class BatchIngestionConfig extends BaseJsonConfig {
   private final String _segmentPushFrequency;
 
   @JsonCreator
-  public BatchIngestionConfig(@JsonProperty("batchConfigMaps") List<Map<String, String>> batchConfigMaps,
+  public BatchIngestionConfig(@JsonProperty("batchConfigMaps") @Nullable List<Map<String, String>> batchConfigMaps,
       @JsonProperty("segmentPushType") String segmentPushType,
       @JsonProperty("segmentPushFrequency") String segmentPushFrequency) {
     _batchConfigMaps = batchConfigMaps;
@@ -50,6 +50,7 @@ public class BatchIngestionConfig extends BaseJsonConfig {
     _segmentPushFrequency = segmentPushFrequency;
   }
 
+  @Nullable
   public List<Map<String, String>> getBatchConfigMaps() {
     return _batchConfigMaps;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
@@ -30,10 +30,10 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 /**
  * Contains all configs related to the batch sources for ingestion.
  */
-public class Batch extends BaseJsonConfig {
+public class BatchIngestionConfig extends BaseJsonConfig {
 
   @JsonPropertyDescription("Configs for all the batch sources to ingest from")
-  private final List<Map<String, String>> _batchConfigs;
+  private final List<Map<String, String>> _batchConfigMaps;
 
   @JsonPropertyDescription("Push type APPEND or REFRESH")
   private final String _segmentPushType;
@@ -42,25 +42,22 @@ public class Batch extends BaseJsonConfig {
   private final String _segmentPushFrequency;
 
   @JsonCreator
-  public Batch(@JsonProperty("batchConfigs") @Nullable List<Map<String, String>> batchConfigs,
-      @JsonProperty("segmentPushType") @Nullable String segmentPushType,
-      @JsonProperty("segmentPushFrequency") @Nullable String segmentPushFrequency) {
-    _batchConfigs = batchConfigs;
+  public BatchIngestionConfig(@JsonProperty("batchConfigMaps") List<Map<String, String>> batchConfigMaps,
+      @JsonProperty("segmentPushType") String segmentPushType,
+      @JsonProperty("segmentPushFrequency") String segmentPushFrequency) {
+    _batchConfigMaps = batchConfigMaps;
     _segmentPushType = segmentPushType;
     _segmentPushFrequency = segmentPushFrequency;
   }
 
-  @Nullable
-  public List<Map<String, String>> getBatchConfigs() {
-    return _batchConfigs;
+  public List<Map<String, String>> getBatchConfigMaps() {
+    return _batchConfigMaps;
   }
 
-  @Nullable
   public String getSegmentPushType() {
     return _segmentPushType;
   }
 
-  @Nullable
   public String getSegmentPushFrequency() {
     return _segmentPushFrequency;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.config.table;
+package org.apache.pinot.spi.config.table.ingestion;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,11 +29,15 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 
 
 /**
- * Class representing table ingestion configuration. For example, configs needed for
- * decoding, data source configs, ingestion transformations (flattening, filtering, transformations etc.)
- * TODO: Move fields from table config which are ingestion related (e.g. streamConfigs, segment push type, append freq etc)
+ * Class representing table ingestion configuration i.e. all configs related to the data source and the ingestion properties and operations
  */
 public class IngestionConfig extends BaseJsonConfig {
+
+  @JsonPropertyDescription("Config related to the batch data source")
+  private final Batch _batch;
+
+  @JsonPropertyDescription("Config related to the stream data source")
+  private final Stream _stream;
 
   @JsonPropertyDescription("Config related to filtering records during ingestion")
   private final FilterConfig _filterConfig;
@@ -42,10 +46,24 @@ public class IngestionConfig extends BaseJsonConfig {
   private final List<TransformConfig> _transformConfigs;
 
   @JsonCreator
-  public IngestionConfig(@JsonProperty("filterConfig") @Nullable FilterConfig filterConfig,
+  public IngestionConfig(@JsonProperty("batch") @Nullable Batch batch,
+      @JsonProperty("stream") @Nullable Stream stream,
+      @JsonProperty("filterConfig") @Nullable FilterConfig filterConfig,
       @JsonProperty("transformConfigs") @Nullable List<TransformConfig> transformConfigs) {
+    _batch = batch;
+    _stream = stream;
     _filterConfig = filterConfig;
     _transformConfigs = transformConfigs;
+  }
+
+  @Nullable
+  public Batch getBatch() {
+    return _batch;
+  }
+
+  @Nullable
+  public Stream getStream() {
+    return _stream;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
-import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
-import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 
 
 /**
@@ -33,11 +31,11 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
  */
 public class IngestionConfig extends BaseJsonConfig {
 
-  @JsonPropertyDescription("Config related to the batch data source")
-  private final Batch _batch;
+  @JsonPropertyDescription("Config related to the batch data sources")
+  private final BatchIngestionConfig _batchIngestionConfig;
 
-  @JsonPropertyDescription("Config related to the stream data source")
-  private final Stream _stream;
+  @JsonPropertyDescription("Config related to the stream data sources")
+  private final StreamIngestionConfig _streamIngestionConfig;
 
   @JsonPropertyDescription("Config related to filtering records during ingestion")
   private final FilterConfig _filterConfig;
@@ -46,24 +44,24 @@ public class IngestionConfig extends BaseJsonConfig {
   private final List<TransformConfig> _transformConfigs;
 
   @JsonCreator
-  public IngestionConfig(@JsonProperty("batch") @Nullable Batch batch,
-      @JsonProperty("stream") @Nullable Stream stream,
+  public IngestionConfig(@JsonProperty("batchIngestionConfig") @Nullable BatchIngestionConfig batchIngestionConfig,
+      @JsonProperty("streamIngestionConfig") @Nullable StreamIngestionConfig streamIngestionConfig,
       @JsonProperty("filterConfig") @Nullable FilterConfig filterConfig,
       @JsonProperty("transformConfigs") @Nullable List<TransformConfig> transformConfigs) {
-    _batch = batch;
-    _stream = stream;
+    _batchIngestionConfig = batchIngestionConfig;
+    _streamIngestionConfig = streamIngestionConfig;
     _filterConfig = filterConfig;
     _transformConfigs = transformConfigs;
   }
 
   @Nullable
-  public Batch getBatch() {
-    return _batch;
+  public BatchIngestionConfig getBatchIngestionConfig() {
+    return _batchIngestionConfig;
   }
 
   @Nullable
-  public Stream getStream() {
-    return _stream;
+  public StreamIngestionConfig getStreamIngestionConfig() {
+    return _streamIngestionConfig;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Stream.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Stream.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table.ingestion;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+/**
+ * Contains all the configs related to the streams for ingestion
+ */
+public class Stream {
+
+  @JsonPropertyDescription("All configs for the streams from which to ingest")
+  private final List<Map<String, String>> _streamConfigs;
+
+  @JsonCreator
+  public Stream(@JsonProperty("stream") @Nullable List<Map<String, String>> streamConfigs) {
+    _streamConfigs = streamConfigs;
+  }
+
+  @Nullable
+  public List<Map<String, String>> getStreamConfigs() {
+    return _streamConfigs;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Stream.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/Stream.java
@@ -24,18 +24,19 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 /**
  * Contains all the configs related to the streams for ingestion
  */
-public class Stream {
+public class Stream extends BaseJsonConfig {
 
   @JsonPropertyDescription("All configs for the streams from which to ingest")
   private final List<Map<String, String>> _streamConfigs;
 
   @JsonCreator
-  public Stream(@JsonProperty("stream") @Nullable List<Map<String, String>> streamConfigs) {
+  public Stream(@JsonProperty("streamConfigs") @Nullable List<Map<String, String>> streamConfigs) {
     _streamConfigs = streamConfigs;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -30,18 +30,17 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 /**
  * Contains all the configs related to the streams for ingestion
  */
-public class Stream extends BaseJsonConfig {
+public class StreamIngestionConfig extends BaseJsonConfig {
 
   @JsonPropertyDescription("All configs for the streams from which to ingest")
-  private final List<Map<String, String>> _streamConfigs;
+  private final List<Map<String, String>> _streamConfigMaps;
 
   @JsonCreator
-  public Stream(@JsonProperty("streamConfigs") @Nullable List<Map<String, String>> streamConfigs) {
-    _streamConfigs = streamConfigs;
+  public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {
+    _streamConfigMaps = streamConfigMaps;
   }
 
-  @Nullable
-  public List<Map<String, String>> getStreamConfigs() {
-    return _streamConfigs;
+  public List<Map<String, String>> getStreamConfigMaps() {
+    return _streamConfigMaps;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -47,35 +47,35 @@ public class BatchConfig {
     _type = batchConfigsMap.get(BatchConfigProperties.BATCH_TYPE);
     Preconditions.checkState(_type != null, "Property: %s cannot be null", BatchConfigProperties.BATCH_TYPE);
 
-    String inputDirURIKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.INPUT_DIR_URI);
+    String inputDirURIKey = BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.INPUT_DIR_URI);
     _inputDirURI = batchConfigsMap.get(inputDirURIKey);
     Preconditions.checkState(_inputDirURI != null, "Property: %s cannot be null", inputDirURIKey);
 
-    String outputDirURIKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.OUTPUT_DIR_URI);
+    String outputDirURIKey = BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.OUTPUT_DIR_URI);
     _outputDirURI = batchConfigsMap.get(outputDirURIKey);
     Preconditions.checkState(_outputDirURI != null, "Property: %s cannot be null", outputDirURIKey);
 
-    String fsClassNameKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.FS_CLASS);
+    String fsClassNameKey = BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.FS_CLASS);
     _fsClassName = batchConfigsMap.get(fsClassNameKey);
     Preconditions.checkState(_fsClassName != null, "Property: %s cannot be null", fsClassNameKey);
 
-    String inputFormatKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.INPUT_FORMAT);
+    String inputFormatKey = BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.INPUT_FORMAT);
     String inputFormat = batchConfigsMap.get(inputFormatKey);
     Preconditions.checkState(inputFormat != null, "Property: %s cannot be null", inputFormat);
     _inputFormat = FileFormat.valueOf(inputFormat.toUpperCase());
 
     String recordReaderClassNameKey =
-        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_CLASS);
+        BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.RECORD_READER_CLASS);
     _recordReaderClassName = batchConfigsMap.get(recordReaderClassNameKey);
     Preconditions.checkState(_recordReaderClassName != null, "Property: %s cannot be null", recordReaderClassNameKey);
 
     String recordReaderConfigClassNameKey =
-        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_CONFIG_CLASS);
+        BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.RECORD_READER_CONFIG_CLASS);
     _recordReaderConfigClassName = batchConfigsMap.get(recordReaderConfigClassNameKey);
 
-    String fsPropPrefix = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.FS_PROP_PREFIX);
+    String fsPropPrefix = BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.FS_PROP_PREFIX);
     String recordReaderPropPrefix =
-        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_PROP_PREFIX);
+        BatchConfigProperties.constructBatchProperty(_type, BatchConfigProperties.RECORD_READER_PROP_PREFIX);
     for (Map.Entry<String, String> entry : batchConfigsMap.entrySet()) {
       String key = entry.getKey();
       if (key.startsWith(fsPropPrefix)) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.ingestion.batch;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.data.readers.FileFormat;
+
+
+/**
+ * Provides all config related to the batch data source, as configured in the table config's ingestion config
+ */
+public class BatchConfig {
+  private final String _tableNameWithType;
+  private final String _type;
+  private final String _inputDirURI;
+  private final String _outputDirURI;
+  private final String _fsClassName;
+  private final Map<String, String> _fsProps = new HashMap<>();
+  private final FileFormat _inputFormat;
+  private final String _recordReaderClassName;
+  private final String _recordReaderConfigClassName;
+  private final Map<String, String> _recordReaderProps = new HashMap<>();
+
+  private final Map<String, String> _batchConfigMap = new HashMap<>();
+
+  public BatchConfig(String tableNameWithType, Map<String, String> batchConfigsMap) {
+    _tableNameWithType = tableNameWithType;
+
+    _type = batchConfigsMap.get(BatchConfigProperties.BATCH_TYPE);
+    Preconditions.checkState(_type != null, "Property: %s cannot be null", BatchConfigProperties.BATCH_TYPE);
+
+    String inputDirURIKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.INPUT_DIR_URI);
+    _inputDirURI = batchConfigsMap.get(inputDirURIKey);
+    Preconditions.checkState(_inputDirURI != null, "Property: %s cannot be null", inputDirURIKey);
+
+    String outputDirURIKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.OUTPUT_DIR_URI);
+    _outputDirURI = batchConfigsMap.get(outputDirURIKey);
+    Preconditions.checkState(_outputDirURI != null, "Property: %s cannot be null", outputDirURIKey);
+
+    String fsClassNameKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.FS_CLASS);
+    _fsClassName = batchConfigsMap.get(fsClassNameKey);
+    Preconditions.checkState(_fsClassName != null, "Property: %s cannot be null", fsClassNameKey);
+
+    String inputFormatKey = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.INPUT_FORMAT);
+    String inputFormat = batchConfigsMap.get(inputFormatKey);
+    Preconditions.checkState(inputFormat != null, "Property: %s cannot be null", inputFormat);
+    _inputFormat = FileFormat.valueOf(inputFormat.toUpperCase());
+
+    String recordReaderClassNameKey =
+        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_CLASS);
+    _recordReaderClassName = batchConfigsMap.get(recordReaderClassNameKey);
+    Preconditions.checkState(_recordReaderClassName != null, "Property: %s cannot be null", recordReaderClassNameKey);
+
+    String recordReaderConfigClassNameKey =
+        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_CONFIG_CLASS);
+    _recordReaderConfigClassName = batchConfigsMap.get(recordReaderConfigClassNameKey);
+
+    String fsPropPrefix = BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.FS_PROP_PREFIX);
+    String recordReaderPropPrefix =
+        BatchConfigProperties.constructStreamProperty(_type, BatchConfigProperties.RECORD_READER_PROP_PREFIX);
+    for (Map.Entry<String, String> entry : batchConfigsMap.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith(fsPropPrefix)) {
+        _fsProps.put(key, entry.getValue());
+      } else if (key.startsWith(recordReaderPropPrefix)) {
+        _recordReaderProps.put(key, entry.getValue());
+      }
+      _batchConfigMap.put(key, entry.getValue());
+    }
+  }
+
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public String getType() {
+    return _type;
+  }
+
+  public String getInputDirURI() {
+    return _inputDirURI;
+  }
+
+  public String getOutputDirURI() {
+    return _outputDirURI;
+  }
+
+  public String getFsClassName() {
+    return _fsClassName;
+  }
+
+  public Map<String, String> getFsProps() {
+    return _fsProps;
+  }
+
+  public FileFormat getInputFormat() {
+    return _inputFormat;
+  }
+
+  public String getRecordReaderClassName() {
+    return _recordReaderClassName;
+  }
+
+  public String getRecordReaderConfigClassName() {
+    return _recordReaderConfigClassName;
+  }
+
+  public Map<String, String> getRecordReaderProps() {
+    return _recordReaderProps;
+  }
+
+  public Map<String, String> getBatchConfigMap() {
+    return _batchConfigMap;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -42,7 +42,7 @@ public class BatchConfigProperties {
   /**
    * Helper method to create a batch config property
    */
-  public static String constructStreamProperty(String batchType, String property) {
+  public static String constructBatchProperty(String batchType, String property) {
     return StringUtils.join(BATCH_PREFIX, batchType, property, DOT_SEPARATOR);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.ingestion.batch;
+
+import org.apache.commons.lang3.StringUtils;
+
+
+/**
+ * Defines all the keys used in the batch configs map
+ */
+public class BatchConfigProperties {
+
+  public static final String DOT_SEPARATOR = ".";
+  public static final String BATCH_PREFIX = "batch";
+
+  public static final String BATCH_TYPE = "batchType";
+  public static final String INPUT_DIR_URI = "inputDirURI";
+  public static final String OUTPUT_DIR_URI = "outputDirURI";
+  public static final String FS_CLASS = "fs.className";
+  public static final String FS_PROP_PREFIX = "fs.prop";
+  public static final String INPUT_FORMAT = "inputFormat";
+  public static final String RECORD_READER_CLASS = "recordReader.className";
+  public static final String RECORD_READER_CONFIG_CLASS = "recordReader.config.className";
+  public static final String RECORD_READER_PROP_PREFIX = "recordReader.prop";
+
+  /**
+   * Helper method to create a batch config property
+   */
+  public static String constructStreamProperty(String batchType, String property) {
+    return StringUtils.join(BATCH_PREFIX, batchType, property, DOT_SEPARATOR);
+  }
+
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+
+
+/**
+ * Helper methods for extracting fields from IngestionConfig
+ */
+public final class IngestionConfigUtils {
+  /**
+   * Fetches the streamConfig from the given realtime table.
+   * First, the ingestionConfigs->stream->streamConfigs will be checked.
+   * If not found, the indexingConfig->streamConfigs will be checked (which is deprecated).
+   * @param tableConfig realtime table config
+   * @return streamConfigs map
+   */
+  public static Map<String, String> getStreamConfigMap(TableConfig tableConfig) {
+    String tableNameWithType = tableConfig.getTableName();
+    Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
+        "Cannot fetch streamConfigs for OFFLINE table: %s", tableNameWithType);
+    Map<String, String> streamConfigMap = null;
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getStreamIngestionConfig() != null) {
+      List<Map<String, String>> streamConfigMaps = tableConfig.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps();
+      Preconditions.checkState(streamConfigMaps.size() == 1, "Only 1 stream supported per table");
+      streamConfigMap = streamConfigMaps.get(0);
+    }
+    if (streamConfigMap == null && tableConfig.getIndexingConfig() != null) {
+      streamConfigMap = tableConfig.getIndexingConfig().getStreamConfigs();
+    }
+    if (streamConfigMap == null) {
+      throw new IllegalStateException("Could not find streamConfigs for REALTIME table: " + tableNameWithType);
+    }
+    return streamConfigMap;
+  }
+
+  /**
+   * Fetches the configured segmentPushType (APPEND/REFRESH) from the table config
+   * First checks in the ingestionConfig. If not found, checks in the segmentsConfig (has been deprecated from here in favor of ingestion config)
+   */
+  public static String getBatchSegmentPushType(TableConfig tableConfig) {
+    String segmentPushType = null;
+    if (tableConfig.getIngestionConfig() != null) {
+      BatchIngestionConfig batchIngestionConfig = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+      if (batchIngestionConfig != null) {
+        segmentPushType = batchIngestionConfig.getSegmentPushType();
+      }
+    }
+    if (segmentPushType == null) {
+      segmentPushType = tableConfig.getValidationConfig().getSegmentPushType();
+    }
+    return segmentPushType;
+  }
+
+  /**
+   * Fetches the configured segmentPushFrequency from the table config
+   * First checks in the ingestionConfig. If not found, checks in the segmentsConfig (has been deprecated from here in favor of ingestion config)
+   */
+  public static String getBatchSegmentPushFrequency(TableConfig tableConfig) {
+    String segmentPushFrequency = null;
+    if (tableConfig.getIngestionConfig() != null) {
+      BatchIngestionConfig batchIngestionConfig = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+      if (batchIngestionConfig != null) {
+        segmentPushFrequency = batchIngestionConfig.getSegmentPushFrequency();
+      }
+    }
+    if (segmentPushFrequency == null) {
+      segmentPushFrequency = tableConfig.getValidationConfig().getSegmentPushFrequency();
+    }
+    return segmentPushFrequency;
+  }
+
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 
 
 /**
- * Helper methods for extracting fields from IngestionConfig
+ * Helper methods for extracting fields from IngestionConfig in a backward compatible manner
  */
 public final class IngestionConfigUtils {
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
-import org.apache.pinot.spi.config.table.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
@@ -48,27 +48,27 @@ public class BatchConfigTest {
     String separator = "|";
     batchConfigMap.put(BatchConfigProperties.BATCH_TYPE, batchType);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_DIR_URI), inputDir);
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.INPUT_DIR_URI), inputDir);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI), outputDir);
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI), outputDir);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_CLASS), fsClass);
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_CLASS), fsClass);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT), inputFormat);
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.INPUT_FORMAT), inputFormat);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS),
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS),
             recordReaderClass);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS),
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS),
             recordReaderConfigClass);
     batchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region",
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region",
             region);
     batchConfigMap.put(
-        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username",
+        BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username",
         username);
     batchConfigMap.put(
-        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
+        BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
             + ".separator", separator);
 
     // config with all the right properties
@@ -82,14 +82,14 @@ public class BatchConfigTest {
     assertEquals(batchConfig.getRecordReaderConfigClassName(), recordReaderConfigClass);
     assertEquals(batchConfig.getFsProps().size(), 2);
     assertEquals(batchConfig.getFsProps().get(
-        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region"),
+        BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region"),
         region);
     assertEquals(batchConfig.getFsProps().get(
-        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username"),
+        BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username"),
         username);
     assertEquals(batchConfig.getRecordReaderProps().size(), 1);
     assertEquals(batchConfig.getRecordReaderProps().get(
-        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
+        BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
             + ".separator"), separator);
     assertEquals(batchConfig.getTableNameWithType(), tableName);
 
@@ -105,7 +105,7 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_DIR_URI));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.INPUT_DIR_URI));
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for missing 'inputDirURI");
@@ -115,7 +115,7 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI));
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for missing 'outputDirURI");
@@ -125,7 +125,7 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.INPUT_FORMAT));
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for missing 'inputFormat");
@@ -135,7 +135,7 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT), "moo");
+        .put(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.INPUT_FORMAT), "moo");
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for incorrect 'inputFormat");
@@ -145,7 +145,7 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS));
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for missing 'recordReaderClassName");
@@ -155,12 +155,12 @@ public class BatchConfigTest {
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS));
     new BatchConfig(tableName, testBatchConfigMap);
 
     testBatchConfigMap = new HashMap<>(batchConfigMap);
     testBatchConfigMap
-        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_CLASS));
+        .remove(BatchConfigProperties.constructBatchProperty(batchType, BatchConfigProperties.FS_CLASS));
     try {
       new BatchConfig(tableName, testBatchConfigMap);
       Assert.fail("Should fail for missing 'fsClassName");

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.ingestion.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.data.readers.FileFormat;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests for BatchConfigs
+ */
+public class BatchConfigTest {
+
+  @Test
+  public void testBatchConfig() {
+    Map<String, String> batchConfigMap = new HashMap<>();
+    String tableName = "foo_REALTIME";
+    String batchType = "s3";
+    String inputDir = "s3://foo/input";
+    String outputDir = "s3://foo/output";
+    String fsClass = "org.apache.S3FS";
+    String region = "us-west";
+    String username = "foo";
+    String inputFormat = "csv";
+    String recordReaderClass = "org.foo.CSVRecordReader";
+    String recordReaderConfigClass = "org.foo.CSVRecordReaderConfig";
+    String separator = "|";
+    batchConfigMap.put(BatchConfigProperties.BATCH_TYPE, batchType);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_DIR_URI), inputDir);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI), outputDir);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_CLASS), fsClass);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT), inputFormat);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS),
+            recordReaderClass);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS),
+            recordReaderConfigClass);
+    batchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region",
+            region);
+    batchConfigMap.put(
+        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username",
+        username);
+    batchConfigMap.put(
+        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
+            + ".separator", separator);
+
+    // config with all the right properties
+    BatchConfig batchConfig = new BatchConfig(tableName, batchConfigMap);
+    assertEquals(batchConfig.getType(), batchType);
+    assertEquals(batchConfig.getInputDirURI(), inputDir);
+    assertEquals(batchConfig.getOutputDirURI(), outputDir);
+    assertEquals(batchConfig.getFsClassName(), fsClass);
+    assertEquals(batchConfig.getInputFormat(), FileFormat.CSV);
+    assertEquals(batchConfig.getRecordReaderClassName(), recordReaderClass);
+    assertEquals(batchConfig.getRecordReaderConfigClassName(), recordReaderConfigClass);
+    assertEquals(batchConfig.getFsProps().size(), 2);
+    assertEquals(batchConfig.getFsProps().get(
+        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".region"),
+        region);
+    assertEquals(batchConfig.getFsProps().get(
+        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_PROP_PREFIX) + ".username"),
+        username);
+    assertEquals(batchConfig.getRecordReaderProps().size(), 1);
+    assertEquals(batchConfig.getRecordReaderProps().get(
+        BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_PROP_PREFIX)
+            + ".separator"), separator);
+    assertEquals(batchConfig.getTableNameWithType(), tableName);
+
+    // Missing props
+    Map<String, String> testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap.remove(BatchConfigProperties.BATCH_TYPE);
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'batchType");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_DIR_URI));
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'inputDirURI");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.OUTPUT_DIR_URI));
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'outputDirURI");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT));
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'inputFormat");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .put(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.INPUT_FORMAT), "moo");
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for incorrect 'inputFormat");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CLASS));
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'recordReaderClassName");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.RECORD_READER_CONFIG_CLASS));
+    new BatchConfig(tableName, testBatchConfigMap);
+
+    testBatchConfigMap = new HashMap<>(batchConfigMap);
+    testBatchConfigMap
+        .remove(BatchConfigProperties.constructStreamProperty(batchType, BatchConfigProperties.FS_CLASS));
+    try {
+      new BatchConfig(tableName, testBatchConfigMap);
+      Assert.fail("Should fail for missing 'fsClassName");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
@@ -101,11 +101,8 @@ public class IngestionConfigUtilsTest {
   public void testGetPushFrequency() {
     // get from ingestion config, when not present in segmentsConfig
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put("batchType", "s3");
-    tableConfig.setIngestionConfig(
-        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null,
-            null, null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null));
     Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "HOURLY");
 
     // get from ingestion config, even if present in segmentsConfig
@@ -129,11 +126,8 @@ public class IngestionConfigUtilsTest {
   public void testGetPushType() {
     // get from ingestion config, when not present in segmentsConfig
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put("batchType", "s3");
-    tableConfig.setIngestionConfig(
-        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null, null,
-            null));
+    tableConfig
+        .setIngestionConfig(new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null));
     Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "APPEND");
 
     // get from ingestion config, even if present in segmentsConfig

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import com.google.common.collect.Lists;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for helper methods in {@link IngestionConfigUtils}
+ */
+public class IngestionConfigUtilsTest {
+
+  @Test
+  public void testGetStreamConfigMap() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    try {
+      IngestionConfigUtils.getStreamConfigMap(tableConfig);
+      Assert.fail("Should fail for OFFLINE table");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").setTimeColumnName("timeColumn").build();
+
+    // get from ingestion config (when not present in indexing config)
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(null, new StreamIngestionConfig(Lists.newArrayList(streamConfigMap)), null, null));
+    Map<String, String> actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
+    Assert.assertEquals(actualStreamConfigsMap.size(), 1);
+    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "kafka");
+
+    // get from ingestion config (even if present in indexing config)
+    Map<String, String> deprecatedStreamConfigMap = new HashMap<>();
+    deprecatedStreamConfigMap.put("streamType", "foo");
+    deprecatedStreamConfigMap.put("customProp", "foo");
+    IndexingConfig indexingConfig = new IndexingConfig();
+    indexingConfig.setStreamConfigs(deprecatedStreamConfigMap);
+    tableConfig.setIndexingConfig(indexingConfig);
+    actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
+    Assert.assertEquals(actualStreamConfigsMap.size(), 1);
+    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "kafka");
+
+    // fail if multiple found
+    tableConfig.setIngestionConfig(new IngestionConfig(null,
+        new StreamIngestionConfig(Lists.newArrayList(streamConfigMap, deprecatedStreamConfigMap)), null, null));
+    try {
+      IngestionConfigUtils.getStreamConfigMap(tableConfig);
+      Assert.fail("Should fail for multiple stream configs");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // get from indexing config
+    tableConfig.setIngestionConfig(null);
+    actualStreamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
+    Assert.assertEquals(actualStreamConfigsMap.size(), 2);
+    Assert.assertEquals(actualStreamConfigsMap.get("streamType"), "foo");
+
+    // fail if found nowhere
+    tableConfig.setIndexingConfig(null);
+    try {
+      IngestionConfigUtils.getStreamConfigMap(tableConfig);
+      Assert.fail("Should fail for no stream config found");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testGetPushFrequency() {
+    // get from ingestion config, when not present in segmentsConfig
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    Map<String, String> batchConfigMap = new HashMap<>();
+    batchConfigMap.put("batchType", "s3");
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null,
+            null, null));
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "HOURLY");
+
+    // get from ingestion config, even if present in segmentsConfig
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
+        new SegmentsValidationAndRetentionConfig();
+    segmentsValidationAndRetentionConfig.setSegmentPushFrequency("DAILY");
+    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "HOURLY");
+
+    // get from segmentsConfig
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig), "DAILY");
+
+    // present nowhere
+    segmentsValidationAndRetentionConfig.setSegmentPushFrequency(null);
+    Assert.assertNull(IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig));
+  }
+
+  @Test
+  public void testGetPushType() {
+    // get from ingestion config, when not present in segmentsConfig
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    Map<String, String> batchConfigMap = new HashMap<>();
+    batchConfigMap.put("batchType", "s3");
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap), "APPEND", "HOURLY"), null, null,
+            null));
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "APPEND");
+
+    // get from ingestion config, even if present in segmentsConfig
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
+        new SegmentsValidationAndRetentionConfig();
+    segmentsValidationAndRetentionConfig.setSegmentPushType("REFRESH");
+    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "APPEND");
+
+    // get from segmentsConfig
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    Assert.assertEquals(IngestionConfigUtils.getBatchSegmentPushType(tableConfig), "REFRESH");
+
+    // present nowhere
+    segmentsValidationAndRetentionConfig.setSegmentPushType(null);
+    Assert.assertNull(IngestionConfigUtils.getBatchSegmentPushType(tableConfig));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.minion.rollup.MergeType;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
+import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -238,8 +239,8 @@ public class SegmentMergeCommand extends AbstractBaseAdminCommand implements Com
 
     // Fetch time related configurations from schema and table config.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String pushFrequency = validationConfig.getSegmentPushFrequency();
-    String pushType = validationConfig.getSegmentPushType();
+    String pushFrequency = IngestionUtils.getBatchSegmentPushFrequency(tableConfig);
+    String pushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
     String timeColumnName = validationConfig.getTimeColumnName();
     DateTimeFormatSpec dateTimeFormatSpec = null;
     if (timeColumnName != null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
@@ -34,12 +34,12 @@ import org.apache.pinot.core.minion.rollup.MergeType;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.name.NormalizedDateSegmentNameGenerator;
-import org.apache.pinot.core.util.IngestionUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.tools.Command;
@@ -239,8 +239,8 @@ public class SegmentMergeCommand extends AbstractBaseAdminCommand implements Com
 
     // Fetch time related configurations from schema and table config.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String pushFrequency = IngestionUtils.getBatchSegmentPushFrequency(tableConfig);
-    String pushType = IngestionUtils.getBatchSegmentPushType(tableConfig);
+    String pushFrequency = IngestionConfigUtils.getBatchSegmentPushFrequency(tableConfig);
+    String pushType = IngestionConfigUtils.getBatchSegmentPushType(tableConfig);
     String timeColumnName = validationConfig.getTimeColumnName();
     DateTimeFormatSpec dateTimeFormatSpec = null;
     if (timeColumnName != null) {


### PR DESCRIPTION
## Description
https://github.com/apache/incubator-pinot/issues/6242
Moving streamConfigs to the ingestionConfig.
Adding batchConfig, very similar to streamConfig into the ingestionConfig.
Moved segmentPushType and segmentPushFrequency to the batchConfig.



## Release Notes
Moved streamConfigs to ingestionConfigs. 
Added batchConfigs, which are very similar to streamConfigs, but for batch sources.
Deprecated indexingConfig -> streamConfigs, segmentsConfig -> segmentPushType and segmentsConfig -> segmentPushFrequency.


