### PR TITLE
Use StringUtils.replace for setting string literal expression

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
@@ -113,7 +114,7 @@ public class RequestUtils {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
     } else {
-      literal.setStringValue(node.toValue().replace("''", "'"));
+      literal.setStringValue(StringUtils.replace(node.toValue(), "''", "'"));
     }
     expression.setLiteral(literal);
     return expression;


### PR DESCRIPTION
For very large queries (several 100s of lines, size of single query 50KB+), @mayankshriv  had noticed the overhead of SqlNode.toString when converting the predicates to literal expression in `getLiteralExpression` . See the below flamegraph profile. The time spent ratio between calcite internal code (`SqlParser.parseQuery`) and our code (`toExpression`) is 1:1

![Screen Shot 2020-12-03 at 10 04 34 AM](https://user-images.githubusercontent.com/2150694/101079851-e2025880-355c-11eb-9340-584ed986207f.png)

In the PR https://github.com/apache/incubator-pinot/pull/6258/ by @fx19880617 , this code was optimized to avoid the overhead of SqlNode.toString and replaceAll by using SqlNode.toValue().replace("''", "'"). This helped significantly by shifting the overhead more towards calcite internal code. The ratio changed to 4 : 1 as seen in the flamegraph below But String.replace() was still taking reasonable time for our huge queries where the replacement is actually not needed. This internally uses regex to find the occurrence of '' in the string literal and replace it with '. 

![Screen Shot 2020-12-03 at 10 36 47 AM](https://user-images.githubusercontent.com/2150694/101080646-e2e7ba00-355d-11eb-918a-3808b05344e9.png)

In this PR, we use StringUtils.replace since this first uses indexOf to find if the searchString ('') is present in the query. If not, it returns immediately. If present, it builds the query without regex. This shifts the overhead pretty much towards Calcite internal code as the ratio is changed to 10 : 1 as seen in the flamegraph. The box for SqlParser.parseQuery widens

![Screen Shot 2020-12-03 at 10 38 20 AM](https://user-images.githubusercontent.com/2150694/101081838-74a3f700-355f-11eb-9267-0f71240e37ee.png)