### PR TITLE
Fix: Close HelixAdmin appropriately, when setting up Helix Cluster.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -66,22 +66,29 @@ public class HelixSetupUtils {
   }
 
   private static void setupHelixClusterIfNeeded(String helixClusterName, String zkPath) {
-    HelixAdmin admin = new ZKHelixAdmin(zkPath);
-    if (admin.getClusters().contains(helixClusterName)) {
-      LOGGER.info("Helix cluster: {} already exists", helixClusterName);
-    } else {
-      LOGGER.info("Creating a new Helix cluster: {}", helixClusterName);
-      admin.addCluster(helixClusterName, false);
-      // Enable Auto-Join for the cluster
-      HelixConfigScope configScope =
-          new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
-      Map<String, String> configMap = new HashMap<>();
-      configMap.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, Boolean.toString(true));
-      configMap.put(ENABLE_CASE_INSENSITIVE_KEY, Boolean.toString(false));
-      configMap.put(DEFAULT_HYPERLOGLOG_LOG2M_KEY, Integer.toString(DEFAULT_HYPERLOGLOG_LOG2M));
-      configMap.put(CommonConstants.Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.toString(false));
-      admin.setConfig(configScope, configMap);
-      LOGGER.info("New Helix cluster: {} created", helixClusterName);
+    HelixAdmin admin = null;
+    try {
+      admin = new ZKHelixAdmin(zkPath);
+      if (admin.getClusters().contains(helixClusterName)) {
+        LOGGER.info("Helix cluster: {} already exists", helixClusterName);
+      } else {
+        LOGGER.info("Creating a new Helix cluster: {}", helixClusterName);
+        admin.addCluster(helixClusterName, false);
+        // Enable Auto-Join for the cluster
+        HelixConfigScope configScope =
+            new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(helixClusterName).build();
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(ZKHelixManager.ALLOW_PARTICIPANT_AUTO_JOIN, Boolean.toString(true));
+        configMap.put(ENABLE_CASE_INSENSITIVE_KEY, Boolean.toString(false));
+        configMap.put(DEFAULT_HYPERLOGLOG_LOG2M_KEY, Integer.toString(DEFAULT_HYPERLOGLOG_LOG2M));
+        configMap.put(CommonConstants.Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.toString(false));
+        admin.setConfig(configScope, configMap);
+        LOGGER.info("New Helix cluster: {} created", helixClusterName);
+      }
+    } finally {
+      if (admin != null) {
+        admin.close();
+      }
     }
   }
 


### PR DESCRIPTION
Currently, we cannot select multiple controller tests and run them in IDE successfully.
We see that after the first test that extends `ControllerTest`, the setup for next test
is unsuccessful due to the following reason:

- In `startController`, we setup Helix as well as Pinot Controllers.
- Both of these end up opening a ZKClient, however, only one of them (Pinot Controller)
  closes the zkClient.
- Since Helix controller does not close the ZKCLient, it remains alive, even after the
  first test's `cleanup()` is called.
- Given that we use SharedZKClientFactory which is a singleton class, and when running
  multiple tests from IDE, they use the same JVM, the second test ends up getting
  an obsolete ZKClient from preivous test, which is already disconnected.

This PR fixes the issue by appropriately closing the HelixAdmin (which closes the ZKClient)
when completed.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
