### PR TITLE
Segment reset API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -362,23 +362,22 @@ public class PinotSegmentRestletResource {
   @POST
   @Path("segments/{tableNameWithType}/{segmentName}/reset")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Resets a segment by first disabling it, waiting for external view to stabilize, and finally enabling it again",
-      notes = "Resets a segment by disabling and then enabling a segment")
+  @ApiOperation(value = "Resets a segment by first disabling it, waiting for external view to stabilize, and finally enabling it again", notes = "Resets a segment by disabling and then enabling the segment")
   public SuccessResponse resetSegment(
       @ApiParam(value = "Name of the table with type", required = true) @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @ApiParam(value = "Time in millis to wait for external view to converge") @QueryParam("externalViewWaitTimeMs") long externalViewWaitTimeMs) {
+      @ApiParam(value = "Maximum time in milliseconds to wait for reset to be completed. By default, uses serverAdminRequestTimeout") @QueryParam("maxWaitTimeMs") long maxWaitTimeMs) {
     segmentName = URIUtils.decode(segmentName);
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     try {
       Preconditions.checkState(tableType != null, "Must provide table name with type: %s", tableNameWithType);
       _pinotHelixResourceManager.resetSegment(tableNameWithType, segmentName,
-          externalViewWaitTimeMs > 0 ? externalViewWaitTimeMs
-              : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
-      return new SuccessResponse("Successfully invoked segment reset");
+          maxWaitTimeMs > 0 ? maxWaitTimeMs : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      return new SuccessResponse(
+          String.format("Successfully reset segment: %s of table: %s", segmentName, tableNameWithType));
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          String.format("Failed to reset segment: %s in table: %s. %s", segmentName, tableNameWithType, e.getMessage()),
+          String.format("Failed to reset segment: %s of table: %s. %s", segmentName, tableNameWithType, e.getMessage()),
           Status.NOT_FOUND);
     }
   }
@@ -391,17 +390,16 @@ public class PinotSegmentRestletResource {
   @POST
   @Path("segments/{tableNameWithType}/reset")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Resets all segments of the table, by first disabling them, waiting for external view to stabilize, and finally enabling the segments",
-      notes = "Resets a segment by disabling and then enabling a segment")
+  @ApiOperation(value = "Resets all segments of the table, by first disabling them, waiting for external view to stabilize, and finally enabling the segments", notes = "Resets a segment by disabling and then enabling a segment")
   public SuccessResponse resetAllSegments(
       @ApiParam(value = "Name of the table with type", required = true) @PathParam("tableNameWithType") String tableNameWithType,
-      @ApiParam(value = "Time in millis to wait for external view to converge") @QueryParam("externalViewWaitTimeMs") long externalViewWaitTimeMs) {
+      @ApiParam(value = "Maximum time in milliseconds to wait for reset to be completed. By default, uses serverAdminRequestTimeout") @QueryParam("maxWaitTimeMs") long maxWaitTimeMs) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     try {
       Preconditions.checkState(tableType != null, "Must provide table name with type: %s", tableNameWithType);
-      _pinotHelixResourceManager.resetAllSegments(tableNameWithType, externalViewWaitTimeMs > 0 ? externalViewWaitTimeMs
-          : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
-      return new SuccessResponse("Successfully invoked segment reset");
+      _pinotHelixResourceManager.resetAllSegments(tableNameWithType,
+          maxWaitTimeMs > 0 ? maxWaitTimeMs : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      return new SuccessResponse(String.format("Successfully reset all segments of table: %s", tableNameWithType));
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Failed to reset segments in table: %s. %s", tableNameWithType, e.getMessage()),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -375,10 +376,14 @@ public class PinotSegmentRestletResource {
           maxWaitTimeMs > 0 ? maxWaitTimeMs : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
       return new SuccessResponse(
           String.format("Successfully reset segment: %s of table: %s", segmentName, tableNameWithType));
+    } catch (IllegalStateException e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to reset segments in table: %s. %s", tableNameWithType, e.getMessage()),
+          Status.NOT_FOUND);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Failed to reset segment: %s of table: %s. %s", segmentName, tableNameWithType, e.getMessage()),
-          Status.NOT_FOUND);
+          Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -400,10 +405,14 @@ public class PinotSegmentRestletResource {
       _pinotHelixResourceManager.resetAllSegments(tableNameWithType,
           maxWaitTimeMs > 0 ? maxWaitTimeMs : _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
       return new SuccessResponse(String.format("Successfully reset all segments of table: %s", tableNameWithType));
-    } catch (Exception e) {
+    } catch (IllegalStateException e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Failed to reset segments in table: %s. %s", tableNameWithType, e.getMessage()),
           Status.NOT_FOUND);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to reset segments in table: %s. %s", tableNameWithType, e.getMessage()),
+          Status.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1828,8 +1828,9 @@ public class PinotHelixResourceManager {
     }
     if (!instancesToCheck.isEmpty()) {
       throw new TimeoutException(String.format(
-          "Timed out waiting for external view to stabilize after call to disable/reset segment: %s of table: %s. Skipping enable of segment.",
-          segmentName, tableNameWithType));
+          "Timed out waiting for external view to stabilize after call to disable/reset segment: %s of table: %s. "
+              + "Disable/reset might complete in the background, but skipping enable of segment.", segmentName,
+          tableNameWithType));
     }
 
     // Lastly, enable segment
@@ -1914,7 +1915,8 @@ public class PinotHelixResourceManager {
     }
     if (!segmentInstancesToCheck.isEmpty()) {
       throw new TimeoutException(String.format(
-          "Timed out waiting for external view to stabilize after call to disable/reset segments. Skipping enable of segments of table: %s",
+          "Timed out waiting for external view to stabilize after call to disable/reset segments. "
+              + "Disable/reset might complete in the background, but skipping enable of segments of table: %s",
           tableNameWithType));
     }
 


### PR DESCRIPTION
Adding a reset API. This API will disable and then enable the segment. This API will be useful in case of resetting consumers which are stuck as reported in https://github.com/apache/incubator-pinot/issues/6308.
NOTE: Manual testing done. Writing tests pending.

1. If the segment is in ERROR state, invoking this API will send state transitions first to OFFLINE, wait for EV to stabilize, and then back to ONLINE/CONSUMING.
2. If segment is ONLINE/CONSUMING, invoking this API will send state transitions, first to OFFLINE, wait for EV to stabilize, and then back to ONLINE/CONSUMING.

Reset one segment:
```
 curl -X POST "http://localhost:9000/segments/transcript_REALTIME/transcript__1__3__20201208T1956Z/reset" -H "accept: application/json"
{"status":"Successfully reset segment: transcript__1__3__20201208T1956Z of table: transcript_REALTIME"}
``` 
Reset all segments:
```
curl -X POST "http://localhost:9000/segments/transcript_REALTIME/reset" -H "accept: application/json" 
{"status":"Successfully reset all segments of table: transcript_REALTIME"}
```