### PR TITLE
[TE] frontend - rca/harleyjj - Enable forecast baseline in RCA UI

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-details/template.hbs
@@ -56,6 +56,7 @@
             <div class="col-xs-4 no-padding">
               {{date-range-picker
                 class="te-range-picker"
+                alwaysShowCalendars=true
                 timePicker=true
                 timePicker24Hour=true
                 timePickerIncrement=pill.timePickerIncrement
@@ -362,6 +363,7 @@
             <div class="col-xs-4 no-padding">
               {{date-range-picker
                 class="te-range-picker"
+                alwaysShowCalendars=true
                 timePicker=true
                 timePicker24Hour=true
                 timePickerIncrement=pill.timePickerIncrement
@@ -395,6 +397,7 @@
           <div class="col-xs-4 no-padding">
             {{date-range-picker
               class="te-range-picker"
+              alwaysShowCalendars=true
               timePicker=true
               timePicker24Hour=true
               timePickerIncrement=pill.timePickerIncrement

--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
@@ -62,6 +62,7 @@
         id="date-picker"
         parentEl=".te-modal"
         timePicker=showTimePicker
+        alwaysShowCalendars=true
         maxDate=maxTime
         start=viewAnomalyStart
         end=viewAnomalyEnd

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
@@ -33,19 +33,6 @@ export default Component.extend({
 
   timeseriesMode: null, // ""
 
-  //
-  // external (optional)
-  //
-  analysisRangeMax: makeTime().add(1, 'day').startOf('day'),
-
-  analysisRangePredefined: {
-    'Today': [makeTime(), makeTime().startOf('day').add(1, 'days')],
-    'Last 3 days': [makeTime().subtract(2, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
-    'Last 7 days': [makeTime().subtract(6, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
-    'Last 14 days': [makeTime().subtract(13, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
-    'Last 28 days': [makeTime().subtract(27, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')]
-  },
-
   /**
    * Mapping of granularity values translated from backend
    * @type {Object}
@@ -70,6 +57,42 @@ export default Component.extend({
   analysisRangeEnd: null, // 0
 
   granularity: null, // ""
+
+  //
+  // external (optional)
+  //
+  analysisRangeMax: computed('compareMode', function() {
+    const compareMode = get(this, 'compareMode');
+    if (compareMode === 'forecast') {
+      return null;
+    }
+    return makeTime().add(1, 'day').startOf('day');
+  }),
+
+  analysisRangePredefined: computed('compareMode', function() {
+    const compareMode = get(this, 'compareMode');
+    let ranges = {
+      'Today': [makeTime(), makeTime().startOf('day').add(1, 'days')],
+      'Last 3 days': [makeTime().subtract(2, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
+      'Last 7 days': [makeTime().subtract(6, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
+      'Last 14 days': [makeTime().subtract(13, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')],
+      'Last 28 days': [makeTime().subtract(27, 'days').startOf('day'), makeTime().startOf('day').add(1, 'days')]
+    };
+    let futureRanges = {}
+    if (compareMode === 'forecast') {
+      futureRanges = {
+        'Tomorrow': [makeTime().startOf('day').add(1, 'days'), makeTime().startOf('day').add(2, 'days')],
+        'Next 3 days': [makeTime().startOf('day'), makeTime().startOf('day').add(3, 'days')],
+        'Next 7 days': [makeTime().startOf('day'), makeTime().startOf('day').add(7, 'days')],
+        'Next 14 days': [makeTime().startOf('day'), makeTime().startOf('day').add(14, 'days')],
+        'Next 28 days': [makeTime().startOf('day'), makeTime().startOf('day').add(28, 'days')]
+      };
+    }
+    return {
+      ...ranges,
+      ...futureRanges
+    };
+  }),
 
   /**
    * Selected value in the granularity dropdown

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
@@ -9,6 +9,7 @@
   </label>
   {{date-range-picker
     class="te-range-picker"
+    alwaysShowCalendars=true
     start=analysisRangeStart
     end=analysisRangeEnd
     maxDate=analysisRangeMax

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -38,6 +38,7 @@ export default Component.extend({
   slider: null,
   sliderOptionsCache: null,
   showBaselineModal: false,
+  showForecastTimeRanges: false,
   customBaselineValue: 'wo1w',
 
   rangeOptions: {
@@ -54,7 +55,7 @@ export default Component.extend({
     },
     {
       groupName: 'Algorithm',
-      options: [ 'predicted' ]
+      options: [ 'predicted', 'forecast' ]
     },
     {
       groupName: 'Custom Baseline Selector',
@@ -90,7 +91,11 @@ export default Component.extend({
     return makeTime(this.get('anomalyRange')[1]).format(serverDateFormat);
   }),
 
-  maxDateFormatted: computed(function() {
+  maxDateFormatted: computed('compareMode', function() {
+    const compareMode = this.get('compareMode');
+    if (compareMode === 'forecast') {
+      return null;
+    }
     return makeTime().startOf('hour').add(1, 'hours').format(serverDateFormat);
   }),
 
@@ -196,6 +201,7 @@ export default Component.extend({
       if (compareMode === 'custom') {
         set(this, 'showBaselineModal', true);
       } else {
+        set(this, 'showForecastTimeRanges', compareMode === 'forecast');
         const { anomalyRange, onChange } = this.getProperties('anomalyRange', 'onChange');
         onChange(anomalyRange[0], anomalyRange[1], compareMode);
       }


### PR DESCRIPTION
## Description
- Adds forecast as baseline option in RCA UI
- Enables selection of future dates only when forecast baseline is selected
- Fixes small bug where calendar will disappear from date-picker at random times
- Depends on the backend offering forecast baseline in metric/timeseries endpoint (see [PR](https://github.com/apache/incubator-pinot/pull/6265))
