### PR TITLE
Avoids triggering GH action workflow on non-code changes

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -22,6 +22,12 @@ name: Pinot Tests
 on:
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - "docs/**"
+      - "licenses/**"
+      - "licenses-binary/**"
+      - "website/**"
+      - "**.md"
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Description

I noticed that we are running CI on every single change including changes in README, docs and licence files which is not necessary at all.

GitHub actions supports path filters which we can use to avoid running CI on changes in markdown or text files. This PR utilizes that to filter docs, licence, website and README file. 

### References for this PR:
- https://github.community/t/using-on-push-tags-ignore-and-paths-ignore-together/16931
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
- https://github.com/hypertrace/hypertrace-service/pull/48 
- https://github.com/openshift/gatekeeper/blob/1fb8db0b4d81cd366a56808f950c3d6f8719f658/.github/workflows/workflow.yaml 
