### PR TITLE
Replace sql literal regex replace

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -112,7 +112,7 @@ public class RequestUtils {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
     } else {
-      literal.setStringValue(node.toString().replaceAll("^'|'$", "").replace("''", "'"));
+      literal.setStringValue(node.toValue().replace("''", "'"));
     }
     expression.setLiteral(literal);
     return expression;


### PR DESCRIPTION
## Description
Replace sql literal regex replace of single quote by using `SqlLiteral.toValue()` method.
 