### PR TITLE
Fix table cache logic in pinot-broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1002,7 +1002,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         columnName = splits[1];
       }
       if (columnNameMap != null) {
-        return columnNameMap.getOrDefault(columnName, columnName);
+        return columnNameMap.getOrDefault(columnName.toLowerCase(), columnName);
       } else {
         return columnName;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
@@ -106,7 +106,7 @@ public class SelectAstNode extends BaseAstNode {
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
     // Set the query source
     QuerySource querySource = new QuerySource();
-    querySource.setTableName(_resourceName);
+    querySource.setTableName(_tableName);
     brokerRequest.setQuerySource(querySource);
 
     sendBrokerRequestUpdateToChildren(brokerRequest);
@@ -169,7 +169,7 @@ public class SelectAstNode extends BaseAstNode {
   public void updatePinotQuery(PinotQuery pinotQuery) {
     // Set data source
     DataSource dataSource = new DataSource();
-    dataSource.setTableName(_resourceName);
+    dataSource.setTableName(_tableName);
     pinotQuery.setDataSource(dataSource);
     sendPinotQueryUpdateToChildren(pinotQuery);
     if (_offset != -1) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1307,7 +1307,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     for (String query : queries) {
       try {
-        postQuery(query);
+        JsonNode response = postQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "PQL: " + query + " failed");
+
+        response = postSqlQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "SQL: " + query + " failed");
       } catch (Exception e) {
         // Fail the test when exception caught
         throw new RuntimeException("Got Exceptions from query - " + query);
@@ -1334,7 +1338,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     for (String query : queries) {
       try {
-        postQuery(query);
+        JsonNode response = postQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "PQL: " + query + " failed");
+
+        response = postSqlQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "SQL: " + query + " failed");
       } catch (Exception e) {
         // Fail the test when exception caught
         throw new RuntimeException("Got Exceptions from query - " + query);
@@ -1363,7 +1371,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     for (String query : queries) {
       try {
-        postQuery(query);
+        JsonNode response = postQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "PQL: " + query + " failed");
+
+        response = postSqlQuery(query);
+        assertTrue(response.get("numSegmentsProcessed").asLong() >= 1L, "SQL: " + query + " failed");
       } catch (Exception e) {
         // Fail the test when exception caught
         throw new RuntimeException("Got Exceptions from query - " + query);


### PR DESCRIPTION
## Description
This PR fixes table cache and its related integration test in pinot-broker. 
Currently the column name in queries doesn't get converted to lower cases before fetching the real column name in table cache.
And the case insensitivity setting is currently invalid for **pql** queries, thus also fixing the table name in `SelectAstNode` class and  updating the tests to send **sql** and **pql** queries in OfflineClusterIntegrationTest class.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
