### PR TITLE
Include exception message in the ControllerApplicationException for /validate

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -390,7 +390,7 @@ public class PinotTableRestletResource {
       }
       return tableConfigValidateStr.toString();
     } catch (Exception e) {
-      String msg = String.format("Invalid table config: %s", tableConfig.getTableName());
+      String msg = String.format("Invalid table config: %s. %s", tableConfig.getTableName(), e.getMessage());
       throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
     }
   }


### PR DESCRIPTION
When validating an invalid table config, the reason is not returned in the result in swagger. It is returned correctly in add table. Doing the same in validate, so that the cluster manager can display the right message on the UI.