### PR TITLE
Skips travis CI test on documentation-only change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,21 @@ language: java
 os: linux
 dist: trusty
 
+# Prevent test build of a documentation-only change.
+#
+# if: conditions are preferred as they obviate job creation. However, they can only use
+# pre-defined env variables or globals that can be evaluated statically. The other way to skip
+# is to exit early. We do that here to prevent overhead of running tests that only include Markdown
+# (documentation) updates.
+_terminate_if_only_docs: &terminate_if_only_docs
+  - |
+    if [ -n "${TRAVIS_COMMIT_RANGE}" ] && ! git diff --name-only "${TRAVIS_COMMIT_RANGE}" -- | grep -qv '\.md$'; then
+      echo "Stopping job as changes only affect documentation (ex. README.md)"
+      travis_terminate 0
+    fi
+
 before_install:
+  - *terminate_if_only_docs
   - sudo apt-get update && sudo apt-get install -y --no-install-recommends gdb
   - mkdir -p ~/bin && curl -sSL -o ~/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x ~/bin/jq
   - export PATH=$PATH:~/bin


### PR DESCRIPTION
## Description

similar to https://github.com/apache/incubator-pinot/pull/6316 but for Travis CI as requested by @fx19880617 . 

This PR prevents test build of a documentation-only change specifically in markdown files. 

This change won't handle all paths with non-code components like https://github.com/apache/incubator-pinot/pull/6316 but will only handle markdown file changes. If you want to avoid Travis CI getting triggered on you commits in website files or other non-code directories please use message like `[skip travis] Updated xyz` in your commit. (https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build)

### References for this PR:
- https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build
- https://github.com/openzipkin/docker-java/pull/43/ 
- https://stackoverflow.com/questions/32791470/exclude-files-from-triggering-a-travis-ci-build-on-github
