### PR TITLE
Make default operator for multi-term and phrase text search queries configurable

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -230,6 +230,10 @@ public class IndexLoadingConfig {
     return _columnProperties;
   }
 
+  public void setColumnProperties(Map<String, Map<String, String>> columnProperties) {
+    _columnProperties = columnProperties;
+  }
+
   /**
    * Used in two places:
    * (1) In {@link org.apache.pinot.core.segment.index.column.PhysicalColumnIndexContainer}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.queries;
 
-import it.unimi.dsi.fastutil.Hash;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.queries;
 
+import it.unimi.dsi.fastutil.Hash;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,8 +28,10 @@ import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
@@ -91,8 +94,10 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
   private static final String QUERY_LOG_TEXT_COL_NAME = "QUERY_LOG_TEXT_COL";
   private static final String SKILLS_TEXT_COL_NAME = "SKILLS_TEXT_COL";
   private static final String SKILLS_TEXT_COL_DICT_NAME = "SKILLS_TEXT_COL_DICT";
+  private static final String SKILLS_COPY_TEXT_COL_NAME = "SKILLS_TEXT_COL_1";
   private static final String INT_COL_NAME = "INT_COL";
-  private static final List<String> RAW_TEXT_INDEX_COLUMNS = Arrays.asList(QUERY_LOG_TEXT_COL_NAME, SKILLS_TEXT_COL_NAME);
+  private static final List<String> RAW_TEXT_INDEX_COLUMNS =
+      Arrays.asList(QUERY_LOG_TEXT_COL_NAME, SKILLS_TEXT_COL_NAME, SKILLS_COPY_TEXT_COL_NAME);
   private static final List<String> DICT_TEXT_INDEX_COLUMNS = Arrays.asList(SKILLS_TEXT_COL_DICT_NAME);
   private static final int INT_BASE_VALUE = 1000;
 
@@ -128,6 +133,11 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
     textIndexColumns.addAll(DICT_TEXT_INDEX_COLUMNS);
     indexLoadingConfig.setTextIndexColumns(textIndexColumns);
     indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(DICT_TEXT_INDEX_COLUMNS));
+    Map<String, Map<String, String>> columnProperties = new HashMap<>();
+    Map<String, String> props = new HashMap<>();
+    props.put(FieldConfig.TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES, "true");
+    columnProperties.put(SKILLS_COPY_TEXT_COL_NAME, props);
+    indexLoadingConfig.setColumnProperties(columnProperties);
     ImmutableSegment immutableSegment =
         ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
     _indexSegment = immutableSegment;
@@ -160,6 +170,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
         .addSingleValueDimension(QUERY_LOG_TEXT_COL_NAME, FieldSpec.DataType.STRING)
         .addSingleValueDimension(SKILLS_TEXT_COL_NAME, FieldSpec.DataType.STRING)
         .addSingleValueDimension(SKILLS_TEXT_COL_DICT_NAME, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(SKILLS_COPY_TEXT_COL_NAME, FieldSpec.DataType.STRING)
         .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR.getPath());
@@ -204,9 +215,11 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
         if (counter >= skillCount) {
           row.putField(SKILLS_TEXT_COL_NAME, "software engineering");
           row.putField(SKILLS_TEXT_COL_DICT_NAME, "software engineering");
+          row.putField(SKILLS_COPY_TEXT_COL_NAME, "software engineering");
         } else {
           row.putField(SKILLS_TEXT_COL_NAME, skills[counter]);
           row.putField(SKILLS_TEXT_COL_DICT_NAME, skills[counter]);
+          row.putField(SKILLS_COPY_TEXT_COL_NAME, skills[counter]);
         }
         rows.add(row);
         counter++;
@@ -542,8 +555,18 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
 
     query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" AND Java AND C++') LIMIT 50000";
     testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
-
     query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" AND Java AND C++') LIMIT 50000";
+    testTextSearchAggregationQueryHelper(query, expected.size());
+
+    // test for the index configured to use AND as the default
+    // conjunction operator
+    query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" Java C++') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
+    query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" Java C++') LIMIT 50000";
+    testTextSearchAggregationQueryHelper(query, expected.size());
+    query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND Java AND C++') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
+    query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND Java AND C++') LIMIT 50000";
     testTextSearchAggregationQueryHelper(query, expected.size());
 
     // TEST 22: composite phrase and term query using boolean operator OR
@@ -569,8 +592,14 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
 
     query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" Java C++') LIMIT 50000";
     testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
-
     query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" Java C++') LIMIT 50000";
+    testTextSearchAggregationQueryHelper(query, expected.size());
+
+    // test for the index configured to use AND as the default
+    // conjunction operator
+    query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" OR Java OR C++') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
+    query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" OR Java OR C++') LIMIT 50000";
     testTextSearchAggregationQueryHelper(query, expected.size());
 
     // TEST 23: composite phrase and term query using both AND and OR
@@ -585,8 +614,21 @@ public class TextSearchQueriesTest extends BaseQueriesTest {  private static fin
 
     query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" AND (Java C++)') LIMIT 50000";
     testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
-
     query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '\"distributed systems\" AND (Java C++)') LIMIT 50000";
+    testTextSearchAggregationQueryHelper(query, expected.size());
+
+    // test for the index configured to use AND as the default
+    // conjunction operator
+    query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND (Java OR C++)') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
+    query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND (Java OR C++)') LIMIT 50000";
+    testTextSearchAggregationQueryHelper(query, expected.size());
+    expected = new ArrayList<>();
+    expected.add(new Serializable[]{1005, "Distributed systems, Java, C++, Go, distributed query engines for analytics and data warehouses, Machine learning, spark, Kubernetes, transaction processing"});
+    expected.add(new Serializable[]{1017, "Distributed systems, Apache Kafka, publish-subscribe, building and deploying large scale production systems, concurrency, multi-threading, C++, CPU processing, Java"});
+    query = "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND (Java C++)') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
+    query = "SELECT COUNT(*) FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL_1, '\"distributed systems\" AND (Java C++)') LIMIT 50000";
     testTextSearchAggregationQueryHelper(query, expected.size());
 
     // TEST 24: prefix query

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -43,6 +43,7 @@ public class FieldConfig extends BaseJsonConfig {
   // Lucene creates a query result cache if this option is enabled
   // the cache improves performance of repeatable queries
   public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "enableQueryCacheForTextIndex";
+  public static String TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES = "useANDForMultiTermTextIndexQueries";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,


### PR DESCRIPTION
Multi term or phrase queries for text index like the following use implicit OR operator (Lucene default)

- WHERE text_match(col, 't1 t2 \"p1\" \"p2\") is equivalent to WHERE text_match(col, 't1 OR t2 OR \"p1\" OR  \"p2\")

Minor enhancement - We need to make the default operator (OR) configurable on a per text index basis. This was recently requested as our internal users ramp this feature. 