### PR TITLE
Decimal percentile support.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -56,31 +56,32 @@ public class AggregationFunctionFactory {
           // Single argument percentile (e.g. Percentile99(foo), PercentileTDigest95(bar), etc.)
           if (remainingFunctionName.matches("\\d+")) {
             // Percentile
-            return new PercentileAggregationFunction(firstArgument, parsePercentile(remainingFunctionName));
+            return new PercentileAggregationFunction(firstArgument, parsePercentileToInt(remainingFunctionName));
           } else if (remainingFunctionName.matches("EST\\d+")) {
             // PercentileEst
             String percentileString = remainingFunctionName.substring(3);
-            return new PercentileEstAggregationFunction(firstArgument, parsePercentile(percentileString));
+            return new PercentileEstAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
           } else if (remainingFunctionName.matches("TDIGEST\\d+")) {
             // PercentileTDigest
             String percentileString = remainingFunctionName.substring(7);
-            return new PercentileTDigestAggregationFunction(firstArgument, parsePercentile(percentileString));
+            return new PercentileTDigestAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
           } else if (remainingFunctionName.matches("\\d+MV")) {
             // PercentileMV
             String percentileString = remainingFunctionName.substring(0, remainingFunctionName.length() - 2);
-            return new PercentileMVAggregationFunction(firstArgument, parsePercentile(percentileString));
+            return new PercentileMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
           } else if (remainingFunctionName.matches("EST\\d+MV")) {
             // PercentileEstMV
             String percentileString = remainingFunctionName.substring(3, remainingFunctionName.length() - 2);
-            return new PercentileEstMVAggregationFunction(firstArgument, parsePercentile(percentileString));
+            return new PercentileEstMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
           } else if (remainingFunctionName.matches("TDIGEST\\d+MV")) {
             // PercentileTDigestMV
             String percentileString = remainingFunctionName.substring(7, remainingFunctionName.length() - 2);
-            return new PercentileTDigestMVAggregationFunction(firstArgument, parsePercentile(percentileString));
+            return new PercentileTDigestMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
           }
         } else if (numArguments == 2) {
-          // Double arguments percentile (e.g. percentile(foo, 99), percentileTDigest(bar, 95), etc.)
-          int percentile = parsePercentile(arguments.get(1).getLiteral());
+          // Double arguments percentile (e.g. percentile(foo, 99), percentileTDigest(bar, 95), etc.) where the
+          // second argument is a decimal number from 0.0 to 100.0.
+          double percentile = parsePercentileToDouble(arguments.get(1).getLiteral());
           if (remainingFunctionName.isEmpty()) {
             // Percentile
             return new PercentileAggregationFunction(firstArgument, percentile);
@@ -175,9 +176,15 @@ public class AggregationFunctionFactory {
     }
   }
 
-  private static int parsePercentile(String percentileString) {
+  private static int parsePercentileToInt(String percentileString) {
     int percentile = Integer.parseInt(percentileString);
     Preconditions.checkArgument(percentile >= 0 && percentile <= 100, "Invalid percentile: %s", percentile);
+    return percentile;
+  }
+
+  private static double parsePercentileToDouble(String percentileString) {
+    double percentile = Double.parseDouble(percentileString);
+    Preconditions.checkArgument(percentile >= 0d && percentile <= 100d, "Invalid percentile: %s", percentile);
     return percentile;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -58,16 +58,15 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILE.getName() + (int)_percentile + "_" + _expression :
-        AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName() + (int) _percentile + "_" + _expression
+        : AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
-        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int) _percentile + "("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -34,10 +34,20 @@ import org.apache.pinot.core.query.request.context.ExpressionContext;
 public class PercentileAggregationFunction extends BaseSingleInputAggregationFunction<DoubleArrayList, Double> {
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
-  protected final int _percentile;
+  //version 0 functions specified in the of form PERCENTILE<2-digits>(column)
+  //version 1 functions of form PERCENTILE(column, <2-digits>.<16-digits>)
+  protected final int _version;
+  protected final double _percentile;
 
   public PercentileAggregationFunction(ExpressionContext expression, int percentile) {
     super(expression);
+    _version = 0;
+    _percentile = percentile;
+  }
+
+  public PercentileAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression);
+    _version = 1;
     _percentile = percentile;
   }
 
@@ -48,12 +58,16 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILE.getName() + (int)_percentile + "_" + _expression :
+        AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
+        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -35,10 +35,20 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class PercentileEstAggregationFunction extends BaseSingleInputAggregationFunction<QuantileDigest, Long> {
   public static final double DEFAULT_MAX_ERROR = 0.05;
 
-  protected final int _percentile;
+  //version 0 functions specified in the of form PERCENTILEEST<2-digits>(column)
+  //version 1 functions of form PERCENTILEEST(column, <2-digits>.<16-digits>)
+  protected final int _version;
+  protected final double _percentile;
 
   public PercentileEstAggregationFunction(ExpressionContext expression, int percentile) {
     super(expression);
+    _version = 0;
+    _percentile = percentile;
+  }
+
+  public PercentileEstAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression);
+    _version = 1;
     _percentile = percentile;
   }
 
@@ -49,12 +59,16 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILEEST.getName() + (int)_percentile + "_" + _expression:
+        AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
+        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -59,16 +59,15 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILEEST.getName() + (int)_percentile + "_" + _expression:
-        AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName() + (int) _percentile + "_" + _expression
+        : AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
-        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int) _percentile + "("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -44,16 +44,16 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILEEST.getName() + (int)_percentile + "MV_" + _expression :
-        AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName() + (int) _percentile + "MV_" + _expression
+        : AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
-        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int) _percentile + "mv("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile
+            + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -33,6 +33,10 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
     super(expression, percentile);
   }
 
+  public PercentileEstMVAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression, percentile);
+  }
+
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.PERCENTILEESTMV;
@@ -40,12 +44,16 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILEEST.getName() + (int)_percentile + "MV_" + _expression :
+        AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
+        AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -33,6 +33,10 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
     super(expression, percentile);
   }
 
+  public PercentileMVAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression, percentile);
+  }
+
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.PERCENTILEMV;
@@ -40,12 +44,16 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILE.getName() + (int)_percentile + "MV_" + _expression:
+        AggregationFunctionType.PERCENTILE.getName()  + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILE.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
+        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -44,16 +44,15 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILE.getName() + (int)_percentile + "MV_" + _expression:
-        AggregationFunctionType.PERCENTILE.getName()  + _percentile + "MV_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName() + (int) _percentile + "MV_" + _expression
+        : AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
-        AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int) _percentile + "mv("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -62,16 +62,16 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILETDIGEST.getName() + (int)_percentile + "_" + _expression:
-        AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName() + (int) _percentile + "_" + _expression
+        : AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
-        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int) _percentile + "("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile
+            + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -38,10 +38,20 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class PercentileTDigestAggregationFunction extends BaseSingleInputAggregationFunction<TDigest, Double> {
   public static final int DEFAULT_TDIGEST_COMPRESSION = 100;
 
-  protected final int _percentile;
+  //version 0 functions specified in the of form PERCENTILETDIGEST<2-digits>(column)
+  //version 1 functions of form PERCENTILETDIGEST(column, <2-digits>.<16-digits>)
+  protected final int _version;
+  protected final double _percentile;
 
   public PercentileTDigestAggregationFunction(ExpressionContext expression, int percentile) {
     super(expression);
+    _version = 0;
+    _percentile = percentile;
+  }
+
+  public PercentileTDigestAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression);
+    _version = 1;
     _percentile = percentile;
   }
 
@@ -52,12 +62,16 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILETDIGEST.getName() + (int)_percentile + "_" + _expression:
+        AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int)_percentile + "(" + _expression + ")" :
+        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -44,16 +44,16 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public String getColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILETDIGEST.getName() + (int)_percentile + "MV_" + _expression:
-        AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
+    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName() + (int) _percentile + "MV_" + _expression
+        : AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return _version == 0 ?
-        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
-        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
+    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int) _percentile + "mv("
+        + _expression + ")"
+        : AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile
+            + ")";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -33,6 +33,10 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
     super(expression, percentile);
   }
 
+  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, double percentile) {
+    super(expression, percentile);
+  }
+
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.PERCENTILETDIGESTMV;
@@ -40,12 +44,16 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
 
   @Override
   public String getColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILETDIGEST.getName() + (int)_percentile + "MV_" + _expression:
+        AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
   }
 
   @Override
   public String getResultColumnName() {
-    return AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + _percentile + "mv(" + _expression + ")";
+    return _version == 0 ?
+        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int)_percentile + "mv(" + _expression + ")":
+        AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -135,6 +135,48 @@ public class AggregationFunctionFactoryTest {
     assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
+    function = getFunction("PeRcEnTiLe", "(column, 5)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
+    assertEquals(aggregationFunction.getColumnName(), "percentile5.0_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.0)");
+
+    function = getFunction("PeRcEnTiLe", "(column, 5.5)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
+    assertEquals(aggregationFunction.getColumnName(), "percentile5.5_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.5)");
+
+    function = getFunction("PeRcEnTiLeEsT", "(column, 50)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileEst50.0_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 50.0)");
+
+    function = getFunction("PeRcEnTiLeEsT", "(column, 55.555)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileEst55.555_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 55.555)");
+
+    function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99.0_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.0)");
+
+    function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99.9999)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99.9999_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.9999)");
+
     function = getFunction("CoUnTmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
@@ -239,10 +281,42 @@ public class AggregationFunctionFactoryTest {
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest95mv(column)");
+
+    function = getFunction("PeRcEnTiLeMv", "(column, 10)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentile10.0MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentilemv(column, 10.0)");
+
+    function = getFunction("PeRcEnTiLeEsTmV", "(column, 90)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentileEst90.0MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentileestmv(column, 90.0)");
+
+    function = getFunction("PeRcEnTiLeTdIgEsTmV", "(column, 95)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95.0MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
+
+    function = getFunction("PeRcEnTiLe_TdIgEsT_mV", "(column, 95)");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
+    assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
+    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95.0MV_column");
+    assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
   }
 
   private FunctionContext getFunction(String functionName) {
-    return QueryContextConverterUtils.getExpression(functionName + ARGUMENT).getFunction();
+    return getFunction(functionName, ARGUMENT);
+  }
+
+  private FunctionContext getFunction(String functionName, String args) {
+    return QueryContextConverterUtils.getExpression(functionName + args).getFunction();
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableMultiValueQueriesTest.java
@@ -437,19 +437,26 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
 
   @Test
   public void testPercentile50MV() {
-    List<String> queries = Arrays.asList("SELECT PERCENTILE50MV(column6) FROM testTable",
-        "SELECT PERCENTILEMV(column6, 50) FROM testTable", "SELECT PERCENTILEMV(column6, '50') FROM testTable",
-        "SELECT PERCENTILEMV(column6, \"50\") FROM testTable");
+    List<String> queries = Arrays
+        .asList("SELECT PERCENTILE50MV(column6) FROM testTable", "SELECT PERCENTILEMV(column6, 50) FROM testTable",
+            "SELECT PERCENTILEMV(column6, '50') FROM testTable", "SELECT PERCENTILEMV(column6, \"50\") FROM testTable");
 
     DataSchema dataSchema;
     List<Object[]> rows;
     int expectedResultsSize;
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.RESPONSE_FORMAT, CommonConstants.Broker.Request.SQL);
-    for (String query : queries) {
+    for (int i = 0; i < queries.size(); i++) {
+      String query = queries.get(i);
       BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
-      dataSchema = new DataSchema(new String[]{"percentile50mv(column6)"},
-          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+
+      // Schema for first query is different from schema of the rest of the queries because the second query is using PERCENTILEEMV
+      // function that works off decimal values.
+      dataSchema = i == 0 ? new DataSchema(new String[]{"percentile50mv(column6)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE})
+          : new DataSchema(new String[]{"percentilemv(column6, 50.0)"},
+              new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+
       rows = new ArrayList<>();
       rows.add(new Object[]{2147483647.0});
       expectedResultsSize = 1;
@@ -463,8 +470,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
           expectedResultsSize, dataSchema);
 
       brokerResponse = getBrokerResponseForPqlQuery(query + FILTER + SV_GROUP_BY, queryOptions);
-      dataSchema = new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
-          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+
+      // Schema for first query is different from schema of the rest of the queries because the second query is using PERCENTILEEMV
+      // function that works off decimal values.
+      dataSchema = i == 0 ? new DataSchema(new String[]{"column8", "percentile50mv(column6)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE})
+          : new DataSchema(new String[]{"column8", "percentilemv(column6, 50.0)"},
+              new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+
       rows = new ArrayList<>();
       rows.add(new Object[]{"118380643", 5392989.0});
       expectedResultsSize = 10;
@@ -472,8 +485,14 @@ public class InterSegmentResultTableMultiValueQueriesTest extends BaseMultiValue
           expectedResultsSize, dataSchema);
 
       brokerResponse = getBrokerResponseForPqlQuery(query + FILTER + MV_GROUP_BY, queryOptions);
-      dataSchema = new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
-          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+
+      // Schema for first query is different from schema of the rest of the queries because the second query is using PERCENTILEEMV
+      // function that works off decimal values.
+      dataSchema = i == 0 ? new DataSchema(new String[]{"column7", "percentile50mv(column6)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE})
+          : new DataSchema(new String[]{"column7", "percentilemv(column6, 50.0)"},
+              new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+
       rows = new ArrayList<>();
       rows.add(new Object[]{"341", 5084850.0});
       QueriesTestUtils.testInterSegmentResultTable(brokerResponse, 174560L, 426752L, 349120L, 400000L, rows,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentResultTableSingleValueQueriesTest.java
@@ -581,7 +581,7 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
 
   @Test
   public void testPercentile50() {
-    List<String> queries = Arrays.asList("SELECT PERCENTILE50(column1), PERCENTILE50(column3) FROM testTable",
+    List<String> queries = Arrays.asList("SELECT PERCENTILE50(column1),PERCENTILE50(column3) FROM testTable",
         "SELECT PERCENTILE(column1, 50), PERCENTILE(column3, 50) FROM testTable",
         "SELECT PERCENTILE(column1, '50'), PERCENTILE(column3, '50') FROM testTable",
         "SELECT PERCENTILE(column1, \"50\"), PERCENTILE(column3, \"50\") FROM testTable");
@@ -591,10 +591,13 @@ public class InterSegmentResultTableSingleValueQueriesTest extends BaseSingleVal
     int expectedResultsSize;
     Map<String, String> queryOptions = new HashMap<>(2);
     queryOptions.put(QueryOptionKey.RESPONSE_FORMAT, Request.SQL);
-    for (String query : queries) {
+    for (int i = 0; i < queries.size(); i++) {
+      String query = queries.get(i);
       BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query, queryOptions);
-      dataSchema = new DataSchema(new String[]{"percentile50(column1)", "percentile50(column3)"},
-          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
+      dataSchema = i == 0 ? new DataSchema(new String[]{"percentile50(column1)", "percentile50(column3)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE})
+          : new DataSchema(new String[]{"percentile(column1, 50.0)", "percentile(column3, 50.0)"},
+              new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
       rows = new ArrayList<>();
       rows.add(new Object[]{1107310944.0, 1080136306.0});
       expectedResultsSize = 1;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestMVQueriesTest.java
@@ -24,6 +24,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -31,11 +35,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.spi.data.readers.RecordReader;
-import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import org.apache.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
-import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 
 
@@ -103,8 +103,8 @@ public class PercentileTDigestMVQueriesTest extends PercentileTDigestQueriesTest
 
   @Override
   protected String getAggregationQuery(int percentile) {
-    return String
-        .format("SELECT PERCENTILE%dMV(%s), PERCENTILETDIGEST%dMV(%s), PERCENTILETDIGEST%d(%s) FROM %s", percentile,
-            DOUBLE_COLUMN, percentile, DOUBLE_COLUMN, percentile, TDIGEST_COLUMN, TABLE_NAME);
+    return String.format("SELECT PERCENTILE%1$dMV(%2$s), PERCENTILETDIGEST%1$dMV(%2$s), PERCENTILETDIGEST%1$d(%3$s), "
+            + "PERCENTILEMV(%2$s, %1$d), PERCENTILETDIGESTMV(%2$s, %1$d), PERCENTILETDIGEST(%3$s, %1$d) FROM %4$s",
+        percentile, DOUBLE_COLUMN, TDIGEST_COLUMN, TABLE_NAME);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -168,11 +168,17 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
     List<Object> aggregationResult = resultsBlock.getAggregationResult();
     Assert.assertNotNull(aggregationResult);
-    Assert.assertEquals(aggregationResult.size(), 3);
-    DoubleList doubleList = (DoubleList) aggregationResult.get(0);
-    Collections.sort(doubleList);
-    assertTDigest((TDigest) aggregationResult.get(1), doubleList);
-    assertTDigest((TDigest) aggregationResult.get(2), doubleList);
+    Assert.assertEquals(aggregationResult.size(), 6);
+    DoubleList doubleList0 = (DoubleList) aggregationResult.get(0);
+    Collections.sort(doubleList0);
+    assertTDigest((TDigest) aggregationResult.get(1), doubleList0);
+    assertTDigest((TDigest) aggregationResult.get(2), doubleList0);
+
+    DoubleList doubleList3 = (DoubleList)aggregationResult.get(3);
+    Collections.sort(doubleList3);
+    Assert.assertEquals(doubleList3, doubleList0);
+    assertTDigest((TDigest) aggregationResult.get(4), doubleList0);
+    assertTDigest((TDigest) aggregationResult.get(5), doubleList0);
   }
 
   @Test
@@ -181,12 +187,18 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
       BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getAggregationQuery(percentile));
       List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
       Assert.assertNotNull(aggregationResults);
-      Assert.assertEquals(aggregationResults.size(), 3);
+      Assert.assertEquals(aggregationResults.size(), 6);
       double expected = Double.parseDouble((String) aggregationResults.get(0).getValue());
-      double resultForDoubleColumn = Double.parseDouble((String) aggregationResults.get(1).getValue());
-      Assert.assertEquals(resultForDoubleColumn, expected, DELTA, ERROR_MESSAGE);
-      double resultForTDigestColumn = Double.parseDouble((String) aggregationResults.get(2).getValue());
-      Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+      double resultForDoubleColumn1 = Double.parseDouble((String) aggregationResults.get(1).getValue());
+      Assert.assertEquals(resultForDoubleColumn1, expected, DELTA, ERROR_MESSAGE);
+      double resultForTDigestColumn2 = Double.parseDouble((String) aggregationResults.get(2).getValue());
+      Assert.assertEquals(resultForTDigestColumn2, expected, DELTA, ERROR_MESSAGE);
+      double resultForDoubleColumn3 = Double.parseDouble((String) aggregationResults.get(3).getValue());
+      Assert.assertEquals(resultForDoubleColumn3, expected, DELTA, ERROR_MESSAGE);
+      double resultForDoubleColumn4 = Double.parseDouble((String) aggregationResults.get(4).getValue());
+      Assert.assertEquals(resultForDoubleColumn4, expected, DELTA, ERROR_MESSAGE);
+      double resultForTDigestColumn5 = Double.parseDouble((String) aggregationResults.get(5).getValue());
+      Assert.assertEquals(resultForTDigestColumn5, expected, DELTA, ERROR_MESSAGE);
     }
   }
 
@@ -200,10 +212,16 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
     while (groupKeyIterator.hasNext()) {
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      DoubleList doubleList = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
-      Collections.sort(doubleList);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 1), doubleList);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 2), doubleList);
+      DoubleList doubleList0 = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
+      Collections.sort(doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 1), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 2), doubleList0);
+
+      DoubleList doubleList3 = (DoubleList) groupByResult.getResultForKey(groupKey, 3);
+      Collections.sort(doubleList3);
+      Assert.assertEquals(doubleList3, doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 4), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 5), doubleList0);
     }
   }
 
@@ -213,7 +231,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
       BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(getGroupByQuery(percentile));
       List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
       Assert.assertNotNull(aggregationResults);
-      Assert.assertEquals(aggregationResults.size(), 3);
+      Assert.assertEquals(aggregationResults.size(), 6);
       Map<String, Double> expectedValues = new HashMap<>();
       for (GroupByResult groupByResult : aggregationResults.get(0).getGroupByResult()) {
         expectedValues.put(groupByResult.getGroup().get(0), Double.parseDouble((String) groupByResult.getValue()));
@@ -230,13 +248,31 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
         double resultForTDigestColumn = Double.parseDouble((String) groupByResult.getValue());
         Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
       }
+      for (GroupByResult groupByResult : aggregationResults.get(3).getGroupByResult()) {
+        String group = groupByResult.getGroup().get(0);
+        double expected = expectedValues.get(group);
+        double resultForTDigestColumn = Double.parseDouble((String) groupByResult.getValue());
+        Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+      }
+      for (GroupByResult groupByResult : aggregationResults.get(4).getGroupByResult()) {
+        String group = groupByResult.getGroup().get(0);
+        double expected = expectedValues.get(group);
+        double resultForTDigestColumn = Double.parseDouble((String) groupByResult.getValue());
+        Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+      }
+      for (GroupByResult groupByResult : aggregationResults.get(5).getGroupByResult()) {
+        String group = groupByResult.getGroup().get(0);
+        double expected = expectedValues.get(group);
+        double resultForTDigestColumn = Double.parseDouble((String) groupByResult.getValue());
+        Assert.assertEquals(resultForTDigestColumn, expected, DELTA, ERROR_MESSAGE);
+      }
     }
   }
 
   protected String getAggregationQuery(int percentile) {
     return String
-        .format("SELECT PERCENTILE%d(%s), PERCENTILETDIGEST%d(%s), PERCENTILETDIGEST%d(%s) FROM %s", percentile,
-            DOUBLE_COLUMN, percentile, DOUBLE_COLUMN, percentile, TDIGEST_COLUMN, TABLE_NAME);
+        .format("SELECT PERCENTILE%1$d(%2$s), PERCENTILETDIGEST%1$d(%2$s), PERCENTILETDIGEST%1$d(%3$s), PERCENTILE(%2$s, %1$d), PERCENTILETDIGEST(%2$s, %1$d), PERCENTILETDIGEST(%3$s, %1$d) FROM %4$s",
+            percentile, DOUBLE_COLUMN, TDIGEST_COLUMN, TABLE_NAME);
   }
 
   private String getGroupByQuery(int percentile) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -270,9 +270,10 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
   }
 
   protected String getAggregationQuery(int percentile) {
-    return String
-        .format("SELECT PERCENTILE%1$d(%2$s), PERCENTILETDIGEST%1$d(%2$s), PERCENTILETDIGEST%1$d(%3$s), PERCENTILE(%2$s, %1$d), PERCENTILETDIGEST(%2$s, %1$d), PERCENTILETDIGEST(%3$s, %1$d) FROM %4$s",
-            percentile, DOUBLE_COLUMN, TDIGEST_COLUMN, TABLE_NAME);
+    return String.format(
+        "SELECT PERCENTILE%1$d(%2$s), PERCENTILETDIGEST%1$d(%2$s), PERCENTILETDIGEST%1$d(%3$s), PERCENTILE(%2$s, %1$d), "
+            + "PERCENTILETDIGEST(%2$s, %1$d), PERCENTILETDIGEST(%3$s, %1$d) FROM %4$s", percentile, DOUBLE_COLUMN,
+        TDIGEST_COLUMN, TABLE_NAME);
   }
 
   private String getGroupByQuery(int percentile) {


### PR DESCRIPTION
This PR adds support for specifying decimal percentile (99.999, 0.00001, etc) through the following functions:
```
PERCENTILE(column, percentile)
PERCENTILEEST(column, percentile)
PERCENTILETDIGEST(column, percentile)
PERCENTILEMV(column, percentile)
PERCENTILEESTMV(column, percentile)
PERCENTILETDIGESTMV(column, percentile)
```

Note that there is no change in the external behavior of existing percentile functions, that only take integer percentile values, as described in [documentation](https://docs.pinot.apache.org/users/user-guide-query/supported-aggregations). However, the internal implementation of these functions were changed to support decimal percentile values as well.

Files modified to allow for successfully parsing and validating decimal values in new percentile functions:

> AggregationFunctionFactory.java

Existing implementation of percentile functions were modified to allow for supporting both the existing and the new percentile functions with decimal values:

> PercentileAggregationFunction.java
> PercentileEstAggregationFunction.java
> PercentileEstMVAggregationFunction.java
> PercentileMVAggregationFunction.java
> PercentileTDigestAggregationFunction.java
> PercentileTDigestMVAggregationFunction.java

Files modified to add / fix new unit tests:

> AggregationFunctionFactoryTest.java
> PercentileTDigestQueriesTest.java
> InterSegmentResultTableMultiValueQueriesTest.java
> InterSegmentResultTableSingleValueQueriesTest.java
> PercentileTDigestMVQueriesTest.java
> PercentileTDigestQueriesTest.java

I will update the documentation once this PR is complete.