### PR TITLE
Adding a version option to pinot admin to show all the component versions

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.tools.admin;
 
 import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.pinot.common.Utils;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.admin.command.AddSchemaCommand;
@@ -136,6 +138,9 @@ public class PinotAdministrator {
 
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   boolean _help = false;
+
+  @Option(name = "-version", required = false, help = true, aliases = {"-v", "--v", "--version"}, usage = "Print the version of Pinot package.")
+  boolean _version = false;
   boolean _status = false;
 
   private boolean getStatus() {
@@ -146,8 +151,9 @@ public class PinotAdministrator {
     try {
       CmdLineParser parser = new CmdLineParser(this);
       parser.parseArgument(args);
-
-      if ((_subCommand == null) || _help) {
+      if (_version) {
+        printVersion();
+      } else if ((_subCommand == null) || _help) {
         printUsage();
       } else if (_subCommand.getHelp()) {
         _subCommand.printUsage();
@@ -159,6 +165,14 @@ public class PinotAdministrator {
       LOGGER.error("Error: {}", e.getMessage());
     } catch (Exception e) {
       LOGGER.error("Exception caught: ", e);
+    }
+  }
+
+  private void printVersion() {
+    LOGGER.info("List All Pinot Component Versions:");
+    Map<String, String> componentVersions = Utils.getComponentVersions();
+    for (Map.Entry<String, String> entry : componentVersions.entrySet()) {
+      LOGGER.info("Package: {}, Version: {}", entry.getKey(), entry.getValue());
     }
   }
 


### PR DESCRIPTION
## Description
Adding a new option: -v into pinot-admin script to show all the component versions.
Sample Output:
```
➜ bin/pinot-admin.sh -v
List All Pinot Component Versions:
Package: pinot-protobuf, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-kafka-2.0, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-avro, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-distribution, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-csv, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-s3, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-batch-ingestion-standalone, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-confluent-avro, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-thrift, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-orc, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-batch-ingestion-spark, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-gcs, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-hdfs, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-batch-ingestion-hadoop, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-adls, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-json, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
Package: pinot-parquet, Version: 0.7.0-SNAPSHOT-23f7770ffc795b917c83efd3e36fcb369177bf01
```