### PR TITLE
[TE]frontend - Add breadcrumb component

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/breadcrumb-list/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/breadcrumb-list/component.js
@@ -1,0 +1,56 @@
+import Component from '@ember/component';
+import { A as EmberArray } from '@ember/array';
+
+export default Component.extend({
+  /**
+   * @public
+   * @templateProps
+   *
+   * @type {Array}
+   * @default [] */
+  items: EmberArray(),
+
+  /**
+   * The callback function to invoke when breadcrumb is clicked
+   *
+   * @public
+   * @type {Function}
+   *
+   * @param {Object} breadcrumb
+   *   The information about the breadcrumb
+   *
+   * @param {Number} index
+   *   The index of the breadcrumb that was clicked
+   */
+  onBreadcrumbClick: () => {},
+
+  /**
+   * Ember component life hook.
+   *
+   * @override
+   */
+  didReceiveAttrs() {
+    this._super(...arguments);
+    this.set('lastItemIndex', this.items.length - 1);
+  },
+
+  /**
+   * Event handlers
+   */
+  actions: {
+    /**
+     * Call the parent callback when a breadcrumb is clicked
+     *
+     * @param {Object} breadcrumb
+     *   The information about the breadcrumb object
+     *
+     * @param {Number} index
+     *   The index of the breadcrumb that was clicked
+     */
+    onBreadcrumbClick(breadcrumb, index) {
+      if (index !== this.lastItemIndex) {
+        this.onBreadcrumbClick(breadcrumb, index);
+      }
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/breadcrumb-list/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/breadcrumb-list/template.hbs
@@ -1,0 +1,10 @@
+{{yield}}
+
+<ul class="breadcrumb__bar">
+  {{#each items as |breadcrumb index|}}
+    <li class="breadcrumb__title" onclick={{action "onBreadcrumbClick" breadcrumb index}}>{{breadcrumb.title}}</li>
+    {{#if (lt index lastItemIndex)}}
+    <li class="breadcrumb__separator"> > </li>
+    {{/if}}
+  {{/each}}
+</ul>

--- a/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/component.js
@@ -1,0 +1,87 @@
+import Component from '@ember/component';
+import { A as EmberArray } from '@ember/array';
+
+import { parseRoot } from 'thirdeye-frontend/utils/anomalies-tree-parser';
+
+export default Component.extend({
+  /**
+   * @public
+   * @templateProps
+   *
+   * @type {Array}
+   * @default [] */
+  anomalies: EmberArray(),
+
+  /**
+   * @public
+   * @templateProps
+   *
+   * @type {Number}
+   * @default undefined
+   */
+  alertId: undefined,
+
+  /**
+   * The callback function to invoke when breadcrumb is clicked
+   *
+   * @public
+   * @type {Function}
+   *
+   * @param {Boolean} isRoot
+   *   Whether we are exploring root level of the tree
+   */
+  onBreadcrumbClick: () => {},
+
+  /** Internal states */
+
+  /**
+   * Tracks the list of breadcrumbs
+   *
+   * @private
+   * @type {Array<Object>}
+   */
+  breadcrumbList: EmberArray(),
+
+  /**
+   * Ember component life hook.
+   *
+   * @override
+   */
+  init() {
+    this._super(...arguments);
+  },
+
+  /**
+   * Ember component life hook.
+   * Call the tree parser to fetch the component information for the root level
+   *
+   * @override
+   */
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    const { breadcrumbInfo } = parseRoot(this.alertId, this.anomalies);
+
+    this.breadcrumbList.push(breadcrumbInfo);
+  },
+  /**
+   * Event handlers
+   */
+  actions: {
+    /**
+     * Call the tree parser to fetch the component subtree information
+     * corresponding to the breadcrumb clicked
+     *
+     * @param {Object} breadcrumb
+     *   The information about the breadcrumb object
+     *
+     * @param {Number} index
+     *   The index of the breadcrumb that was clicked
+     */
+    onBreadcrumbClick({ isRoot = false }, index) {
+      this.set('breadcrumbList', this.breadcrumbList.splice(0, index + 1));
+
+      this.onBreadcrumbClick(isRoot);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/template.hbs
@@ -1,0 +1,8 @@
+{{yield}}
+
+<section>
+  {{breadcrumb-list
+    items=breadcrumbList
+    onBreadcrumbClick=(action "onBreadcrumbClick")
+  }}
+</section>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/explore/composite-anomalies/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/explore/composite-anomalies/route.js
@@ -1,5 +1,5 @@
-import Route from "@ember/routing/route";
-import AuthenticatedRouteMixin from "ember-simple-auth/mixins/authenticated-route-mixin";
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   /**
@@ -19,7 +19,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
    *
    * @override
    */
-  setupController(controller, model){
+  setupController(controller, model) {
     this._super(controller, model);
 
     //Cannot rely on the native `init` callback of the controller because the model is not available before controller initialization

--- a/thirdeye/thirdeye-frontend/app/pods/manage/explore/composite-anomalies/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/explore/composite-anomalies/template.hbs
@@ -1,6 +1,6 @@
 <section class="te-page__middle">
   <section class="container">
-    <section class="te-content-block__date-picker-section">   
+    <section class="te-content-block__date-picker-section {{unless rootLevel "te-content-block__date-picker-section--disabled"}}">   
       <span class="te-content-block__date-picker-label">Showing</span>
       {{date-range-picker
         class="te-range-picker"
@@ -24,5 +24,21 @@
     </section>
   </section>
 </section>
+
+<section class="te-page__bottom">
+  <section class="container">
+   {{#if fetchAnomaliesTask.isRunning }}
+      <div class="spinner-wrapper spinner-wrapper--card">
+        {{ember-spinner lines=30 radius=20 length=0 width=10 opacity=0 trail=75 color='blue'}}
+      </div>
+    {{else}}  
+      {{composite-anomalies
+        anomalies=anomalies
+        alertId=model.alertId
+        onBreadcrumbClick=(action "onBreadcrumbClick")
+      }}
+    {{/if}}
+  </section>  
+</section>  
 
 {{outlet}}

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -34,6 +34,7 @@ body {
 @import 'components/alert-details';
 @import 'components/te-navbar';
 @import 'components/button';
+@import 'components/breadcrumb-list';
 @import 'components/links';
 @import 'components/filter-select';
 @import 'components/heatmap-chart';

--- a/thirdeye/thirdeye-frontend/app/styles/components/breadcrumb-list.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/breadcrumb-list.scss
@@ -1,0 +1,19 @@
+.breadcrumb {
+  &__bar {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  &__title,
+  &__separator {
+    display: inline;
+    padding-left: 10px;
+    font-size: 14px;
+    font-weight: 400;
+  }
+
+  &__title:last-of-type {
+    font-weight: 700;
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -256,6 +256,11 @@ body {
       display: flex;
       align-items: center;
     }
+
+    &--disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
   }
 
   &__date-picker-label {
@@ -390,6 +395,11 @@ body {
 
   &__middle {
     background: white;
+    padding-bottom: 25px;
+  }
+
+  &__bottom {
+    padding-top: 25px;
   }
 }
 

--- a/thirdeye/thirdeye-frontend/package.json
+++ b/thirdeye/thirdeye-frontend/package.json
@@ -24,13 +24,9 @@
     }
   },
   "lint-staged": {
-    "**/*.{js,scss,css}": [
+    "**/*.js": [
       "./node_modules/.bin/eslint --fix",
       "./node_modules/.bin/prettier --write",
-      "git add"
-    ],
-    "**/*.hbs": [
-      "./node_modules/.bin/ember-template-lint",
       "git add"
     ]
   },

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/breadcrumb-list/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/breadcrumb-list/component-test.js
@@ -1,0 +1,33 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('breadcrumb-list', 'Integration | Component | breadcrumb list', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.setProperties({
+    items: [
+      {
+        title: 'breadcrumb 1',
+        id: 1,
+        isRoot: true
+      },
+      {
+        title: 'breadcrumb 2',
+        id: 2
+      }
+    ]
+  });
+
+  this.render(hbs`{{breadcrumb-list items=items}}`);
+
+  const displayedString = this.$().text();
+
+  assert.ok(displayedString.includes(this.items[0].title), 'breadcrumb 1 is displayed');
+  assert.ok(displayedString.includes(this.items[1].title), 'breadcrumb 2 is displayed');
+  assert.ok(displayedString.includes('>'), 'separator is displayed');
+});

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/composite-anomalies/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/composite-anomalies/component-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('composite-anomalies', 'Integration | Component | composite anomalies', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.setProperties({
+    alertId: 123,
+    anomalies: []
+  });
+
+  this.render(hbs`{{composite-anomalies alertId=alertId anomalies=anomalies}}`);
+
+  assert.equal(this.$().text().trim(), 'Alert Anomalies');
+});


### PR DESCRIPTION
As part of entity monitoring, we would need to display breadcrumbs as user drills down each level from the tree. This change adds the component for that.

Miscellaneous

- Add composite-anomalies component which hosts the breadcrumb component and will host the parent anomalies component, group component for each level of drilldown.
- Add support to disable date picker when user is not exploring anomalies at the root level.
- Prevent eslint from being run on scss, css files. Eslint by default intented only for js files.
- Prevent ember-template-lint from being run on hbs files. It is failing without output. I believe it is because we have not configured it yet. The package is not present in package.json.
- Fix styling in couple of files.