### PR TITLE
add redis module dependency

### DIFF
--- a/docker/images/pinot-superset/requirements-db.txt
+++ b/docker/images/pinot-superset/requirements-db.txt
@@ -17,3 +17,4 @@
 # under the License.
 #
 pinotdb==0.3.3
+redis==3.4.1


### PR DESCRIPTION
## Description
add redis module dependency to docker build script to un-break container

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
