### PR TITLE
Broker time range pruning(#6189)

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
@@ -570,14 +570,14 @@ public class RoutingManager implements ClusterChangeHandler {
     }
 
     InstanceSelector.SelectionResult calculateRouting(BrokerRequest brokerRequest) {
-      List<String> selectedSegments = _segmentSelector.select(brokerRequest);
+      Set<String> selectedSegments = _segmentSelector.select(brokerRequest);
       if (!selectedSegments.isEmpty()) {
         for (SegmentPruner segmentPruner : _segmentPruners) {
           selectedSegments = segmentPruner.prune(brokerRequest, selectedSegments);
         }
       }
       if (!selectedSegments.isEmpty()) {
-        return _instanceSelector.select(brokerRequest, selectedSegments);
+        return _instanceSelector.select(brokerRequest, new ArrayList<>(selectedSegments));
       } else {
         return new InstanceSelector.SelectionResult(Collections.emptyMap(), Collections.emptyList());
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -25,8 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.routing.segmentpruner;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +69,7 @@ public class PartitionSegmentPruner implements SegmentPruner {
   public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
     // Bulk load partition info for all online segments
     int numSegments = onlineSegments.size();
-    List<String> segments = new ArrayList<>(onlineSegments);
+    List<String> segments = new ArrayList<>(numSegments);
     List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
     for (String segment : onlineSegments) {
       segments.add(segment);
@@ -148,12 +149,12 @@ public class PartitionSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public List<String> prune(BrokerRequest brokerRequest, List<String> segments) {
+  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
     FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
     if (filterQueryTree == null) {
       return segments;
     }
-    List<String> selectedSegments = new ArrayList<>();
+    Set<String> selectedSegments = new HashSet<>();
     for (String segment : segments) {
       PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
       if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterQueryTree,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.broker.routing.segmentpruner;
 
-import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -51,5 +50,5 @@ public interface SegmentPruner {
   /**
    * Prunes the segments queried by the given broker request, returns the selected segments to be queried.
    */
-  List<String> prune(BrokerRequest brokerRequest, List<String> segments);
+  Set<String> prune(BrokerRequest brokerRequest, Set<String> segments);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -1,0 +1,346 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpruner;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
+import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.request.FilterQueryTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code TimeSegmentPruner} prunes segments based on their time column start & end time metadata stored in ZK. The pruner
+ * supports queries with filter (or nested filter) of EQUALITY and RANGE predicates.
+ */
+public class TimeSegmentPruner implements SegmentPruner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeSegmentPruner.class);
+  private static final long MIN_START_TIME = 0;
+  private static final long MAX_END_TIME = Long.MAX_VALUE;
+  private static final Interval DEFAULT_INTERVAL = new Interval(MIN_START_TIME, MAX_END_TIME);
+  private static final char DELIMITER = '\0';
+  private static final String LEGACY_DELIMITER = "\t\t";
+  private static final char START_INCLUSIVE = '(';
+  private static final char END_INCLUSIVE = ')';
+  private static final String UNBOUNDED = "*";
+
+  private final String _tableNameWithType;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String _segmentZKMetadataPathPrefix;
+  private final String _timeColumn;
+  private final DateTimeFormatSpec _timeFormatSpec;
+
+  private volatile IntervalTree<String> _intervalTree;
+  private final Map<String, Interval> _intervalMap = new HashMap<>();
+
+  public TimeSegmentPruner(TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableNameWithType = tableConfig.getTableName();
+    _propertyStore = propertyStore;
+    _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(_tableNameWithType) + "/";
+    _timeColumn = tableConfig.getValidationConfig().getTimeColumnName();
+    Preconditions
+        .checkNotNull(_timeColumn, "Time column must be configured in table config for table: %s", _tableNameWithType);
+
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    Preconditions.checkNotNull(schema, "Failed to find schema for table: %s", _tableNameWithType);
+    DateTimeFieldSpec dateTimeSpec = schema.getSpecForTimeColumn(_timeColumn);
+    Preconditions.checkNotNull(dateTimeSpec, "Field spec must be specified in schema for time column: %s of table: %s",
+        _timeColumn, _tableNameWithType);
+    _timeFormatSpec = new DateTimeFormatSpec(dateTimeSpec.getFormat());
+  }
+
+  @Override
+  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+    // Bulk load time info for all online segments
+    int numSegments = onlineSegments.size();
+    List<String> segments = new ArrayList<>(numSegments);
+    List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
+    for (String segment : segments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT, false);
+    for (int i = 0; i < numSegments; i++) {
+      String segment = segments.get(i);
+      Interval interval = extractIntervalFromSegmentZKMetaZNRecord(segment, znRecords.get(i));
+      _intervalMap.put(segment, interval);
+    }
+    _intervalTree = new IntervalTree<>(_intervalMap);
+  }
+
+  private Interval extractIntervalFromSegmentZKMetaZNRecord(String segment, @Nullable ZNRecord znRecord) {
+    // Segments without metadata or with invalid time interval will be set with [min_start, max_end] and will not be pruned
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return DEFAULT_INTERVAL;
+    }
+
+    long startTime = znRecord.getLongField(CommonConstants.Segment.START_TIME, -1);
+    long endTime = znRecord.getLongField(CommonConstants.Segment.END_TIME, -1);
+    if (startTime < 0 || endTime < 0 || startTime > endTime) {
+      LOGGER.warn("Failed to find valid time interval for segment: {}, table: {}", segment, _tableNameWithType);
+      return DEFAULT_INTERVAL;
+    }
+
+    TimeUnit timeUnit = znRecord.getEnumField(CommonConstants.Segment.TIME_UNIT, TimeUnit.class, TimeUnit.DAYS);
+    return new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime));
+  }
+
+  @Override
+  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+    // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
+    //       ones. The refreshed segment ZK metadata change won't be picked up.
+    for (String segment : onlineSegments) {
+      _intervalMap.computeIfAbsent(segment, k -> extractIntervalFromSegmentZKMetaZNRecord(k,
+          _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT)));
+    }
+    _intervalMap.keySet().retainAll(onlineSegments);
+    _intervalTree = new IntervalTree<>(_intervalMap);
+  }
+
+
+  @Override
+  public synchronized void refreshSegment(String segment) {
+    Interval interval = extractIntervalFromSegmentZKMetaZNRecord(segment, _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+    _intervalMap.put(segment, interval);
+    _intervalTree = new IntervalTree<>(_intervalMap);
+  }
+
+  /**
+   * NOTE: Pruning is done by searching _intervalTree based on request time interval and check if the results
+   *       are in the input segments. By doing so we will have run time O(M * logN) (N: # of all online segments,
+   *       M: # of qualified intersected segments).
+   */
+  @Override
+  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+    IntervalTree<String> intervalTree = _intervalTree;
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    if (filterQueryTree == null) {
+      return segments;
+    }
+    List<Interval> intervals = getFilterTimeIntervals(filterQueryTree);
+    if (intervals == null) { // cannot prune based on time for input request
+      return segments;
+    }
+    if (intervals.isEmpty()) { // invalid query time interval
+      return Collections.emptySet();
+    }
+
+    Set<String> selectedSegments = new HashSet<>();
+    for (Interval interval : intervals) {
+      for (String segment : intervalTree.searchAll(interval)) {
+        if (segments.contains(segment)) {
+          selectedSegments.add(segment);
+        }
+      }
+    }
+    return selectedSegments;
+  }
+
+  /**
+   * @return Null if no time condition or cannot filter base on the condition (e.g. 'SELECT * from myTable where time < 50 OR firstName = Jason')
+   * @return Empty list if time condition is specified but invalid (e.g. 'SELECT * from myTable where time < 50 AND time > 100')
+   */
+  @Nullable
+  private List<Interval> getFilterTimeIntervals(FilterQueryTree filterQueryTree) {
+    switch (filterQueryTree.getOperator()) {
+      case AND:
+        List<List<Interval>> andIntervals = new ArrayList<>();
+        for (FilterQueryTree child : filterQueryTree.getChildren()) {
+          List<Interval> childIntervals = getFilterTimeIntervals(child);
+          if (childIntervals != null) {
+            if (childIntervals.isEmpty()) {
+              return Collections.emptyList();
+            }
+            andIntervals.add(childIntervals);
+          }
+        }
+        if (andIntervals.isEmpty()) {
+          return null;
+        }
+        return getIntersectionSortedIntervals(andIntervals);
+      case OR:
+        List<List<Interval>> orIntervals = new ArrayList<>();
+        for (FilterQueryTree child : filterQueryTree.getChildren()) {
+          List<Interval> childIntervals = getFilterTimeIntervals(child);
+          if (childIntervals == null) {
+            return null;
+          } else {
+            orIntervals.add(childIntervals);
+          }
+        }
+        return getUnionSortedIntervals(orIntervals);
+      case EQUALITY:
+        if (filterQueryTree.getColumn().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(filterQueryTree.getValue().get(0));
+          return Collections.singletonList(new Interval(timeStamp, timeStamp));
+        }
+        return null;
+      case RANGE:
+        if (filterQueryTree.getColumn().equals(_timeColumn)) {
+          return parseInterval(filterQueryTree.getValue());
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  private List<Interval> getIntersectionSortedIntervals(List<List<Interval>> intervals) {
+    // Requires input intervals are sorted, the return intervals will be sorted
+    return getIntersectionSortedIntervals(intervals, 0, intervals.size());
+  }
+
+  private List<Interval> getIntersectionSortedIntervals(List<List<Interval>> intervals, int start, int end) {
+    if (start + 1 == end) {
+      return intervals.get(start);
+    }
+
+    int mid = start + (end - start) / 2;
+    List<Interval> interval1 = getIntersectionSortedIntervals(intervals, start, mid);
+    List<Interval> interval2 = getIntersectionSortedIntervals(intervals, mid, end);
+    return getIntersectionTwoSortedIntervals(interval1, interval2);
+  }
+
+  /**
+   * Intersect two list of non-overlapping sorted intervals.
+   * E.g. {[1, 3], [4, 6], [7, 8], [10, 10]} and {[2, 5], [7, 9]} are merged as {[2, 3], [4, 5], [7, 8]}
+   */
+  private List<Interval> getIntersectionTwoSortedIntervals(List<Interval> intervals1, List<Interval> intervals2) {
+    List<Interval> res = new ArrayList<>();
+    int size1 = intervals1.size();
+    int size2 = intervals2.size();
+    int i = 0;
+    int j = 0;
+    while (i < size1 && j < size2) {
+      Interval interval1 = intervals1.get(i);
+      Interval interval2 = intervals2.get(j);
+      if (interval1.intersects(interval2)) {
+        res.add(Interval.getIntersection(interval1, interval2));
+      }
+      if (interval1._max <= interval2._max) {
+        i++;
+      } else {
+        j++;
+      }
+    }
+    return res;
+  }
+
+  private List<Interval> getUnionSortedIntervals(List<List<Interval>> intervals) {
+    // Requires input intervals are sorted, the return intervals will be sorted
+    return getUnionSortedIntervals(intervals, 0, intervals.size());
+  }
+
+  private List<Interval> getUnionSortedIntervals(List<List<Interval>> intervals, int start, int end) {
+    if (start + 1 == end) {
+      return intervals.get(start);
+    }
+
+    int mid = start + (end - start) / 2;
+    List<Interval> intervals1 = getUnionSortedIntervals(intervals, start, mid);
+    List<Interval> intervals2 = getUnionSortedIntervals(intervals, mid, end);
+    return getUnionTwoSortedIntervals(intervals1, intervals2);
+  }
+
+  /**
+   * Union two list of non-overlapping sorted intervals.
+   * E.g. {[1, 2], [5, 7], [9, 10]} and {[2, 3], [4, 8]} are merged as {[1, 3], [4, 8], [9, 10]}
+   */
+  private List<Interval> getUnionTwoSortedIntervals(List<Interval> intervals1, List<Interval> intervals2) {
+    List<Interval> res = new ArrayList<>();
+    int size1 = intervals1.size();
+    int size2 = intervals2.size();
+    int i = 0;
+    int j = 0;
+    while (i < size1 || j < size2) {
+      // Get the `smaller` interval
+      Interval interval = null;
+      if (j == size2 || i < size1 && intervals1.get(i).compareTo(intervals2.get(j)) <= 0) {
+        interval = intervals1.get(i++);
+      } else {
+        interval = intervals2.get(j++);
+      }
+      // If not overlapping with current result, add as a new interval
+      int resSize = res.size();
+      if (res.isEmpty() || !interval.intersects(res.get(resSize - 1))) {
+        res.add(interval);
+      } else {
+        // If overlaps with the result, union with current result
+        res.set(resSize - 1, Interval.getUnion(interval, res.get(resSize - 1)));
+      }
+    }
+    return res;
+  }
+
+  /**
+   * Parse interval to millisecond as [min, max] with both sides included.
+   * E.g. '(* 16311]' is parsed as [0, 16311], '(1455 16311)' is parsed as [1456, 16310]
+   */
+  private List<Interval> parseInterval(List<String> intervalExpressions) {
+    Preconditions.checkState(intervalExpressions != null && intervalExpressions.size() == 1,
+        "Cannot parse range expressions from query: %s", intervalExpressions);
+    long startTime = MIN_START_TIME;
+    long endTime = MAX_END_TIME;
+    String intervalExpression = intervalExpressions.get(0);
+    boolean startInclusive = intervalExpression.charAt(0) == START_INCLUSIVE;
+    boolean endInclusive = intervalExpression.charAt(intervalExpression.length() - 1) == END_INCLUSIVE;
+    String interval = intervalExpression.substring(1, intervalExpression.length() - 1);
+    String[] split = StringUtils.split(interval, DELIMITER);
+    if (split.length != 2) {
+      split = StringUtils.split(interval, LEGACY_DELIMITER);
+    }
+
+    if (!split[0].equals(UNBOUNDED)) {
+      startTime = startInclusive? _timeFormatSpec.fromFormatToMillis(split[0]) + 1 : _timeFormatSpec.fromFormatToMillis(split[0]);
+    }
+    if (!split[1].equals(UNBOUNDED)) {
+      endTime = endInclusive ? _timeFormatSpec.fromFormatToMillis(split[1]) - 1 : _timeFormatSpec.fromFormatToMillis(split[1]);
+    }
+
+    if (startTime > endTime) {
+      return Collections.emptyList();
+    }
+    return Collections.singletonList(new Interval(startTime, endTime));
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/Interval.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/Interval.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpruner.interval;
+
+import com.google.common.base.Preconditions;
+
+
+/**
+ * The {@code Interval} class represents an one-dimensional closed interval which contains both ends.
+ */
+public class Interval implements Comparable<Interval> {
+  public final long _min;
+  public final long _max;
+
+  public Interval(long min, long max) {
+    Preconditions.checkState(min <= max, "invalid interval [{}, {}]", min, max);
+    _min = min;
+    _max = max;
+  }
+
+  public boolean intersects(Interval o) {
+    Preconditions.checkNotNull(o, "Invalid interval: null");
+    return _max >= o._min && o._max >= _min;
+  }
+
+  @Override
+  public int compareTo(Interval o) {
+    Preconditions.checkNotNull(o, "Compare to invalid interval: null");
+    if (_min < o._min) {
+      return -1;
+    } else if (_min > o._min) {
+      return 1;
+    } else if (_max < o._max) {
+      return -1;
+    } else if (_max > o._max) {
+      return 1;
+    }
+    else return 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Interval interval = (Interval) o;
+
+    if (_min != interval._min) {
+      return false;
+    }
+    return _max == interval._max;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (_min ^ (_min >>> 32));
+    result = 31 * result + (int) (_max ^ (_max >>> 32));
+    return result;
+  }
+
+  public static Interval getIntersection(Interval a, Interval b) {
+    Preconditions.checkNotNull(a, "Intersect invalid intervals {} and {}", a, b);
+    Preconditions.checkNotNull(b, "Intersect invalid intervals {} and {}", a, b);
+    if (!a.intersects(b)) {
+      return null;
+    }
+    return new Interval(Math.max(a._min, b._min), Math.min(a._max, b._max));
+  }
+
+  public static Interval getUnion(Interval a, Interval b) {
+    // Can only merge two intervals if they overlap
+    Preconditions.checkNotNull(a, "Union invalid intervals {} and {}", a, b);
+    Preconditions.checkNotNull(b, "Union invalid intervals {} and {}", a, b);
+    if (!a.intersects(b)) {
+      return null;
+    }
+    return new Interval(Math.min(a._min, b._min), Math.max(a._max, b._max));
+  }
+
+  @Override
+  public String toString() {
+    return "[" + _min + ", " + _max + "]";
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/IntervalTree.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/IntervalTree.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpruner.interval;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.utils.Pairs;
+
+
+/**
+ * The {@code IntervalTree} class represents read-only balanced binary interval tree map (from intervals to values)
+ */
+public class IntervalTree<Value> {
+
+  // List representation of BST with root at index 0. For node with index x, it's left child index is (2x+1), right child index is (2x+2)
+  private final List<Node> _nodes;
+
+  public IntervalTree(Map<Value, Interval> valueToIntervalMap) {
+    Map<Interval, List<Value>> intervalToValuesMap = new HashMap<>();
+    for (Map.Entry<Value, Interval> entry : valueToIntervalMap.entrySet()) {
+      intervalToValuesMap.putIfAbsent(entry.getValue(), new ArrayList<>());
+      intervalToValuesMap.get(entry.getValue()).add(entry.getKey());
+    }
+
+    List<Node<Value>> sortedNodes = new ArrayList<>();
+    for (Map.Entry<Interval, List<Value>> entry : intervalToValuesMap.entrySet()) {
+      sortedNodes.add(new Node(entry.getKey(), entry.getValue()));
+    }
+    Collections.sort(sortedNodes);
+    _nodes = buildIntervalTree(sortedNodes);
+    buildAuxiliaryInfo();
+  }
+
+  /**
+   * Build interval bst by bfs, the root for each subtree will be the one with median interval.
+   * A typical balanced tree:
+   *                              [10, 20]
+   *                              /       \
+   *                       [8, 15]        [12, 20]
+   *                          /            /
+   *                   [5, 10]       [10, 30]
+   * is represented as  { [10, 20], [8, 15], [12, 20], [5, 10], null, [10, 30] }
+   */
+  private List<Node> buildIntervalTree(List<Node<Value>> sortedNodes) {
+    List<Node> resNodes = new ArrayList<>();
+    LinkedList<Pairs.IntPair> indexQueue = new LinkedList<>();
+    indexQueue.add(new Pairs.IntPair(0, sortedNodes.size()));
+    int count = 0;
+    while (count < sortedNodes.size()) {
+      Pairs.IntPair indexPair = indexQueue.pollFirst();
+      int start = indexPair.getLeft();
+      int end = indexPair.getRight();
+
+      if (start < end) {
+        int mid = start + (end - start) / 2;
+        resNodes.add(sortedNodes.get(mid));
+        count++;
+        indexQueue.add(new Pairs.IntPair(start, mid));
+        indexQueue.add(new Pairs.IntPair(mid + 1, end));
+      } else {
+        resNodes.add(null);
+      }
+    }
+    return resNodes;
+  }
+
+  private void buildAuxiliaryInfo() {
+    // Build max info for the interval tree by dfs
+    buildAuxiliaryInfo(0);
+  }
+
+  private void buildAuxiliaryInfo(int nodeIndex) {
+    if (!hasNode(nodeIndex)) {
+      return;
+    }
+
+    int leftChildIndex = getLeftChildIndex(nodeIndex);
+    int rightChildIndex = getRightChildIndex(nodeIndex);
+
+    buildAuxiliaryInfo(leftChildIndex);
+    buildAuxiliaryInfo(rightChildIndex);
+
+    long max = _nodes.get(nodeIndex)._interval._max;
+    max = Math.max(getMax(rightChildIndex), Math.max(max, getMax(leftChildIndex)));
+    _nodes.get(nodeIndex)._max = max;
+  }
+
+  private int getLeftChildIndex(int nodeIndex) {
+    return nodeIndex * 2 + 1;
+  }
+
+  private int getRightChildIndex(int nodeIndex) {
+    return  nodeIndex * 2 + 2;
+  }
+
+  private long getMax(int index) {
+    if (!hasNode(index)) {
+      return Long.MIN_VALUE;
+    }
+    return _nodes.get(index)._max;
+  }
+
+  /**
+   * Find all values whose intervals intersect with the input interval.
+   *
+   * @param searchInterval search interval
+   * @return list of all qualified values.
+   */
+  public List<Value> searchAll(Interval searchInterval) {
+    List<Value> list = new ArrayList<>();
+    if (searchInterval == null) {
+      return list;
+    }
+    searchAll(0, searchInterval, list);
+    return list;
+  }
+
+  private void searchAll(int nodeIndex, Interval searchInterval, List<Value> list) {
+    if (!hasNode(nodeIndex)) {
+      return;
+    }
+
+    int leftChildIndex = getLeftChildIndex(nodeIndex);
+    int rightChildIndex = getRightChildIndex(nodeIndex);
+
+    if (hasNode(leftChildIndex) && getMax(leftChildIndex) >= searchInterval._min) {
+      searchAll(leftChildIndex, searchInterval, list);
+    }
+
+    Node<Value> node = _nodes.get(nodeIndex);
+    Interval interval = node._interval;
+    if (searchInterval.intersects(interval)) {
+      list.addAll(node._values);
+    }
+
+    if (interval._min <= searchInterval._max) {
+      searchAll(rightChildIndex, searchInterval, list);
+    }
+  }
+
+  private boolean hasNode(int nodeIndex) {
+    return nodeIndex < _nodes.size() && _nodes.get(nodeIndex) != null;
+  }
+
+  private class Node<Value> implements Comparable<Node> {
+    private final Interval _interval;
+    private final List<Value> _values;
+    private long _max; // max interval right end of subtree rooted at this node
+
+    Node(Interval interval, List<Value> values) {
+      _interval = interval;
+      _values = values;
+    }
+
+    @Override
+    public int compareTo(Node o) {
+      Preconditions.checkNotNull(o, "Compare to invalid node: null");
+      return _interval.compareTo(o._interval);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Node<?> node = (Node<?>) o;
+
+      return _interval.equals(node._interval);
+    }
+
+    @Override
+    public int hashCode() {
+      return _interval.hashCode();
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.broker.routing.segmentselector;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -31,7 +29,7 @@ import org.apache.pinot.common.request.BrokerRequest;
  * Segment selector for offline table.
  */
 public class OfflineSegmentSelector implements SegmentSelector {
-  private volatile List<String> _segments;
+  private volatile Set<String> _segments;
 
   @Override
   public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
@@ -43,11 +41,11 @@ public class OfflineSegmentSelector implements SegmentSelector {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 
-    _segments = Collections.unmodifiableList(new ArrayList<>(onlineSegments));
+    _segments = Collections.unmodifiableSet(onlineSegments);
   }
 
   @Override
-  public List<String> select(BrokerRequest brokerRequest) {
+  public Set<String> select(BrokerRequest brokerRequest) {
     return _segments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.broker.routing.segmentselector;
 
-import java.util.List;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -60,5 +59,5 @@ public interface SegmentSelector {
    * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset
    * (table) without overlap.
    */
-  List<String> select(BrokerRequest brokerRequest);
+  Set<String> select(BrokerRequest brokerRequest);
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/IntervalST/IntervalTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/IntervalST/IntervalTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.IntervalST;
+
+import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IntervalTest {
+
+  @Test
+  public void testInterval() {
+    Interval a = new Interval(1, 5);
+    Interval b = new Interval(6, 8);
+    Interval c = new Interval(1, 4);
+    Interval d = new Interval(1, 6);
+    Interval e = new Interval(1, 5);
+    Interval f = new Interval(5, 5);
+
+    // test compareTo
+    Assert.assertTrue(a.compareTo(b) < 0);
+    Assert.assertTrue(a.compareTo(c) > 0);
+    Assert.assertTrue(a.compareTo(d) < 0);
+    Assert.assertTrue(a.compareTo(e) == 0);
+
+    // test intersects
+    Assert.assertFalse(a.intersects(b));
+    Assert.assertTrue(a.intersects(f));
+
+    // test intersection
+    Assert.assertEquals(Interval.getIntersection(a, b), null);
+    Assert.assertEquals(Interval.getIntersection(a, c), c);
+    Assert.assertEquals(Interval.getIntersection(b, d), new Interval(6, 6));
+
+    // test union
+    Assert.assertEquals(Interval.getUnion(a, b), null);
+    Assert.assertEquals(Interval.getUnion(b, d), new Interval(1, 8));
+    Assert.assertEquals(Interval.getUnion(a, d), d);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/IntervalST/IntervalTreeTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/IntervalST/IntervalTreeTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.IntervalST;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
+import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IntervalTreeTest {
+
+  @Test
+  public void testIntervalTree() {
+    Interval interval0 = new Interval(0, 1);
+    Interval interval1 = new Interval(2, 18);
+    Interval interval2 = new Interval(5, 7);
+    Interval interval3 = new Interval(5, 7);
+    Interval interval4 = new Interval(5, 15);
+    Interval interval5 = new Interval(7, 9);
+    Interval interval6 = new Interval(12, 14);
+    Interval interval7 = new Interval(17, 17);
+    Interval interval8 = new Interval(17, 23);
+    Interval interval9 = new Interval(17, 23);
+    Interval interval10 = new Interval(17, 23);
+    Interval interval11 = new Interval(20, 30);
+    Interval interval12 = new Interval(25, 28);
+
+    String name0 = interval0.toString() + ": 0";
+    String name1 = interval1.toString() + ": 1";
+    String name2 = interval2.toString() + ": 2";
+    String name3 = interval3.toString() + ": 3";
+    String name4 = interval4.toString() + ": 4";
+    String name5 = interval5.toString() + ": 5";
+    String name6 = interval6.toString() + ": 6";
+    String name7 = interval7.toString() + ": 7";
+    String name8 = interval8.toString() + ": 8";
+    String name9 = interval9.toString() + ": 9";
+    String name10 = interval10.toString() + ": 10";
+    String name11 = interval11.toString() + ": 11";
+    String name12 = interval12.toString() + ": 12";
+
+    Map<String, Interval> nameToIntervalMap = new HashMap<>();
+    nameToIntervalMap.put(name0, interval0);
+    nameToIntervalMap.put(name1, interval1);
+    nameToIntervalMap.put(name2, interval2);
+    nameToIntervalMap.put(name3, interval3);
+    nameToIntervalMap.put(name4, interval4);
+    nameToIntervalMap.put(name5, interval5);
+
+    nameToIntervalMap.put(name6, interval6);
+    nameToIntervalMap.put(name7, interval7);
+    nameToIntervalMap.put(name8, interval8);
+    nameToIntervalMap.put(name9, interval9);
+    nameToIntervalMap.put(name10, interval10);
+    nameToIntervalMap.put(name11, interval11);
+    nameToIntervalMap.put(name12, interval12);
+
+    IntervalTree<String> intervalTree = new IntervalTree<>(nameToIntervalMap);
+    Assert.assertEquals(intervalTree.searchAll(new Interval(40, 40)), Collections.emptyList());
+    Assert.assertEquals(new HashSet<>(intervalTree.searchAll(new Interval(0, 10))),
+        new HashSet<>(Arrays.asList(name0, name1, name2, name3, name4, name5)));
+    Assert.assertEquals(new HashSet<>(intervalTree.searchAll(new Interval(10, 20))),
+        new HashSet<>(Arrays.asList(name1, name4, name6, name7, name8, name9, name10, name11)));
+    Assert.assertEquals(new HashSet<>(intervalTree.searchAll(new Interval(20, 30))),
+        new HashSet<>(Arrays.asList(name8, name9, name10, name11, name12)));
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -114,7 +114,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
 
     startController(properties);
-    
+
     startBroker();
     startServers(2);
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
@@ -27,6 +27,7 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 public class RoutingConfig extends BaseJsonConfig {
   public static final String PARTITION_SEGMENT_PRUNER_TYPE = "partition";
+  public static final String TIME_SEGMENT_PRUNER_TYPE = "time";
   public static final String REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "replicaGroup";
   public static final String STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE = "strictReplicaGroup";
 


### PR DESCRIPTION
For issue #6189:
 
Add broker time range based pruner for routing. Query operators supported: `RANGE`, `=, <, <=, >, >=`, `AND`, `OR`
To enable this pruner, table config need to be set as:
```
"routing": {
    "segmentPrunerTypes": ["Time"]
  }
```
For multiple pruners, time pruner will by default be the first one.

Benchmark experiments comparing naive method (intervalMP below) and the interval tree method:

```
100 segments/table: intervalMP-> 0.002 milli seconds, intervalST-> 0.0057 milli seconds, 0.40 performance ratio, average segments/table: 100.0, average result size: 10.6, result size percentage 10.6
1000 segments/table: intervalMP-> 0.022 milli seconds, intervalST-> 0.0150 milli seconds, 1.51 performance ratio, average segments/table: 1000.0, average result size: 51.6, result size percentage 5.16
10000 segments/table: intervalMP-> 0.31milli seconds, intervalST-> 0.05 milli seconds, 6.33 performance ratio, average segments/table: 10000.0, average result size: 500.9, result size percentage 5.009
100000 segments/table: intervalMP-> 5.83 milli seconds, intervalST-> 1.11 milli seconds, 5.24 performance ratio, average segments/table: 100000.0, average result size: 5001.4, result size percentage 5.0
1000000 segments/table: intervalMP-> 55.05 milli seconds, intervalST-> 20.03 milli seconds, 2.74 performance ratio, average segments/table: 1000000.0, average result size: 50001.9, result size percentage 5.0

```

```
1000000 segments/table: intervalMP-> 74.87 milli seconds, intervalST-> 78.14 milli seconds, 0.95 performance ratio, average segments/table: 1000000.0, average result size: 500000.4, result size percentage 50.0
1000000 segments/table: intervalMP-> 54.96 milli seconds, intervalST-> 27.73 milli seconds, 1.98 performance ratio, average segments/table: 1000000.0, average result size: 50000.6, result size percentage 5.0
1000000 segments/table: intervalMP-> 61.87 milli seconds, intervalST-> 4.60 milli seconds, 13.42 performance ratio, average segments/table: 1000000.0, average result size: 5001.7, result size percentage 0.5
1000000 segments/table: intervalMP-> 59.22 milli seconds, intervalST-> 0.88 milli seconds, 66.94 performance ratio, average segments/table: 1000000.0, average result size: 502.6, result size percentage 0.05
1000000 segments/table: intervalMP-> 61.34 milli seconds, intervalST-> 0.14 milli seconds, 428.39 performance ratio, average segments/table: 1000000.0, average result size: 52.7, result size percentage 0.005

```
The experiments are consistent with theory: the interval tree method performance much better if the result size is much smaller compared with the total # of segments.