### PR TITLE
Make plugins to be configurable in environment variables

### DIFF
--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -182,13 +182,19 @@ fi
 
 if [ -z "$JAVA_OPTS" ] ; then
   ALL_JAVA_OPTS="@EXTRA_JVM_ARGUMENTS@"
-
-  # For java 8, we set jvm system property `plugins.dir` to load Pinot plugins
-  if [ "$JAVA_VER" -eq 8 ] ; then
-    ALL_JAVA_OPTS="$ALL_JAVA_OPTS -Dplugins.dir=$BASEDIR/plugins"
-  fi
 else
   ALL_JAVA_OPTS=$JAVA_OPTS
+fi
+
+# For java 8, we set jvm system property `plugins.dir` to load Pinot plugins
+if [ "$JAVA_VER" -eq 8 ] ; then
+  if [ -z "$PLUGINS_DIR" ] ; then
+    PLUGINS_DIR=$BASEDIR/plugins
+  fi
+  ALL_JAVA_OPTS="$ALL_JAVA_OPTS -Dplugins.dir=$PLUGINS_DIR"
+  if [ -n "$PLUGINS_INCLUDE" ] ; then
+    ALL_JAVA_OPTS="$ALL_JAVA_OPTS -Dplugins.include=$PLUGINS_INCLUDE"
+  fi
 fi
 
 # For java 9 and later, we need to set extra java options to access JDK’s internal APIs.


### PR DESCRIPTION
## Description
Adding environment variables for JDK 8 Pinot admin script:
`PLUGINS_DIR`: Configure Pinot plugins dir, default to `$BASEDIR/plugins`
`PLUGINS_INCLUDE`: Comma-separated list of plugins to be loaded, default is loading all.

Current behavior expects users to set plugins directory when they modify `JAVA_OPTS`, e.g. set -xmx.
After the change, when users chagne JAVA_OPT, the script will automatically append the plugin directory as default scripts. User can also specify env var: `PLUGINS_DIR` and `PLUGINS_INCLUDE` to modify the plugin imports.