### PR TITLE
Fixing the issue for realtime table creation with env variables in stream configs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -110,6 +110,7 @@ import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.config.ConfigUtils;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
@@ -1323,7 +1324,9 @@ public class PinotHelixResourceManager {
     }
   }
 
-  private void ensureRealtimeClusterIsSetUp(TableConfig realtimeTableConfig) {
+  private void ensureRealtimeClusterIsSetUp(TableConfig rawRealtimeTableConfig) {
+    // Need to apply environment variabls here to ensure the secrets used in stream configs are correctly applied.
+    TableConfig realtimeTableConfig = ConfigUtils.applyConfigWithEnvVariables(rawRealtimeTableConfig);
     String realtimeTableName = realtimeTableConfig.getTableName();
     StreamConfig streamConfig = new StreamConfig(realtimeTableConfig.getTableName(),
         IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig));


### PR DESCRIPTION
## Description
Fixing the issue of failure to create a realtime table with env variable inside it.

Current Pinot doesn't apply env variables during the table creation phase. 
For the real-time table creation, Kafka consumer won't be initialized correctly when Kafka connection secrets are configured as env variables. E.g.
```
"ssl.truststore.password": "${KAFKA_TRUSTSTORE_PASSWORD}",
"ssl.keystore.password": "${KAFKA_KEYSTORE_PASSWORD}",
```