### PR TITLE
Update Helm readme with latest incubator repo

### DIFF
--- a/kubernetes/helm/README.md
+++ b/kubernetes/helm/README.md
@@ -244,14 +244,14 @@ kubectl get all -n pinot-quickstart
 - For helm v3.0.0
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install -n pinot-quickstart kafka incubator/kafka --set replicas=1
 ```
 
 - For helm v2.12.1
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install --namespace "pinot-quickstart"  --name kafka incubator/kafka --set replicas=1
 ```
 


### PR DESCRIPTION
Old `https://kubernetes-charts-incubator.storage.googleapis.com` has been replaced by `https://charts.helm.sh/incubator`.