### PR TITLE
Update download page for release 0.6.0

### DIFF
--- a/website/src/pages/download.js
+++ b/website/src/pages/download.js
@@ -60,6 +60,50 @@ function Download() {
 
                                     <div className="panel--title">0.5.0</div>
 
+                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz">
+                                        <div className="panel--title">
+                                            Official source release
+                                        </div>
+                                    </a>
+                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.sha512">
+                                        <div className="panel--subtitle">
+                                            SHA512
+                                        </div>
+                                    </a>
+                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.asc">
+                                        <div className="panel--subtitle">
+                                            ASC
+                                        </div>
+                                    </a>
+
+                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz">
+                                        <div className="panel--title">
+                                            Official binary release
+                                        </div>
+                                    </a>
+                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.sha512">
+                                        <div className="panel--subtitle">
+                                            SHA512
+                                        </div>
+                                    </a>
+                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.asc">
+                                        <div className="panel--subtitle">
+                                            ASC{" "}
+                                        </div>
+                                    </a>
+                                </a>
+                            </div>
+                            <div className="col">
+                                <a
+                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz"
+                                    className="panel panel--link text--center"
+                                >
+                                    <div className="panel--icon">
+                                        <i className="feather icon-download"></i>
+                                    </div>
+
+                                    <div className="panel--title">0.5.0</div>
+
                                     <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -293,7 +293,7 @@ function Installation() {
                     </TabItem>
                     <TabItem value="binary">
                         <CodeBlock className="language-bash">
-                            {`VERSION=0.5.0\nwget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`}
+                            {`VERSION=0.6.0\nwget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`}
                         </CodeBlock>
                     </TabItem>
                     <TabItem value="github">
@@ -352,11 +352,11 @@ function Home() {
             >
                 <div className="container">
                     <Link
-                        to="https://docs.pinot.apache.org/basics/releases/0.5.0"
+                        to="https://docs.pinot.apache.org/basics/releases/0.6.0"
                         className={styles.indexAnnouncement}
                     >
                         <span className="badge badge-primary">release</span>
-                        v0.5.0 has been released! Check the release notes
+                        v0.6.0 has been released! Check the release notes
                     </Link>
                     <h1 className="hero__title">{siteConfig.title}</h1>
                     <p className="hero__subtitle">


### PR DESCRIPTION
## Description
This PR updates download page to include release 0.6.0.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
