### PR TITLE
 Support for text index without raw

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.indexsegment.generator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
@@ -299,6 +300,7 @@ public class SegmentGeneratorConfig {
     }
   }
 
+  @VisibleForTesting
   public void setColumnProperties(Map<String, Map<String, String>> columnProperties) {
     _columnProperties = columnProperties;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -299,6 +299,10 @@ public class SegmentGeneratorConfig {
     }
   }
 
+  public void setColumnProperties(Map<String, Map<String, String>> columnProperties) {
+    _columnProperties = columnProperties;
+  }
+
   public void setColumnSortOrder(List<String> sortOrder) {
     Preconditions.checkNotNull(sortOrder);
     _columnSortOrder.addAll(sortOrder);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -44,6 +44,9 @@ public class FieldConfig extends BaseJsonConfig {
   // the cache improves performance of repeatable queries
   public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "enableQueryCacheForTextIndex";
   public static String TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES = "useANDForMultiTermTextIndexQueries";
+  public static String TEXT_INDEX_NO_RAW_DATA = "noRawDataForTextIndex";
+  public static String TEXT_INDEX_RAW_VALUE = "rawValueForTextIndex";
+  public static String TEXT_INDEX_DEFAULT_RAW_VALUE = "null";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -46,7 +46,7 @@ public class FieldConfig extends BaseJsonConfig {
   public static String TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES = "useANDForMultiTermTextIndexQueries";
   public static String TEXT_INDEX_NO_RAW_DATA = "noRawDataForTextIndex";
   public static String TEXT_INDEX_RAW_VALUE = "rawValueForTextIndex";
-  public static String TEXT_INDEX_DEFAULT_RAW_VALUE = "null";
+  public static String TEXT_INDEX_DEFAULT_RAW_VALUE = "n";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,


### PR DESCRIPTION
Adding support for text index without raw data.

Our use cases are indexing huge blobs of text (STRING) data. We have seen the raw forward index size upto 2GB per segment for text data. As an example for few of our tables, supporting this mode of text index will lead upto 2TB storage space saving per colo per table. These tables use text index only in the filter clause. The raw values are neither projected nor used in the query in filter other than text_match clause.

- Like other text index configs, the behavior can be enabled on a per index basis through table config
- The actual raw value is used for building the text index.
- For the forward index, a dummy value (that also user can provide) will be used.  Default would be "n"

A potential follow up will be to not have the column at all and just have the index. However, this requires semantic changes in quite a few places in the code that assume that forward index is always there. 