### PR TITLE
Add a Controller endpoint to return table creation time

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -589,7 +589,7 @@ public class PinotTableRestletResource {
     TableType tableType;
     try {
       tableType = TableType.valueOf(tableTypeStr.toUpperCase());
-    } catch (IllegalArgumentException e) {
+    } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, "Illegal table type: " + tableTypeStr,
           Response.Status.BAD_REQUEST);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2573,6 +2573,12 @@ public class PinotHelixResourceManager {
     return onlineSegments;
   }
 
+  public long getTableCreationTimeInMillisFromEpoch(String tableNameWithType) {
+    String zkPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(tableNameWithType);
+    ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
+    return znRecord.getCreationTime();
+  }
+
   /*
    * Uncomment and use for testing on a real cluster
   public static void main(String[] args) throws Exception {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -142,7 +142,7 @@ public class PinotHelixResourceManager {
   public static final long EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS = 10 * 60_000L; // 10 minutes
   public static final long EXTERNAL_VIEW_CHECK_INTERVAL_MS = 1_000L; // 1 second
 
-  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd'T'HHmm'Z'");
+  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
 
   private final Map<String, Map<String, Long>> _segmentCrcMap = new HashMap<>();
   private final Map<String, Map<String, Integer>> _lastKnownSegmentMetadataVersionMap = new HashMap<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -26,6 +26,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -113,6 +114,7 @@ import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.config.table.TableStats;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -139,6 +141,8 @@ public class PinotHelixResourceManager {
   // TODO: make this configurable
   public static final long EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS = 10 * 60_000L; // 10 minutes
   public static final long EXTERNAL_VIEW_CHECK_INTERVAL_MS = 1_000L; // 1 second
+
+  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd'T'HHmm'Z'");
 
   private final Map<String, Map<String, Long>> _segmentCrcMap = new HashMap<>();
   private final Map<String, Map<String, Integer>> _lastKnownSegmentMetadataVersionMap = new HashMap<>();
@@ -2573,10 +2577,11 @@ public class PinotHelixResourceManager {
     return onlineSegments;
   }
 
-  public long getTableCreationTimeInMillisFromEpoch(String tableNameWithType) {
+  public TableStats getTableStats(String tableNameWithType) {
     String zkPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(tableNameWithType);
     ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
-    return znRecord.getCreationTime();
+    String creationTime = SIMPLE_DATE_FORMAT.format(znRecord.getCreationTime());
+    return new TableStats(creationTime);
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
@@ -199,6 +200,7 @@ public class PinotHelixResourceManager {
     for (int i = 0; i < _tableUpdaterLocks.length; i++) {
       _tableUpdaterLocks[i] = new Object();
     }
+    SIMPLE_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
   public PinotHelixResourceManager(ControllerConf controllerConf) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/*
+ * Container object for metadata info / stats of Pinot tables
+ */
+public class TableStats {
+  public static final String CREATION_TIME_KEY = "creationTime";
+
+  private String _creationTime;
+
+  public TableStats(String creationTime) {
+    _creationTime = creationTime;
+  }
+
+  @JsonProperty(CREATION_TIME_KEY)
+  public String getCreationTime() {
+    return _creationTime;
+  }
+
+  public void setCreationTime(String creationTime) {
+    _creationTime = creationTime;
+  }
+}


### PR DESCRIPTION
## Description
Added a GET endpoint on Controller to return metadata info/stats about a table. For now only table creation time is in the TableStats object. Later on, more info can be added to this object.

## Testing Done
Ran `quick-start-hybrid.sh` locally and hit the endpoint:
```bash
➜  ~ curl 'localhost:9000/tables/airlineStats/stats' | jq .
{
  "OFFLINE": {
    "creationTime": "20201210T105708Z"
  },
  "REALTIME": {
    "creationTime": "20201210T105712Z"
  }
}
➜  ~ curl 'localhost:9000/tables/airlineStats/stats?type=realtime' | jq .
{
  "REALTIME": {
    "creationTime": "20201210T105712Z"
  }
}
```


### -------------- Previous Description --------------
[Didn't delete so that  the conversation on the PR makes sense]

## Description
Added a GET endpoint on Controller to return table creation time. 
For one of our clusters, some admin tools need to delete the tables two weeks after the creation time. Therefore the table creation time API is exposed in this PR.

## Testing Done
Ran `quick-start-batch.sh` locally and hit the endpoint:
```bash
➜  ~ curl 'localhost:9000/tables/baseballStats/creationTime?type=offline'
1607392187128
➜  ~ date -r 1607392187
Mon Dec  7 17:49:47 PST 2020
➜  ~ curl 'localhost:9000/tables/baseballStats/creationTime'
{"code":400,"error":"Illegal table type: null"}
```
Here is the ZooInspector snapshot for the same table which verifies the creation time returned by the endpoint:
![image](https://user-images.githubusercontent.com/8548220/101429151-18223e00-38b7-11eb-9a69-b111a6c77012.png)

