### PR TITLE
Improve and bug fix on  json record extraction logic

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -75,24 +75,73 @@ public class JsonFunctions {
   @ScalarFunction
   public static String jsonPathString(Object object, String jsonPath)
       throws JsonProcessingException {
-    return JsonUtils.objectToString(jsonPath(object, jsonPath));
+    Object jsonValue = jsonPath(object, jsonPath);
+    if (jsonValue instanceof String) {
+      return (String) jsonValue;
+    }
+    return JsonUtils.objectToString(jsonValue);
+  }
+
+  /**
+   * Extract from Json with path to String
+   */
+  @ScalarFunction
+  public static String jsonPathString(Object object, String jsonPath, String defaultValue) {
+    try {
+      return jsonPathString(object, jsonPath);
+    } catch (Exception e) {
+      return defaultValue;
+    }
   }
 
   /**
    * Extract from Json with path to Long
    */
   @ScalarFunction
-  public static long jsonPathLong(Object object, String jsonPath)
-      throws JsonProcessingException {
-    return Long.parseLong(jsonPathString(object, jsonPath));
+  public static long jsonPathLong(Object object, String jsonPath) {
+    final Object jsonValue = jsonPath(object, jsonPath);
+    if (jsonValue == null) {
+      return Long.MIN_VALUE;
+    }
+    if (jsonValue instanceof Number) {
+      return ((Number) jsonValue).longValue();
+    }
+    return Long.parseLong(jsonValue.toString());
+  }
+
+  /**
+   * Extract from Json with path to Long
+   */
+  @ScalarFunction
+  public static long jsonPathLong(Object object, String jsonPath, long defaultValue) {
+    try {
+      return jsonPathLong(object, jsonPath);
+    } catch (Exception e) {
+      return defaultValue;
+    }
   }
 
   /**
    * Extract from Json with path to Double
    */
   @ScalarFunction
-  public static double jsonPathDouble(Object object, String jsonPath)
-      throws JsonProcessingException {
-    return Double.parseDouble(jsonPathString(object, jsonPath));
+  public static double jsonPathDouble(Object object, String jsonPath) {
+    final Object jsonValue = jsonPath(object, jsonPath);
+    if (jsonValue instanceof Number) {
+      return ((Number) jsonValue).doubleValue();
+    }
+    return Double.parseDouble(jsonValue.toString());
+  }
+
+  /**
+   * Extract from Json with path to Double
+   */
+  @ScalarFunction
+  public static double jsonPathDouble(Object object, String jsonPath, double defaultValue) {
+    try {
+      return jsonPathDouble(object, jsonPath);
+    } catch (Exception e) {
+      return defaultValue;
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -60,6 +60,9 @@ public class JsonFunctionsTest {
     assertEquals(JsonFunctions.jsonPathString(jsonString, "$.actor.id"), "33500718");
     assertEquals(JsonFunctions.jsonPathLong(jsonString, "$.actor.id"), 33500718L);
     assertEquals(JsonFunctions.jsonPathDouble(jsonString, "$.actor.id"), 33500718.0);
+    assertEquals(JsonFunctions.jsonPathString(jsonString, "$.actor.aaa", "null"), "null");
+    assertEquals(JsonFunctions.jsonPathLong(jsonString, "$.actor.aaa", 100L), 100L);
+    assertEquals(JsonFunctions.jsonPathDouble(jsonString, "$.actor.aaa", 53.2), 53.2);
   }
 
 }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,9 +41,11 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
 
   @Override
   public void init(@Nullable Set<String> fields, @Nullable RecordExtractorConfig recordExtractorConfig) {
-    _fields = fields;
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
+      _fields = Collections.emptySet();
+    } else {
+      _fields = ImmutableSet.copyOf(fields);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.csv;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.csv.CSVRecord;
@@ -41,7 +42,7 @@ public class CSVRecordExtractor extends BaseRecordExtractor<CSVRecord> {
     if (fields == null || fields.isEmpty()) {
       _fields = csvRecordExtractorConfig.getColumnNames();
     } else {
-      _fields = fields;
+      _fields = ImmutableSet.copyOf(fields);
     }
     _multiValueDelimiter = csvRecordExtractorConfig.getMultiValueDelimiter();
   }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.plugin.inputformat.json;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -36,9 +38,11 @@ public class JSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
 
   @Override
   public void init(Set<String> fields, @Nullable RecordExtractorConfig recordExtractorConfig) {
-    _fields = fields;
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
+      _fields = Collections.emptySet();
+    } else {
+      _fields = ImmutableSet.copyOf(fields);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.plugin.inputformat.protobuf;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +45,11 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
 
   @Override
   public void init(@Nullable Set<String> fields, RecordExtractorConfig recordExtractorConfig) {
-    _fields = fields;
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
+      _fields = Collections.emptySet();
+    } else {
+      _fields = ImmutableSet.copyOf(fields);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.plugin.inputformat.thrift;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -41,10 +43,12 @@ public class ThriftRecordExtractor extends BaseRecordExtractor<TBase> {
 
   @Override
   public void init(@Nullable Set<String> fields, RecordExtractorConfig recordExtractorConfig) {
-    _fields = fields;
     _fieldIds = ((ThriftRecordExtractorConfig) recordExtractorConfig).getFieldIds();
     if (fields == null || fields.isEmpty()) {
       _extractAll = true;
+      _fields = Collections.emptySet();
+    } else {
+      _fields = ImmutableSet.copyOf(fields);
     }
   }
 


### PR DESCRIPTION
## Description
1. Make RecordExtractor always copy the fields to extract.

The issue found was that this field set used to init RecordExtractor might be modified after, so we shouldn't reply on it.
 
Discovered this when debugging a realtime table with all columns extracting from a JSON payload object. In the init call, this payload field is there, but when doing the real msg decoder, the same class only contains fields in schema and the payload field is gone.

2. Adding jsonPath functions with a default value, to avoid ingestion stop or msg loss.