### PR TITLE
Use sorted index based filtering only for dictionary encoded column

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -55,7 +55,7 @@ public class FilterOperatorUtils {
     // operator is used only if the column is sorted and has dictionary.
     Predicate.Type predicateType = predicateEvaluator.getPredicateType();
     if (predicateType == Predicate.Type.RANGE) {
-      if (dataSource.getDataSourceMetadata().isSorted() && (dataSource.getDictionary() != null)) {
+      if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
         return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
       if (dataSource.getRangeIndex() != null) {
@@ -65,7 +65,7 @@ public class FilterOperatorUtils {
     } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
       return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
     } else {
-      if (dataSource.getDataSourceMetadata().isSorted() && (dataSource.getDictionary() != null)) {
+      if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
         return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
       if (dataSource.getInvertedIndex() != null) {


### PR DESCRIPTION
Currently we build sorted index only if the column is dictionary encoded. However, when we write `isSorted` in on-disk segment metadata, we write on the basis of pre-index stats collector. So, for a sorted column without dictionary, segment metadata will still indicate column as sorted

`properties.setProperty(getKeyFor(column, IS_SORTED), String.valueOf(columnIndexCreationInfo.isSorted()));`

During query processing, when we create filter operator, we check the data source metadata to see if the column is sorted and create sorted index based filter operator. However, using this operator for any sorted raw column will lead to the following error stack since we end up using a raw value based predicate evaluator for a dictionary based filter operator. 

The solution is to do the additional check on data source to see if the column is dictionary encoded or not

````
java.lang.UnsupportedOperationException
181762         at org.apache.pinot.core.operator.filter.predicate.BaseRawValueBasedPredicateEvaluator.getMatchingDictIds(BaseRawValueBasedPredicateEvaluator.java:40)
181763         at org.apache.pinot.core.operator.filter.SortedIndexBasedFilterOperator.getNextBlock(SortedIndexBasedFilterOperator.java:68)
181764         at org.apache.pinot.core.operator.filter.SortedIndexBasedFilterOperator.getNextBlock(SortedIndexBasedFilterOperator.java:35)
181765         at org.apache.pinot.core.operator.BaseOperator.nextBlock(BaseOperator.java:49)
181766         at org.apache.pinot.core.operator.DocIdSetOperator.getNextBlock(DocIdSetOperator.java:62)
181767         at org.apache.pinot.core.operator.DocIdSetOperator.getNextBlock(DocIdSetOperator.java:35)
181768         at org.apache.pinot.core.operator.BaseOperator.nextBlock(BaseOperator.java:49)
181769         at org.apache.pinot.core.operator.ProjectionOperator.getNextBlock(ProjectionOperator.java:57)
181770         at org.apache.pinot.core.operator.ProjectionOperator.getNextBlock(ProjectionOperator.java:30)`
```