### PR TITLE
some geo function improvements

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -41,6 +41,7 @@ import org.apache.pinot.pql.parsers.pql2.ast.IntegerLiteralAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.LiteralAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.PredicateAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.StringLiteralAstNode;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
 
 
@@ -131,6 +132,12 @@ public class RequestUtils {
     return expression;
   }
 
+  public static Expression getLiteralExpression(byte[] value) {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setStringValue(BytesUtils.toHexString(value));
+    return expression;
+  }
+
   public static Expression getLiteralExpression(Integer value) {
     return getLiteralExpression(value.longValue());
   }
@@ -169,6 +176,9 @@ public class RequestUtils {
     }
     if (object instanceof SqlLiteral) {
       return RequestUtils.getLiteralExpression((SqlLiteral) object);
+    }
+    if (object instanceof byte[]) {
+      return RequestUtils.getLiteralExpression((byte[]) object);
     }
     throw new SqlCompilationException(
         new IllegalArgumentException("Unsupported Literal value type - " + object.getClass()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/GeometryUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/GeometryUtils.java
@@ -53,4 +53,20 @@ public class GeometryUtils {
   public static boolean isGeography(Geometry geometry) {
     return geometry.getSRID() == GEOGRAPHY_SRID;
   }
+
+  /**
+   * Sets the geometry to geography.
+   * @param geometry the geometry to set
+   */
+  public static void setGeography(Geometry geometry) {
+    geometry.setSRID(GEOGRAPHY_SRID);
+  }
+
+  /**
+   * Sets to geometry.
+   * @param geometry the geometry to set
+   */
+  public static void setGeometry(Geometry geometry) {
+    geometry.setSRID(0);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -53,7 +53,7 @@ public class ScalarFunctions {
    * @return the created point
    */
   @ScalarFunction
-  public static byte[] stPoint(double x, double y, double isGeography) {
+  public static byte[] stPoint(double x, double y, int isGeography) {
     Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
     if (isGeography > 0) {
       GeometryUtils.setGeography(point);

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -22,6 +22,7 @@ import org.apache.pinot.core.geospatial.GeometryUtils;
 import org.apache.pinot.core.geospatial.serde.GeometrySerializer;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.WKTWriter;
 
 
@@ -41,6 +42,23 @@ public class ScalarFunctions {
   public static byte[] stPoint(double x, double y) {
     return GeometrySerializer
         .serialize(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(x, y)));
+  }
+
+  /**
+   * Creates a point.
+   *
+   * @param x x
+   * @param y y
+   * @param isGeography if it's geography
+   * @return the created point
+   */
+  @ScalarFunction
+  public static byte[] stPoint(double x, double y, double isGeography) {
+    Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
+    if (isGeography > 0) {
+      GeometryUtils.setGeography(point);
+    }
+    return GeometrySerializer.serialize(point);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
@@ -25,6 +25,7 @@ import org.apache.pinot.core.geospatial.serde.GeometrySerializer;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -57,14 +58,14 @@ public class StContainsFunction extends BaseTransformFunction {
     TransformFunction transformFunction = arguments.get(0);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The first argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+        || transformFunction instanceof LiteralTransformFunction, "The first argument must be of bytes type");
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The second argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+        || transformFunction instanceof LiteralTransformFunction, "The second argument must be of bytes type");
     _secondArgument = transformFunction;
   }
 
@@ -84,8 +85,7 @@ public class StContainsFunction extends BaseTransformFunction {
       Geometry firstGeometry = GeometrySerializer.deserialize(firstValues[i]);
       Geometry secondGeometry = GeometrySerializer.deserialize(secondValues[i]);
       if (GeometryUtils.isGeography(firstGeometry) || GeometryUtils.isGeography(secondGeometry)) {
-        throw new RuntimeException(
-            String.format("%s is available for Geometry objects only", FUNCTION_NAME));
+        throw new RuntimeException(String.format("%s is available for Geometry objects only", FUNCTION_NAME));
       }
       _results[i] = firstGeometry.contains(secondGeometry) ? 1 : 0;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
@@ -127,7 +127,6 @@ public class StDistanceFunction extends BaseTransformFunction {
     Point leftPoint = (Point) leftGeometry;
     Point rightPoint = (Point) rightGeometry;
 
-//    return greatCircleDistance(leftPoint.getY(), leftPoint.getX(), rightPoint.getY(), rightPoint.getX());
     return greatCircleDistance(leftPoint.getX(), leftPoint.getY(), rightPoint.getX(), rightPoint.getY());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
@@ -26,6 +26,7 @@ import org.apache.pinot.core.geospatial.serde.GeometrySerializer;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -71,14 +72,14 @@ public class StDistanceFunction extends BaseTransformFunction {
     TransformFunction transformFunction = arguments.get(0);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The first argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+        || transformFunction instanceof LiteralTransformFunction, "The first argument must be of bytes type");
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The second argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+        || transformFunction instanceof LiteralTransformFunction, "The second argument must be of bytes type");
     _secondArgument = transformFunction;
   }
 
@@ -126,7 +127,8 @@ public class StDistanceFunction extends BaseTransformFunction {
     Point leftPoint = (Point) leftGeometry;
     Point rightPoint = (Point) rightGeometry;
 
-    return greatCircleDistance(leftPoint.getY(), leftPoint.getX(), rightPoint.getY(), rightPoint.getX());
+//    return greatCircleDistance(leftPoint.getY(), leftPoint.getX(), rightPoint.getY(), rightPoint.getX());
+    return greatCircleDistance(leftPoint.getX(), leftPoint.getY(), rightPoint.getX(), rightPoint.getY());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -147,7 +147,7 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
-    if(_bytesResult==null) {
+    if (_bytesResult == null) {
       _bytesResult = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
       Arrays.fill(_bytesResult, BytesUtils.toBytes(_literal));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -42,6 +43,7 @@ public class LiteralTransformFunction implements TransformFunction {
   private float[] _floatResult;
   private double[] _doubleResult;
   private String[] _stringResult;
+  private byte[][] _bytesResult;
 
   public LiteralTransformFunction(String literal) {
     _literal = literal;
@@ -145,7 +147,11 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
-    throw new UnsupportedOperationException();
+    if(_bytesResult==null) {
+      _bytesResult = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      Arrays.fill(_bytesResult, BytesUtils.toBytes(_literal));
+    }
+    return _bytesResult;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StDistanceFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StDistanceFunctionTest.java
@@ -48,10 +48,10 @@ public class StDistanceFunctionTest extends GeoFunctionTest {
   @Test
   public void testGeogDistance()
       throws Exception {
-    assertDistance("POINT(-86.67 36.12)", "POINT(-118.40 33.94)", 2886448.9734367016, false);
-    assertDistance("POINT(-118.40 33.94)", "POINT(-86.67 36.12)", 2886448.9734367016, false);
-    assertDistance("POINT(-71.0589 42.3601)", "POINT(-71.2290 42.4430)", 16734.69743457383, false);
-    assertDistance("POINT(-86.67 36.12)", "POINT(-86.67 36.12)", 0.0, false);
+    assertDistance("POINT(36.12 -86.67)", "POINT(33.94 -118.40)", 2886448.9734367016, false);
+    assertDistance("POINT(33.94 -118.40)", "POINT(36.12 -86.67)", 2886448.9734367016, false);
+    assertDistance("POINT(42.3601 -71.0589)", "POINT(42.4430 -71.2290)", 16734.69743457383, false);
+    assertDistance("POINT(36.12 -86.67)", "POINT(36.12 -86.67)", 0.0, false);
 
     //  (FIXME): the follow testings require null handling
 //    assertDistance("POINT EMPTY", "POINT (40 30)", null);

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StPointFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StPointFunctionTest.java
@@ -36,15 +36,36 @@ import org.testng.annotations.Test;
 
 public class StPointFunctionTest extends BaseTransformFunctionTest {
   @Test
-  public void testStPointFunction() {
-    ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("ST_Point(%s,%s)", DOUBLE_SV_COLUMN, DOUBLE_SV_COLUMN));
+  public void testStPointGeogFunction() {
+    testStPointFunction(0);
+    testStPointFunction(1);
+  }
+
+  @Test
+  public void testStPointLiteralFunction() {
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format("ST_Point(20,10, 1)"));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(20, 10));
+      GeometryUtils.setGeography(point);
+      expectedValues[i] = GeometrySerializer.serialize(point);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  private void testStPointFunction(int isGeography) {
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("ST_Point(%s,%s, %d)", DOUBLE_SV_COLUMN, DOUBLE_SV_COLUMN, isGeography));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof StPointFunction);
     Assert.assertEquals(transformFunction.getName(), StPointFunction.FUNCTION_NAME);
     byte[][] expectedValues = new byte[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
       Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(_doubleSVValues[i], _doubleSVValues[i]));
+      if (isGeography > 0) {
+        GeometryUtils.setGeography(point);
+      }
       expectedValues[i] = GeometrySerializer.serialize(point);
     }
     testTransformFunction(transformFunction, expectedValues);

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
@@ -7,7 +7,9 @@
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "schemaName": "meetupRsvp",
-    "replication": "1"
+    "replication": "1",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "1"
   },
   "tenants": {},
   "tableIndexConfig": {


### PR DESCRIPTION
## Description
 - Add a third parameter to `ST_Point` to create the point in geography, this simplifies the geographic point creation. Instead of `ST_GeogFromText(ST_AsText(ST_Point(group_lat, group_lon))`, we can now use `ST_Point(group_lat, group_lon, 1)`.
 - Support `ST_Point` creation from literal such as `ST_Point(44.183189,-115.761905)`
 - Swapped latitude, longitude for `ST_Distance` calculation for geography.
, etc.
## Upgrade Notes

Does this PR otherwise need attention when creating release notes? Things to consider:
- The signature of `ST_Point` is changed to take an optional third parameter. 0 (default) means geometry, 1 means geography
- In `ST_Distance(ST_Point( y1,x1), ST_Point(y2, x2))` is changed to `ST_Distance(ST_Point(x1, y1), ST_Point(x1, y2))` for geography

## Release Notes
The sequence of latitude, longitude is changed for the points in ST_Distance
