### PR TITLE
Fixing the issue with result schema

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -179,7 +179,7 @@ public class SelectionOperatorUtils {
     int numColumns = selectionColumns.size();
     Map<String, DataSchema.ColumnDataType> columnNameToDataType = new HashMap<>();
     DataSchema.ColumnDataType[] finalColumnDataTypes = new DataSchema.ColumnDataType[numColumns];
-    for (int i = 0; i < numColumns; i++) {
+    for (int i = 0; i < dataSchema.size(); i++) {
       columnNameToDataType.put(dataSchema.getColumnName(i), dataSchema.getColumnDataType(i));
     }
     for (int i = 0; i < numColumns; i++) {


### PR DESCRIPTION
The existing code returns the wrong result schema
when order by column does not appear as part of the
selection columns. This fixes the minor bug in the
code and returns the schema correctly.