### PR TITLE
[TE]frontend - Fix the display for "NaN" values in performance-stats

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/template.hbs
@@ -1,13 +1,13 @@
 {{#each statsTransformed as |card|}}
-  <ul class={{if oneCardOnly "te-horizontal-cards__single-card" "te-horizontal-cards__card"}}>
+  <ul class={{if oneCardOnly 'te-horizontal-cards__single-card' 'te-horizontal-cards__card'}}>
     <li class="te-horizontal-cards__card-title">
       <label for="select-dimension" class="control-label te-label">
         {{card.title}}
         <span>
           <i class="glyphicon glyphicon-question-sign"></i>
-            {{#tooltip-on-element class="te-tooltip"}}
-              {{card.description}}
-            {{/tooltip-on-element}}
+          {{#tooltip-on-element class='te-tooltip'}}
+            {{card.description}}
+          {{/tooltip-on-element}}
         </span>
       </label>
     </li>
@@ -16,13 +16,21 @@
         {{#if areTwoSetsOfAnomalies}}
           <!-- Two different anomaly counts -->
           <div class="te-horizontal-cards__val-group">
-            <div class="te-horizontal-cards__card-subt">{{#if isEditMode}}Current{{else}}Old{{/if}}</div>
+            <div class="te-horizontal-cards__card-subt">
+              {{#if isEditMode}}
+                Current
+              {{else}}
+                Old
+              {{/if}}
+            </div>
             <li class="te-horizontal-cards__card-number">
               {{card.old}}
             </li>
           </div>
           <div class="te-horizontal-cards__val-group__margin-left">
-            <div class="te-horizontal-cards__card-subt">New</div>
+            <div class="te-horizontal-cards__card-subt">
+              New
+            </div>
             <li class="te-horizontal-cards__card-number">
               {{card.new}}
             </li>
@@ -30,16 +38,31 @@
         {{else}}
           <!-- Only one anomaly count -->
           <li class="te-horizontal-cards__card-number">
-            {{card.value}}{{#if (eq card.type 'PERCENT')}}%{{/if}}
+            {{#if (eq card.type 'PERCENT')}}
+              {{#if (eq card.value 'NaN')}}
+                N/A
+              {{else}}
+                {{card.value}}%
+              {{/if}}
+            {{else}}
+              {{card.value}}
+            {{/if}}
           </li>
         {{/if}}
       {{else}}
         <!-- Not Anomalies -->
         <li class="te-horizontal-cards__card-number">
-          {{card.value}}{{#if (eq card.type 'PERCENT')}}%{{/if}}
+          {{#if (eq card.type 'PERCENT')}}
+            {{#if (eq card.value 'NaN')}}
+              N/A
+            {{else}}
+              {{card.value}}%
+            {{/if}}
+          {{else}}
+            {{card.value}}
+          {{/if}}
         </li>
       {{/if}}
     </li>
   </ul>
 {{/each}}
- 

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/stats-cards/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/stats-cards/component-test.js
@@ -3,12 +3,12 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | stats cards', function(hooks) {
+module('Integration | Component | stats cards', function (hooks) {
   setupRenderingTest(hooks);
 
   const CARD = '.te-horizontal-cards__card';
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     const fetchedStats = {
       totalAnomalies: {
         value: 10,
@@ -35,39 +35,47 @@ module('Integration | Component | stats cards', function(hooks) {
     const $number = this.$(`${CARD}-number`);
 
     // Testing titles of all cards
-    assert.equal(
-      $title.get(0).innerText.trim(),
-      'Anomalies',
-      'title of 1st card is correct');
-    assert.equal(
-      $title.get(1).innerText.trim(),
-      'Response Rate',
-      'title of 2nd card is correct');
-    assert.equal(
-      $title.get(2).innerText.trim(),
-      'Precision',
-      'title of 3rd card is correct');
-    assert.equal(
-      $title.get(3).innerText.trim(),
-      'Recall',
-      'title of 4th card is correct');  
+    assert.equal($title.get(0).innerText.trim(), 'Anomalies', 'title of 1st card is correct');
+    assert.equal($title.get(1).innerText.trim(), 'Response Rate', 'title of 2nd card is correct');
+    assert.equal($title.get(2).innerText.trim(), 'Precision', 'title of 3rd card is correct');
+    assert.equal($title.get(3).innerText.trim(), 'Recall', 'title of 4th card is correct');
 
     // Testing values of all cards
-    assert.equal(
-      $number.get(0).innerText.trim(),
-      10,
-      'value of 1st card is correct');
-    assert.equal(
-      $number.get(1).innerText.trim(),
-      '30%',
-      'value of 2nd card is correct');
-    assert.equal(
-      $number.get(2).innerText.trim(),
-      '40%',
-      'value of 3rd card is correct');
-    assert.equal(
-      $number.get(3).innerText.trim(),
-      '50%',
-      'value of 4th card is correct');
+    assert.equal($number.get(0).innerText.trim(), 10, 'value of 1st card is correct');
+    assert.equal($number.get(1).innerText.trim(), '30%', 'value of 2nd card is correct');
+    assert.equal($number.get(2).innerText.trim(), '40%', 'value of 3rd card is correct');
+    assert.equal($number.get(3).innerText.trim(), '50%', 'value of 4th card is correct');
+  });
+
+  test('NaN percentage values are represented as N/A', async function (assert) {
+    const fetchedStats = {
+      totalAnomalies: {
+        value: 0,
+        type: 'COUNT'
+      },
+      responseRate: {
+        value: 0,
+        type: 'PERCENT'
+      },
+      precision: {
+        value: 'NaN',
+        type: 'PERCENT'
+      },
+      recall: {
+        value: 'NaN',
+        type: 'PERCENT'
+      }
+    };
+    this.setProperties({ stats: fetchedStats });
+
+    await render(hbs`{{stats-cards
+        stats=stats}}`);
+    const $number = this.$(`${CARD}-number`);
+
+    // Testing values of all cards
+    assert.equal($number.get(0).innerText.trim(), 0, 'value of 1st card is correct');
+    assert.equal($number.get(1).innerText.trim(), '0%', 'value of 2nd card is correct');
+    assert.equal($number.get(2).innerText.trim(), 'N/A', 'value of 3rd card is correct');
+    assert.equal($number.get(3).innerText.trim(), 'N/A', 'value of 4th card is correct');
   });
 });


### PR DESCRIPTION
When anomaly count is 0, the precision and recall being returned by backend is 'NaN' because they are the results of division by 0. On frontend we should represent those as N/A.