### PR TITLE
Ingestion resource with APIs for ingestion via file/URI

### DIFF
--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -198,6 +198,12 @@
       <artifactId>commons-math3</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.io.File;
 import java.net.URI;
 import java.util.Map;
 import javax.inject.Inject;
@@ -78,7 +79,7 @@ import org.slf4j.LoggerFactory;
 public class PinotIngestionRestletResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotIngestionRestletResource.class);
-
+  private static final String UPLOAD_DIR = "upload_dir";
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
 
@@ -105,14 +106,10 @@ public class PinotIngestionRestletResource {
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromFile")
   @ApiOperation(value = "Ingest a file", notes =
-      "Creates a segment using given file and pushes it to Pinot. Example usage:"
-          + "\n```"
+      "Creates a segment using given file and pushes it to Pinot. Example usage:" + "\n```"
           + "\ncurl -X POST -F file=@data.json -H \"Content-Type: multipart/form-data\" \"http://localhost:9000/ingestFromFile?tableNameWithType=foo_OFFLINE&"
-          + "\nbatchConfigMapStr={"
-          + "\n  \"inputFormat\":\"csv\","
-          + "\n  \"recordReader.prop.delimiter\":\"|\""
-          + "\n}\" "
-          + "\n```")
+          + "\nbatchConfigMapStr={" + "\n  \"inputFormat\":\"csv\"," + "\n  \"recordReader.prop.delimiter\":\"|\""
+          + "\n}\" " + "\n```")
   public void ingestFromFile(
       @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Batch config Map as json string. Must pass inputFormat, and optionally record reader properties. e.g. {\"inputFormat\":\"json\"}", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
@@ -146,18 +143,13 @@ public class PinotIngestionRestletResource {
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromURI")
   @ApiOperation(value = "Ingest from the given URI", notes =
-      "Creates a segment using file at the given URI and pushes it to Pinot. Example usage:"
-          + "\n```"
+      "Creates a segment using file at the given URI and pushes it to Pinot. Example usage:" + "\n```"
           + "\ncurl -X POST \"http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE"
-          + "\n&batchConfigMapStr={"
-          + "\n  \"inputFormat\":\"json\","
+          + "\n&batchConfigMapStr={" + "\n  \"inputFormat\":\"json\","
           + "\n  \"input.fs.className\":\"org.apache.pinot.plugin.filesystem.S3PinotFS\","
-          + "\n  \"input.fs.prop.region\":\"us-central\","
-          + "\n  \"input.fs.prop.accessKey\":\"foo\","
-          + "\n  \"input.fs.prop.secretKey\":\"bar\""
-          + "\n}"
-          + "\n&sourceURIStr=s3://test.bucket/path/to/json/data/data.json\""
-          + "\n```")
+          + "\n  \"input.fs.prop.region\":\"us-central\"," + "\n  \"input.fs.prop.accessKey\":\"foo\","
+          + "\n  \"input.fs.prop.secretKey\":\"bar\"" + "\n}"
+          + "\n&sourceURIStr=s3://test.bucket/path/to/json/data/data.json\"" + "\n```")
   public void ingestFromURI(
       @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Batch config Map as json string. Must pass inputFormat, and optionally input FS properties. e.g. {\"inputFormat\":\"json\"}", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
@@ -189,7 +181,7 @@ public class PinotIngestionRestletResource {
 
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfig, _controllerConf.getControllerHost(),
-            Integer.parseInt(_controllerConf.getControllerPort()));
+            Integer.parseInt(_controllerConf.getControllerPort()), new File(_controllerConf.getDataDir(), UPLOAD_DIR));
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.net.URI;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.util.FileIngestionHelper;
+import org.apache.pinot.controller.util.FileIngestionHelper.DataPayload;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.BatchConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.server.ManagedAsync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * APIs related to ingestion
+ */
+@Api(tags = Constants.TABLE_TAG)
+@Path("/")
+public class PinotIngestionRestletResource {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotIngestionRestletResource.class);
+
+  @Inject
+  PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @Inject
+  ControllerConf _controllerConf;
+
+  /**
+   * API to upload a file and ingest it into a Pinot table
+   * @param tableName Name of the table to upload to
+   * @param batchConfigMapStr Batch config Map as a string. Provide the
+   *                          input format (inputFormat)
+   *                          record reader configs (recordReader.prop.<property>),
+   *                          fs class name (input.fs.className)
+   *                          fs configs (input.fs.prop.<property>)
+   * @param fileUpload file to upload as a multipart
+   */
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/ingestFromFile")
+  @ApiOperation(value = "Ingest a file", notes = "Creates a segment using given file and pushes it to Pinot")
+  public void ingestFromFile(
+      @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableName") String tableName,
+      @ApiParam(value = "Batch config map as string", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
+      FormDataMultiPart fileUpload,
+      @Suspended final AsyncResponse asyncResponse) {
+    try {
+      asyncResponse.resume(ingestData(tableName, batchConfigMapStr, new DataPayload(fileUpload)));
+    } catch (Exception e) {
+      asyncResponse.resume(new ControllerApplicationException(LOGGER,
+          String.format("Caught exception when ingesting file into table: %s. %s", tableName, e.getMessage()),
+          Response.Status.INTERNAL_SERVER_ERROR, e));
+    }
+  }
+
+  /**
+   * API to ingest a file into Pinot from a URI
+   * @param tableName Name of the table to upload to
+   * @param batchConfigMapStr Batch config Map as a string. Provide the
+   *                          input format (inputFormat)
+   *                          record reader configs (recordReader.prop.<property>),
+   *                          fs class name (input.fs.className)
+   *                          fs configs (input.fs.prop.<property>)
+   * @param sourceURIStr URI for input file to ingest
+   */
+  @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Path("/ingestFromURI")
+  @ApiOperation(value = "Ingest from the given URI", notes = "Creates a segment using file at the given URI and pushes it to Pinot")
+  public void ingestFromURI(
+      @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableName") String tableName,
+      @ApiParam(value = "Batch config map as string", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
+      @ApiParam(value = "URI", required = true) @QueryParam("sourceURIStr") String sourceURIStr,
+      @Suspended final AsyncResponse asyncResponse) {
+    try {
+      asyncResponse.resume(ingestData(tableName, batchConfigMapStr, new DataPayload(new URI(sourceURIStr))));
+    } catch (Exception e) {
+      asyncResponse.resume(new ControllerApplicationException(LOGGER,
+          String.format("Caught exception when ingesting file into table: %s. %s", tableName, e.getMessage()),
+          Response.Status.INTERNAL_SERVER_ERROR, e));
+    }
+  }
+
+  private SuccessResponse ingestData(String tableName, String batchConfigMapStr, DataPayload payload)
+      throws Exception {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    Preconditions
+        .checkState(TableType.REALTIME != tableType, "Cannot ingest file into REALTIME table: %s", tableName);
+    String tableNameWithType = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(tableName);
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Table: %s not found", tableNameWithType);
+    Map<String, String> batchConfigMap =
+        JsonUtils.stringToObject(batchConfigMapStr, new TypeReference<Map<String, String>>() {});
+    BatchConfig batchConfig = new BatchConfig(tableNameWithType, batchConfigMap);
+    Schema schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
+
+    FileIngestionHelper fileIngestionHelper = new FileIngestionHelper(tableConfig, schema, batchConfig, _controllerConf);
+    return fileIngestionHelper.buildSegmentAndPush(payload);
+  }
+
+
+
+
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -110,10 +110,11 @@ public class PinotIngestionRestletResource {
   @Path("/ingestFromFile")
   @ApiOperation(value = "Ingest a file", notes = "Creates a segment using given file and pushes it to Pinot. "
       + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "
-      + "\n Example usage:" + "\n```"
+      + "\n Example usage (query params need encoding):" + "\n```"
       + "\ncurl -X POST -F file=@data.json -H \"Content-Type: multipart/form-data\" \"http://localhost:9000/ingestFromFile?tableNameWithType=foo_OFFLINE&"
       + "\nbatchConfigMapStr={" + "\n  \"inputFormat\":\"csv\"," + "\n  \"recordReader.prop.delimiter\":\"|\""
-      + "\n}\" " + "\n```")
+      + "\n}\" "
+      + "\n```")
   public void ingestFromFile(
       @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Batch config Map as json string. Must pass inputFormat, and optionally record reader properties. e.g. {\"inputFormat\":\"json\"}", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
@@ -149,7 +150,7 @@ public class PinotIngestionRestletResource {
   @ApiOperation(value = "Ingest from the given URI", notes =
       "Creates a segment using file at the given URI and pushes it to Pinot. "
           + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "
-          + "\nExample usage:" + "\n```"
+          + "\nExample usage (query params need encoding):" + "\n```"
           + "\ncurl -X POST \"http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE"
           + "\n&batchConfigMapStr={" + "\n  \"inputFormat\":\"json\","
           + "\n  \"input.fs.className\":\"org.apache.pinot.plugin.filesystem.S3PinotFS\","

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -142,8 +142,4 @@ public class PinotIngestionRestletResource {
     FileIngestionHelper fileIngestionHelper = new FileIngestionHelper(tableConfig, schema, batchConfig, _controllerConf);
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
-
-
-
-
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -79,6 +79,7 @@ import org.slf4j.LoggerFactory;
 public class PinotIngestionRestletResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotIngestionRestletResource.class);
+  // directory to use under the controller datadir. Controller config can be added for this later if needed.
   private static final String UPLOAD_DIR = "upload_dir";
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -90,6 +91,8 @@ public class PinotIngestionRestletResource {
    * API to upload a file and ingest it into a Pinot table.
    * This call will copy the file locally, create a segment and push the segment to Pinot.
    * A response will be returned after the completion of all of the above steps.
+   * All steps happen on the controller. This API is NOT meant for production environments/large input files.
+   * For Production setup, use the minion batch ingestion mechanism
    *
    * @param tableNameWithType Name of the table to upload to, with type suffix
    * @param batchConfigMapStr Batch config Map as a string. Provide the
@@ -105,11 +108,12 @@ public class PinotIngestionRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromFile")
-  @ApiOperation(value = "Ingest a file", notes =
-      "Creates a segment using given file and pushes it to Pinot. Example usage:" + "\n```"
-          + "\ncurl -X POST -F file=@data.json -H \"Content-Type: multipart/form-data\" \"http://localhost:9000/ingestFromFile?tableNameWithType=foo_OFFLINE&"
-          + "\nbatchConfigMapStr={" + "\n  \"inputFormat\":\"csv\"," + "\n  \"recordReader.prop.delimiter\":\"|\""
-          + "\n}\" " + "\n```")
+  @ApiOperation(value = "Ingest a file", notes = "Creates a segment using given file and pushes it to Pinot. "
+      + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "
+      + "\n Example usage:" + "\n```"
+      + "\ncurl -X POST -F file=@data.json -H \"Content-Type: multipart/form-data\" \"http://localhost:9000/ingestFromFile?tableNameWithType=foo_OFFLINE&"
+      + "\nbatchConfigMapStr={" + "\n  \"inputFormat\":\"csv\"," + "\n  \"recordReader.prop.delimiter\":\"|\""
+      + "\n}\" " + "\n```")
   public void ingestFromFile(
       @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Batch config Map as json string. Must pass inputFormat, and optionally record reader properties. e.g. {\"inputFormat\":\"json\"}", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
@@ -143,7 +147,9 @@ public class PinotIngestionRestletResource {
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromURI")
   @ApiOperation(value = "Ingest from the given URI", notes =
-      "Creates a segment using file at the given URI and pushes it to Pinot. Example usage:" + "\n```"
+      "Creates a segment using file at the given URI and pushes it to Pinot. "
+          + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "
+          + "\nExample usage:" + "\n```"
           + "\ncurl -X POST \"http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE"
           + "\n&batchConfigMapStr={" + "\n  \"inputFormat\":\"json\","
           + "\n  \"input.fs.className\":\"org.apache.pinot.plugin.filesystem.S3PinotFS\","

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -22,6 +22,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.StringUtil;
@@ -299,11 +301,27 @@ public class ControllerRequestURLBuilder {
         tableNameWithType, URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()));
   }
 
+  public String forIngestFromFile(String tableNameWithType, Map<String, String> batchConfigMap)
+      throws UnsupportedEncodingException {
+    String batchConfigMapStr =
+        batchConfigMap.entrySet().stream().map(e -> String.format("\"%s\":\"%s\"", e.getKey(), e.getValue()))
+            .collect(Collectors.joining(",", "{", "}"));
+    return forIngestFromFile(tableNameWithType, batchConfigMapStr);
+  }
+
   public String forIngestFromURI(String tableNameWithType, String batchConfigMapStr, String sourceURIStr)
       throws UnsupportedEncodingException {
     return String.format("%s?tableNameWithType=%s&batchConfigMapStr=%s&sourceURIStr=%s",
         StringUtil.join("/", _baseUrl, "ingestFromURI"), tableNameWithType,
         URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()),
         URLEncoder.encode(sourceURIStr, StandardCharsets.UTF_8.toString()));
+  }
+
+  public String forIngestFromURI(String tableNameWithType, Map<String, String> batchConfigMap, String sourceURIStr)
+      throws UnsupportedEncodingException {
+    String batchConfigMapStr =
+        batchConfigMap.entrySet().stream().map(e -> String.format("\"%s\":\"%s\"", e.getKey(), e.getValue()))
+            .collect(Collectors.joining(",", "{", "}"));
+    return forIngestFromURI(tableNameWithType, batchConfigMapStr, sourceURIStr);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -295,13 +295,13 @@ public class ControllerRequestURLBuilder {
 
   public String forIngestFromFile(String tableNameWithType, String batchConfigMapStr)
       throws UnsupportedEncodingException {
-    return String.format("%s?tableName=%s&batchConfigMapStr=%s", StringUtil.join("/", _baseUrl, "ingestFromFile"),
+    return String.format("%s?tableNameWithType=%s&batchConfigMapStr=%s", StringUtil.join("/", _baseUrl, "ingestFromFile"),
         tableNameWithType, URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()));
   }
 
   public String forIngestFromURI(String tableNameWithType, String batchConfigMapStr, String sourceURIStr)
       throws UnsupportedEncodingException {
-    return String.format("%s?tableName=%s&batchConfigMapStr=%s&sourceURIStr=%s",
+    return String.format("%s?tableNameWithType=%s&batchConfigMapStr=%s&sourceURIStr=%s",
         StringUtil.join("/", _baseUrl, "ingestFromURI"), tableNameWithType,
         URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()),
         URLEncoder.encode(sourceURIStr, StandardCharsets.UTF_8.toString()));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.controller.helix;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -288,5 +291,19 @@ public class ControllerRequestURLBuilder {
       url += "&type=" + instancePartitionsType;
     }
     return url;
+  }
+
+  public String forIngestFromFile(String tableNameWithType, String batchConfigMapStr)
+      throws UnsupportedEncodingException {
+    return String.format("%s?tableName=%s&batchConfigMapStr=%s", StringUtil.join("/", _baseUrl, "ingestFromFile"),
+        tableNameWithType, URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()));
+  }
+
+  public String forIngestFromURI(String tableNameWithType, String batchConfigMapStr, String sourceURIStr)
+      throws UnsupportedEncodingException {
+    return String.format("%s?tableName=%s&batchConfigMapStr=%s&sourceURIStr=%s",
+        StringUtil.join("/", _baseUrl, "ingestFromURI"), tableNameWithType,
+        URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()),
+        URLEncoder.encode(sourceURIStr, StandardCharsets.UTF_8.toString()));
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -52,14 +52,16 @@ public class FileIngestionHelper {
   private final BatchConfig _batchConfig;
   private final String _controllerHost;
   private final int _controllerPort;
+  private final File _uploadDir;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, BatchConfig batchConfig, String controllerHost,
-      int controllerPort) {
+      int controllerPort, File uploadDir) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfig = batchConfig;
     _controllerHost = controllerHost;
     _controllerPort = controllerPort;
+    _uploadDir = uploadDir;
   }
 
   /**
@@ -68,11 +70,12 @@ public class FileIngestionHelper {
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
       throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
-    LOGGER.info("Starting ingestion of {} payload to table: {}", payload._payloadType, tableNameWithType);
+    File workingDir = new File(_uploadDir,
+        String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
+    LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
+        tableNameWithType, workingDir.getAbsolutePath());
 
     // Setup working dir
-    File workingDir = new File(FileUtils.getTempDirectory(),
-        String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
     File inputDir = new File(workingDir, INPUT_DATA_DIR);
     File outputDir = new File(workingDir, OUTPUT_SEGMENT_DIR);
     File segmentTarDir = new File(workingDir, SEGMENT_TAR_DIR);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URI;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.SuccessResponse;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.BatchConfig;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A driver for the ingestion process of the provided file.
+ * Responsible for copying the file locally, building a segment and uploading it to the controller.
+ */
+public class FileIngestionHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileIngestionHelper.class);
+
+  private static final String WORKING_DIR_PREFIX = "working_dir";
+  private static final String INPUT_DATA_DIR = "input_data_dir";
+  private static final String OUTPUT_SEGMENT_DIR = "output_segment_dir";
+  private static final String SEGMENT_TAR_DIR = "segment_tar_dir";
+  private static final String DATA_FILE_PREFIX = "data";
+
+  private final TableConfig _tableConfig;
+  private final Schema _schema;
+  private final BatchConfig _batchConfig;
+  private final ControllerConf _controllerConf;
+
+  public FileIngestionHelper(TableConfig tableConfig, Schema schema,
+      BatchConfig batchConfig, ControllerConf controllerConf) {
+    _tableConfig = tableConfig;
+    _schema = schema;
+    _batchConfig = batchConfig;
+    _controllerConf = controllerConf;
+  }
+
+  /**
+   * Creates a segment using the provided data file/URI and uploads to Pinot
+   */
+  public SuccessResponse buildSegmentAndPush(DataPayload payload)
+      throws Exception {
+    String tableNameWithType = _tableConfig.getTableName();
+
+    // Setup working dir
+    File workingDir = new File(FileUtils.getTempDirectory(),
+        String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
+    File inputDir = new File(workingDir, INPUT_DATA_DIR);
+    File outputDir = new File(workingDir, OUTPUT_SEGMENT_DIR);
+    File segmentTarDir = new File(workingDir, SEGMENT_TAR_DIR);
+    try {
+      Preconditions
+          .checkState(inputDir.mkdirs(), "Could not create directory for downloading input file locally: %s", inputDir);
+      Preconditions.checkState(segmentTarDir.mkdirs(), "Could not create directory for segment tar file: %s", inputDir);
+
+      // Copy file to local working dir
+      File inputFile =
+          new File(inputDir, String.format("%s.%s", DATA_FILE_PREFIX, _batchConfig.getInputFormat().toString().toLowerCase()));
+      if (payload._dataSource.equals(DataSource.URI)) {
+        FileIngestionUtils.copyURIToLocal(_batchConfig, payload._uri, inputFile);
+      } else {
+        FileIngestionUtils.copyMultipartToLocal(payload._multiPart, inputFile);
+      }
+
+      // Build segment
+      SegmentGeneratorConfig segmentGeneratorConfig =
+          FileIngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _batchConfig, _schema, inputFile, outputDir);
+      String segmentName = FileIngestionUtils.buildSegment(segmentGeneratorConfig);
+
+      // Tar and push segment
+      File segmentTarFile =
+          new File(segmentTarDir, segmentName + org.apache.pinot.spi.ingestion.batch.spec.Constants.TAR_GZ_FILE_EXT);
+      TarGzCompressionUtils.createTarGzFile(new File(outputDir, segmentName), segmentTarFile);
+      FileIngestionUtils
+          .uploadSegment(tableNameWithType, Lists.newArrayList(segmentTarFile), _controllerConf.getControllerHost(),
+              Integer.parseInt(_controllerConf.getControllerPort()));
+
+      return new SuccessResponse(
+          "Successfully ingested file into table: " + tableNameWithType + " as segment: " + segmentName);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception when ingesting file to table: {}", tableNameWithType, e);
+      throw e;
+    } finally {
+      FileUtils.deleteQuietly(workingDir);
+    }
+  }
+
+  /**
+   * Enum to identify the source of ingestion file
+   */
+  private enum DataSource {
+    URI,
+    FILE
+  }
+
+  /**
+   * Wrapper around file payload
+   */
+  public static class DataPayload{
+    DataSource _dataSource;
+    FormDataMultiPart _multiPart;
+    URI _uri;
+
+    public DataPayload(FormDataMultiPart multiPart) {
+      _dataSource = DataSource.FILE;
+      _multiPart = multiPart;
+    }
+
+    public DataPayload(URI uri) {
+      _dataSource = DataSource.URI;
+      _uri = uri;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,9 +121,9 @@ public final class FileIngestionUtils {
     if (readerConfigClassName != null) {
       Map<String, String> configs = batchConfig.getRecordReaderProps();
       if (configs == null) {
-        configs = new HashMap<>();
+        configs = Collections.emptyMap();
       }
-      JsonNode jsonNode = new ObjectMapper().valueToTree(configs);
+      JsonNode jsonNode = new ObjectMapper().valueToTree(IngestionConfigUtils.getRecordReaderProps(configs));
       Class<?> clazz = PluginManager.get().loadClass(readerConfigClassName);
       RecordReaderConfig recordReaderConfig = (RecordReaderConfig) JsonUtils.jsonNodeToObject(jsonNode, clazz);
       segmentGeneratorConfig.setReaderConfig(recordReaderConfig);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
@@ -117,17 +117,9 @@ public final class FileIngestionUtils {
     FileFormat fileFormat = batchConfig.getInputFormat();
     segmentGeneratorConfig.setFormat(fileFormat);
     segmentGeneratorConfig.setRecordReaderPath(RecordReaderFactory.getRecordReaderClassName(fileFormat.toString()));
-    String readerConfigClassName = RecordReaderFactory.getRecordReaderConfigClassName(fileFormat.toString());
-    if (readerConfigClassName != null) {
-      Map<String, String> configs = batchConfig.getRecordReaderProps();
-      if (configs == null) {
-        configs = Collections.emptyMap();
-      }
-      JsonNode jsonNode = new ObjectMapper().valueToTree(IngestionConfigUtils.getRecordReaderProps(configs));
-      Class<?> clazz = PluginManager.get().loadClass(readerConfigClassName);
-      RecordReaderConfig recordReaderConfig = (RecordReaderConfig) JsonUtils.jsonNodeToObject(jsonNode, clazz);
-      segmentGeneratorConfig.setReaderConfig(recordReaderConfig);
-    }
+    Map<String, String> configs = batchConfig.getRecordReaderProps();
+    segmentGeneratorConfig.setReaderConfig(
+        RecordReaderFactory.getRecordReaderConfig(fileFormat, IngestionConfigUtils.getRecordReaderProps(configs)));
     // Using current time as postfix to prevent overwriting segments with same time ranges
     segmentGeneratorConfig.setSegmentNameGenerator(
         new SimpleSegmentNameGenerator(tableConfig.getTableName(), String.valueOf(System.currentTimeMillis())));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionUtils.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.name.SimpleSegmentNameGenerator;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.BatchConfig;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
+import org.apache.pinot.spi.utils.retry.RetriableOperationException;
+import org.apache.pinot.spi.utils.retry.RetryPolicies;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Helper methods for ingestion from file
+ */
+public final class FileIngestionUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileIngestionUtils.class);
+  private static final long DEFAULT_RETRY_WAIT_MS = 1000L;
+  private static final int DEFAULT_ATTEMPTS = 3;
+  private static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
+
+  private FileIngestionUtils() {
+  }
+
+  /**
+   * Copy the file from given URI to local file
+   */
+  public static void copyURIToLocal(BatchConfig batchConfig, URI sourceFileURI, File destFile)
+      throws Exception {
+    String sourceFileURIScheme = sourceFileURI.getScheme();
+    if (!PinotFSFactory.isSchemeSupported(sourceFileURIScheme)) {
+      PinotFSFactory.register(sourceFileURIScheme, batchConfig.getInputFsClassName(),
+          IngestionConfigUtils.getFsProps(batchConfig.getInputFsProps()));
+    }
+    PinotFSFactory.create(sourceFileURIScheme).copyToLocalFile(sourceFileURI, destFile);
+  }
+
+  /**
+   * Copy the file from the uploaded multipart to a local file
+   */
+  public static void copyMultipartToLocal(FormDataMultiPart multiPart, File destFile)
+      throws IOException {
+    FormDataBodyPart formDataBodyPart = multiPart.getFields().values().iterator().next().get(0);
+    try (InputStream inputStream = formDataBodyPart.getValueAs(InputStream.class);
+        OutputStream outputStream = new FileOutputStream(destFile)) {
+      IOUtils.copyLarge(inputStream, outputStream);
+    } finally {
+      multiPart.cleanup();
+    }
+  }
+
+  /**
+   * Creates a {@link SegmentGeneratorConfig}
+   * @param tableConfig Table config
+   * @param batchConfig Batch config override provided by the user during upload
+   * @param schema Table schema
+   * @param inputFile The input file
+   * @param outputSegmentDir The output dir
+   */
+  public static SegmentGeneratorConfig generateSegmentGeneratorConfig(TableConfig tableConfig, BatchConfig batchConfig,
+      Schema schema, File inputFile, File outputSegmentDir)
+      throws ClassNotFoundException, IOException {
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setTableName(tableConfig.getTableName());
+    segmentGeneratorConfig.setOutDir(outputSegmentDir.getAbsolutePath());
+    segmentGeneratorConfig.setInputFilePath(inputFile.getAbsolutePath());
+
+    FileFormat fileFormat = batchConfig.getInputFormat();
+    segmentGeneratorConfig.setFormat(fileFormat);
+    segmentGeneratorConfig.setRecordReaderPath(RecordReaderFactory.getRecordReaderClassName(fileFormat.toString()));
+    String readerConfigClassName = RecordReaderFactory.getRecordReaderConfigClassName(fileFormat.toString());
+    if (readerConfigClassName != null) {
+      Map<String, String> configs = batchConfig.getRecordReaderProps();
+      if (configs == null) {
+        configs = new HashMap<>();
+      }
+      JsonNode jsonNode = new ObjectMapper().valueToTree(configs);
+      Class<?> clazz = PluginManager.get().loadClass(readerConfigClassName);
+      RecordReaderConfig recordReaderConfig = (RecordReaderConfig) JsonUtils.jsonNodeToObject(jsonNode, clazz);
+      segmentGeneratorConfig.setReaderConfig(recordReaderConfig);
+    }
+    // Using current time as postfix to prevent overwriting segments with same time ranges
+    segmentGeneratorConfig.setSegmentNameGenerator(
+        new SimpleSegmentNameGenerator(tableConfig.getTableName(), String.valueOf(System.currentTimeMillis())));
+    return segmentGeneratorConfig;
+  }
+
+  /**
+   * Builds a segment using given {@link SegmentGeneratorConfig}
+   * @return segment name
+   */
+  public static String buildSegment(SegmentGeneratorConfig segmentGeneratorConfig)
+      throws Exception {
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig);
+    driver.build();
+    return driver.getSegmentName();
+  }
+
+  /**
+   * Uploads the segment tar files to the provided controller
+   */
+  public static void uploadSegment(String tableNameWithType, List<File> tarFiles, String controllerHost,
+      int controllerPort)
+      throws RetriableOperationException, AttemptsExceededException {
+    for (File tarFile : tarFiles) {
+      String fileName = tarFile.getName();
+      Preconditions
+          .checkArgument(fileName.endsWith(org.apache.pinot.spi.ingestion.batch.spec.Constants.TAR_GZ_FILE_EXT));
+      String segmentName = fileName.substring(0,
+          fileName.length() - org.apache.pinot.spi.ingestion.batch.spec.Constants.TAR_GZ_FILE_EXT.length());
+
+      RetryPolicies.exponentialBackoffRetryPolicy(DEFAULT_ATTEMPTS, DEFAULT_RETRY_WAIT_MS, 5).attempt(() -> {
+        try (InputStream inputStream = new FileInputStream(tarFile)) {
+          SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
+              .uploadSegment(FileUploadDownloadClient.getUploadSegmentHttpURI(controllerHost, controllerPort),
+                  segmentName, inputStream, tableNameWithType);
+          LOGGER.info("Response for pushing table {} segment {} - {}: {}", tableNameWithType, segmentName,
+              response.getStatusCode(), response.getResponse());
+          return true;
+        } catch (HttpErrorStatusException e) {
+          int statusCode = e.getStatusCode();
+          if (statusCode >= 500) {
+            LOGGER.warn("Caught temporary exception while pushing table: {} segment: {}, will retry", tableNameWithType,
+                segmentName, e);
+            return false;
+          } else {
+            LOGGER
+                .error("Caught permanent exception while pushing table: {} segment: {}, won't retry", tableNameWithType,
+                    segmentName, e);
+            throw e;
+          }
+        }
+      });
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for the ingestion restlet
+ *
+ */
+public class PinotIngestionRestletResourceTest extends ControllerTest {
+  private static final String TABLE_NAME = "testTable";
+  private static final String TABLE_NAME_WITH_TYPE = "testTable_OFFLINE";
+  private File _inputFile;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+
+    // Add schema & table
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("foo", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("bar", FieldSpec.DataType.STRING).build();
+    _helixResourceManager.addSchema(schema, true);
+    _helixResourceManager.addTable(tableConfig);
+
+    // Create a file with few records
+    _inputFile = new File(FileUtils.getTempDirectory(), "pinotIngestionRestletResourceTest_data.csv");
+    try (BufferedWriter bw = new BufferedWriter(new FileWriter(_inputFile))) {
+      bw.write("foo|bar\n");
+      bw.write("dog|cooper\n");
+      bw.write("cat|kylo\n");
+      bw.write("dog|cookie\n");
+    }
+  }
+
+  @Test
+  public void testIngestEndpoint()
+      throws Exception {
+
+    List<String> segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE);
+    Assert.assertEquals(segments.size(), 0);
+
+    // ingest from file
+    sendHttpPost(_controllerRequestURLBuilder
+        .forIngestFromFile(TABLE_NAME_WITH_TYPE, "{\"inputFormat\":\"csv\",\"recordReader.prop.delimiter\":\"|\"}"));
+    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE);
+    Assert.assertEquals(segments.size(), 1);
+
+    // ingest from URI
+    sendHttpPost(_controllerRequestURLBuilder
+        .forIngestFromURI(TABLE_NAME_WITH_TYPE, "{\"inputFormat\":\"csv\",\"recordReader.prop.delimiter\":\"|\"}",
+            String.format("file://%s", _inputFile.getAbsolutePath())));
+    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE);
+    Assert.assertEquals(segments.size(), 2);
+  }
+
+  private void sendHttpPost(String uri)
+      throws IOException {
+    HttpClient httpClient = HttpClientBuilder.create().build();
+    HttpPost httpPost = new HttpPost(uri);
+    HttpEntity reqEntity =
+        MultipartEntityBuilder.create().addPart("file", new FileBody(_inputFile.getAbsoluteFile())).build();
+    httpPost.setEntity(reqEntity);
+    HttpResponse response = httpClient.execute(httpPost);
+    int statusCode = response.getStatusLine().getStatusCode();
+    Assert.assertEquals(statusCode, 200);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(_inputFile);
+    stopFakeInstances();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.spi.data.readers;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -121,6 +123,20 @@ public class RecordReaderFactory {
           readerConfigFile);
     }
     throw new UnsupportedOperationException("No supported RecordReader found for file format - '" + fileFormat + "'");
+  }
+
+  /**
+   * Creates a {@link RecordReaderConfig} instance using file format and reader config properties
+   */
+  public static RecordReaderConfig getRecordReaderConfig(FileFormat fileFormat, Map<String, String> configs)
+      throws ClassNotFoundException, IOException {
+    String readerConfigClassName = getRecordReaderConfigClassName(fileFormat.toString());
+    if (readerConfigClassName != null) {
+      JsonNode jsonNode = new ObjectMapper().valueToTree(configs);
+      Class<?> clazz = PluginManager.get().loadClass(readerConfigClassName);
+      return (RecordReaderConfig) JsonUtils.jsonNodeToObject(jsonNode, clazz);
+    }
+    return null;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -100,6 +100,13 @@ public final class IngestionConfigUtils {
     return segmentIngestionFrequency;
   }
 
+  /**
+   * Fetch the properties which belong to record reader, by removing the identifier prefix
+   */
+  public static Map<String, String> getRecordReaderProps(Map<String, String> batchConfigMap) {
+    return getConfigMapWithPrefix(batchConfigMap, BatchConfigProperties.RECORD_READER_PROP_PREFIX + DOT_SEPARATOR);
+  }
+
   public static PinotConfiguration getFsProps(Map<String, String> batchConfigMap) {
     return new PinotConfiguration(getPropsWithPrefix(batchConfigMap, BatchConfigProperties.INPUT_FS_PROP_PREFIX + DOT_SEPARATOR));
   }


### PR DESCRIPTION
## Description
Adding APIs for uploading data to an offline table. These are meant for quick testing/trials, and not intended for production usage. We will be using these in the Cluster Manager to introduce a "Test a file" flow.

**File ingest**
```
curl "http://localhost:9000/ingestFromFile?tableName=transcript_OFFLINE&batchConfigMapStr={"inputFormat":"json"}"  \
-F file=@part1.json
```

**URI ingest** 
Note: 
1. The fs details only need to be provided if scheme is not already registered. 
2. Credentials will by default be taken from local aws credentials
```
curl "http://localhost:9000/ingestFromURI?tableName=transcript_OFFLINE&
batchConfigMapStr={"inputFormat":"json","input.fs.className":"org.apache.pinot.plugin.filesystem.S3PinotFS","input.fs.prop.region":"us-central","input.fs.prop.accessKey":"foo","input.fs.prop.secretKey":"bar"}
&sourceURIStr=s3://test.bucket/jsondata/part1.json" 
  -X POST
```

## Release Notes
Introduced 2 new APIs `/ingestFromFile` and `/ingestFromURI`