### PR TITLE
Allow setting HTTP headers and parameters during schema upload

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -243,8 +243,9 @@ public class FileUploadDownloadClient implements Closeable {
     return requestBuilder.build();
   }
 
-  private static HttpUriRequest getAddSchemaRequest(URI uri, String schemaName, File schemaFile) {
-    return getUploadFileRequest(HttpPost.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), null, null,
+  private static HttpUriRequest getAddSchemaRequest(URI uri, String schemaName, File schemaFile, List<Header> headers,
+      List<NameValuePair> parameters) {
+    return getUploadFileRequest(HttpPost.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), headers, parameters,
         DEFAULT_SOCKET_TIMEOUT_MS);
   }
 
@@ -419,7 +420,25 @@ public class FileUploadDownloadClient implements Closeable {
    */
   public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile)
       throws IOException, HttpErrorStatusException {
-    return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile));
+    return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, null, null));
+  }
+
+  /**
+   * Add schema.
+   *
+   * @param uri URI
+   * @param schemaName Schema name
+   * @param schemaFile Schema file
+   * @param headers HTTP headers
+   * @param parameters HTTP parameters
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile, List<Header> headers,
+      List<NameValuePair> parameters)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, headers, parameters));
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -243,8 +243,8 @@ public class FileUploadDownloadClient implements Closeable {
     return requestBuilder.build();
   }
 
-  private static HttpUriRequest getAddSchemaRequest(URI uri, String schemaName, File schemaFile, List<Header> headers,
-      List<NameValuePair> parameters) {
+  private static HttpUriRequest getAddSchemaRequest(URI uri, String schemaName, File schemaFile,
+      @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters) {
     return getUploadFileRequest(HttpPost.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), headers, parameters,
         DEFAULT_SOCKET_TIMEOUT_MS);
   }
@@ -435,8 +435,8 @@ public class FileUploadDownloadClient implements Closeable {
    * @throws IOException
    * @throws HttpErrorStatusException
    */
-  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile, List<Header> headers,
-      List<NameValuePair> parameters)
+  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile, @Nullable List<Header> headers,
+      @Nullable List<NameValuePair> parameters)
       throws IOException, HttpErrorStatusException {
     return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, headers, parameters));
   }


### PR DESCRIPTION
## Description
Useful for sender to annotate additional information for observability and auditing

