### PR TITLE
Introduce 'LOOKUP' Transform Function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -63,6 +63,7 @@ public enum TransformFunctionType {
   VALUEIN("valueIn"),
   MAPVALUE("mapValue"),
   INIDSET("inIdSet"),
+  LOOKUP("lookUp"),
   GROOVY("groovy"),
   // Special type for annotation based scalar functions
   SCALAR("scalar"),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -170,6 +170,6 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   }
 
   public List<String> getPrimaryKeyColumns() {
-    return new ArrayList<>(_primaryKeyColumns);
+    return _primaryKeyColumns;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.data.manager.offline;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -166,5 +167,9 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
 
   public FieldSpec getColumnFieldSpec(String columnName) {
     return _tableSchema.getFieldSpecFor(columnName);
+  }
+
+  public List<String> getPrimaryKeyColumns() {
+    return new ArrayList<>(_primaryKeyColumns);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +63,11 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
    */
   public static DimensionTableDataManager createInstanceByTableName(String tableNameWithType) {
     return _instances.computeIfAbsent(tableNameWithType, k -> new DimensionTableDataManager());
+  }
+
+  @VisibleForTesting
+  public static DimensionTableDataManager registerDimensionTable(String tableNameWithType, DimensionTableDataManager instance) {
+    return _instances.computeIfAbsent(tableNameWithType, k -> instance);
   }
 
   public static DimensionTableDataManager getInstanceByTableName(String tableNameWithType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -100,7 +100,8 @@ public class LookupTransformFunction extends BaseTransformFunction {
     _dimColumnName = ((LiteralTransformFunction) dimColumnFunction).getLiteral();
 
     List<TransformFunction> joinArguments = arguments.subList(2, arguments.size());
-    for (int i = 0; i < joinArguments.size() / 2; i++) {
+    int numJoinArguments = joinArguments.size();
+    for (int i = 0; i < numJoinArguments / 2; i++) {
       TransformFunction dimJoinKeyFunction = joinArguments.get((i * 2));
       Preconditions.checkArgument(dimJoinKeyFunction instanceof LiteralTransformFunction,
           "JoinKey argument must be a literal(string) representing the primary key for the dimension table");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -149,6 +150,19 @@ public class LookupTransformFunction extends BaseTransformFunction {
           break;
         case LONG:
           pkColumns[i] = ArrayUtils.toObject(tf.transformToLongValuesSV(projectionBlock));
+          break;
+        case FLOAT:
+          pkColumns[i] = ArrayUtils.toObject(tf.transformToFloatValuesSV(projectionBlock));
+          break;
+        case DOUBLE:
+          pkColumns[i] = ArrayUtils.toObject(tf.transformToDoubleValuesSV(projectionBlock));
+          break;
+        case BYTES:
+          byte[][] primitiveValues = tf.transformToBytesValuesSV(projectionBlock);
+          pkColumns[i] = new Byte[numDocuments][];
+          for (int n = 0; n < numDocuments; n++) {
+            pkColumns[i][n] = ArrayUtils.toObject(primitiveValues[n]);
+          }
           break;
         default:
           throw new IllegalStateException("Unknown column type for primary key");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -32,12 +32,13 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 
+
 /**
- * LOOKUP function take 4 or more arguments:
+ * LOOKUP function takes 4 or more arguments:
  * <ul>
  *   <li><b>TableName:</b> name of the dimension table which will be used</li>
  *   <li><b>ColumnName:</b> column name from the dimension table to look up</li>
- *   <li><b>JoinKey:</b> primary key column name for the dimension table. Note: Only primary key[s] is supported for JoinKey</li>
+ *   <li><b>JoinKey:</b> primary key column name for the dimension table. Note: Only primary key[s] are supported for JoinKey</li>
  *   <li><b>JoinValue:</b> primary key value</li>
  *   ...<br>
  *   *[If the dimension table has more then one primary keys (composite pk)]
@@ -47,238 +48,243 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
  * </ul>
  * <br>
  * Example:
- * <pre>{@code select playerName, teamID, lookup('baseballTeams', 'teamName', 'teamID', teamID) from baseballStats limit 10}</pre>
+ * <pre>{@code SELECT
+ *    baseballStats.playerName,
+ *    baseballStats.teamID,
+ *    lookup('baseballTeams', 'teamName', 'teamID', baseballStats.teamID)
+ * FROM
+ *    baseballStats
+ * LIMIT 10}</pre>
  * <br>
  * Above example joins the dimension table 'baseballTeams' into regular table 'baseballStats' on 'teamID' key.
  * Lookup function returns the value of the column 'teamName'.
  */
 public class LookupTransformFunction extends BaseTransformFunction {
-    public static final String FUNCTION_NAME = "lookUp";
-    private static final String TABLE_NAME_SUFFIX = "_OFFLINE";
+  public static final String FUNCTION_NAME = "lookUp";
+  private static final String TABLE_NAME_SUFFIX = "_OFFLINE";
 
-    // Lookup parameters
-    private String _dimTableName;
-    private String _dimColumnName;
-    private final List<String> _joinKeys = new ArrayList<>();
-    private final List<FieldSpec> _joinValueFieldSpecs = new ArrayList<>();
-    private final List<TransformFunction> _joinValueFunctions = new ArrayList<>();
+  // Lookup parameters
+  private String _dimTableName;
+  private String _dimColumnName;
+  private final List<String> _joinKeys = new ArrayList<>();
+  private final List<FieldSpec> _joinValueFieldSpecs = new ArrayList<>();
+  private final List<TransformFunction> _joinValueFunctions = new ArrayList<>();
 
-    private DimensionTableDataManager _dataManager;
-    private FieldSpec _lookupColumnFieldSpec;
+  private DimensionTableDataManager _dataManager;
+  private FieldSpec _lookupColumnFieldSpec;
 
-    @Override
-    public String getName() {
-        return FUNCTION_NAME;
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    // Check that there are correct number of arguments
+    Preconditions
+        .checkArgument(arguments.size() >= 4, "At least 4 arguments are required for LOOKUP transform function");
+    Preconditions
+        .checkArgument(arguments.size() % 2 == 0, "Should have the same number of JoinKey and JoinValue arguments");
+
+    TransformFunction dimTableNameFunction = arguments.get(0);
+    Preconditions.checkArgument(dimTableNameFunction instanceof LiteralTransformFunction,
+        "First argument must be a literal(string) representing the dimension table name");
+    _dimTableName = ((LiteralTransformFunction) dimTableNameFunction).getLiteral();
+
+    TransformFunction dimColumnFunction = arguments.get(1);
+    Preconditions.checkArgument(dimColumnFunction instanceof LiteralTransformFunction,
+        "Second argument must be a literal(string) representing the column name from dimension table to lookup");
+    _dimColumnName = ((LiteralTransformFunction) dimColumnFunction).getLiteral();
+
+    List<TransformFunction> joinArguments = arguments.subList(2, arguments.size());
+    for (int i = 0; i < joinArguments.size() / 2; i++) {
+      TransformFunction dimJoinKeyFunction = joinArguments.get((i * 2));
+      Preconditions.checkArgument(dimJoinKeyFunction instanceof LiteralTransformFunction,
+          "JoinKey argument must be a literal(string) representing the primary key for the dimension table");
+      _joinKeys.add(((LiteralTransformFunction) dimJoinKeyFunction).getLiteral());
+
+      TransformFunction factJoinValueFunction = joinArguments.get((i * 2) + 1);
+      TransformResultMetadata factJoinValueFunctionResultMetadata = factJoinValueFunction.getResultMetadata();
+      Preconditions.checkArgument(factJoinValueFunctionResultMetadata.isSingleValue(),
+          "JoinValue argument must be a single value expression");
+      _joinValueFunctions.add(factJoinValueFunction);
     }
 
-    @Override
-    public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-        // Check that there are correct number of arguments
-        Preconditions.checkArgument(arguments.size() >= 4,
-            "At least 4 arguments are required for LOOKUP transform function");
-        Preconditions.checkArgument(arguments.size() % 2 == 0,
-            "Should have the same number of JoinKey and JoinValue arguments");
+    // Validate lookup table and relevant columns
+    _dataManager = DimensionTableDataManager.getInstanceByTableName(_dimTableName + TABLE_NAME_SUFFIX);
+    Preconditions
+        .checkArgument(_dataManager != null, String.format("Dimension table does not exist: %s", _dimTableName));
 
-        TransformFunction dimTableNameFunction = arguments.get(0);
-        Preconditions.checkArgument(dimTableNameFunction instanceof LiteralTransformFunction,
-            "First argument must be a literal(string) representing the dimension table name");
-        _dimTableName = ((LiteralTransformFunction) dimTableNameFunction).getLiteral();
+    _lookupColumnFieldSpec = _dataManager.getColumnFieldSpec(_dimColumnName);
+    Preconditions.checkArgument(_lookupColumnFieldSpec != null,
+        String.format("Column does not exist in dimension table: %s:%s", _dimTableName, _dimColumnName));
 
-        TransformFunction dimColumnFunction = arguments.get(1);
-        Preconditions.checkArgument(dimColumnFunction instanceof LiteralTransformFunction,
-            "Second argument must be a literal(string) representing the column name from dimension table to lookup");
-        _dimColumnName = ((LiteralTransformFunction) dimColumnFunction).getLiteral();
+    for (String joinKey : _joinKeys) {
+      FieldSpec pkColumnSpec = _dataManager.getColumnFieldSpec(joinKey);
+      Preconditions.checkArgument(pkColumnSpec != null,
+          String.format("Primary key column doesn't exist in dimension table: %s:%s", _dimTableName, joinKey));
+      _joinValueFieldSpecs.add(pkColumnSpec);
+    }
+  }
 
-        List<TransformFunction> joinArguments = arguments.subList(2,arguments.size());
-        for (int i=0; i<joinArguments.size()/2; i++) {
-            TransformFunction dimJoinKeyFunction = joinArguments.get((i*2));
-            Preconditions.checkArgument(dimJoinKeyFunction instanceof LiteralTransformFunction,
-                "JoinKey argument must be a literal(string) representing the primary key for the dimension table");
-            _joinKeys.add(((LiteralTransformFunction) dimJoinKeyFunction).getLiteral());
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return new TransformResultMetadata(_lookupColumnFieldSpec.getDataType(),
+        _lookupColumnFieldSpec.isSingleValueField(), false);
+  }
 
-            TransformFunction factJoinValueFunction = joinArguments.get((i*2)+1);
-            TransformResultMetadata factJoinValueFunctionResultMetadata = factJoinValueFunction.getResultMetadata();
-            Preconditions.checkArgument(factJoinValueFunctionResultMetadata.isSingleValue(),
-                "JoinValue argument must be a single value expression");
-            _joinValueFunctions.add(factJoinValueFunction);
-        }
-
-        // Validate lookup table and relevant columns
-        _dataManager = DimensionTableDataManager.getInstanceByTableName(_dimTableName + TABLE_NAME_SUFFIX);
-        Preconditions.checkArgument(_dataManager != null,
-                String.format("Dimension table does not exist: %s", _dimTableName));
-
-        _lookupColumnFieldSpec = _dataManager.getColumnFieldSpec(_dimColumnName);
-        Preconditions.checkArgument(_lookupColumnFieldSpec != null,
-                String.format("Column does not exist in dimension table: %s:%s", _dimTableName, _dimColumnName));
-
-        for (String joinKey: _joinKeys) {
-            FieldSpec pkColumnSpec = _dataManager.getColumnFieldSpec(joinKey);
-            Preconditions.checkArgument(pkColumnSpec != null,
-                    String.format("Primary key column doesn't exist in dimension table: %s:%s",_dimTableName, joinKey));
-            _joinValueFieldSpecs.add(pkColumnSpec);
-        }
+  private Object[] lookup(ProjectionBlock projectionBlock) {
+    int numPkColumns = _joinKeys.size();
+    int numDocuments = projectionBlock.getNumDocs();
+    Object[][] pkColumns = new Object[numPkColumns][];
+    for (int i = 0; i < numPkColumns; i++) {
+      FieldSpec.DataType colType = _joinValueFieldSpecs.get(i).getDataType();
+      TransformFunction tf = _joinValueFunctions.get(i);
+      switch (colType) {
+        case STRING:
+          pkColumns[i] = tf.transformToStringValuesSV(projectionBlock);
+          break;
+        case INT:
+          pkColumns[i] = ArrayUtils.toObject(tf.transformToIntValuesSV(projectionBlock));
+          break;
+        case LONG:
+          pkColumns[i] = ArrayUtils.toObject(tf.transformToLongValuesSV(projectionBlock));
+          break;
+        default:
+          throw new IllegalStateException("Unknown column type for primary key");
+      }
     }
 
-    @Override
-    public TransformResultMetadata getResultMetadata() {
-        return new TransformResultMetadata(_lookupColumnFieldSpec.getDataType(),
-            _lookupColumnFieldSpec.isSingleValueField(),
-            false);
+    Object[] resultSet = new Object[numDocuments];
+    for (int i = 0; i < numDocuments; i++) {
+      // prepare pk
+      Object[] pkValues = new Object[numPkColumns];
+      for (int j = 0; j < numPkColumns; j++) {
+        pkValues[j] = pkColumns[j][i];
+      }
+      // lookup
+      GenericRow row = _dataManager.lookupRowByPrimaryKey(new PrimaryKey(pkValues));
+      if (row != null && row.getFieldToValueMap().containsKey(_dimColumnName)) {
+        resultSet[i] = row.getValue(_dimColumnName);
+      }
     }
+    return resultSet;
+  }
 
-    private Object[] lookup(ProjectionBlock projectionBlock) {
-        int numPkColumns = _joinKeys.size();
-        int numDocuments = projectionBlock.getNumDocs();
-        Object[][] pkColumns = new Object[numPkColumns][];
-        for (int i=0; i<numPkColumns; i++) {
-            FieldSpec.DataType colType = _joinValueFieldSpecs.get(i).getDataType();
-            TransformFunction tf = _joinValueFunctions.get(i);
-            switch (colType) {
-                case STRING:
-                    pkColumns[i] = tf.transformToStringValuesSV(projectionBlock);
-                    break;
-                case INT:
-                    pkColumns[i] = ArrayUtils.toObject(tf.transformToIntValuesSV(projectionBlock));
-                    break;
-                case LONG:
-                    pkColumns[i] = ArrayUtils.toObject(tf.transformToLongValuesSV(projectionBlock));
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown column type for primary key");
-            }
-        }
-
-        Object[] resultSet = new Object[numDocuments];
-        for (int i=0; i<numDocuments; i++) {
-            // prepare pk
-            Object[] pkValues = new Object[numPkColumns];
-            for (int j=0; j<numPkColumns; j++) {
-                pkValues[j] = pkColumns[j][i];
-            }
-            // lookup
-            GenericRow row = _dataManager.lookupRowByPrimaryKey(new PrimaryKey(pkValues));
-            if (row != null && row.getFieldToValueMap().containsKey(_dimColumnName)) {
-                resultSet[i] = row.getValue(_dimColumnName);
-            }
-        }
-        return resultSet;
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    int[] resultSet = new int[lookupObjects.length];
+    Arrays.fill(resultSet, ((Number) _lookupColumnFieldSpec.getDefaultNullValue()).intValue());
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = ((Number) lookupObjects[i]).intValue();
     }
+    return resultSet;
+  }
 
-    @Override
-    public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        int[] resultSet = new int[lookupObjects.length];
-        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).intValue());
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = ((Number)lookupObjects[i]).intValue();
-        }
-        return resultSet;
+  @Override
+  public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    long[] resultSet = new long[lookupObjects.length];
+    Arrays.fill(resultSet, ((Number) _lookupColumnFieldSpec.getDefaultNullValue()).longValue());
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = ((Number) lookupObjects[i]).longValue();
     }
+    return resultSet;
+  }
 
-    @Override
-    public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        long[] resultSet = new long[lookupObjects.length];
-        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).longValue());
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = ((Number)lookupObjects[i]).longValue();
-        }
-        return resultSet;
+  @Override
+  public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    float[] resultSet = new float[lookupObjects.length];
+    Arrays.fill(resultSet, ((Number) _lookupColumnFieldSpec.getDefaultNullValue()).floatValue());
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = ((Number) lookupObjects[i]).floatValue();
     }
+    return resultSet;
+  }
 
-    @Override
-    public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        float[] resultSet = new float[lookupObjects.length];
-        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).floatValue());
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = ((Number)lookupObjects[i]).floatValue();
-        }
-        return resultSet;
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    double[] resultSet = new double[lookupObjects.length];
+    Arrays.fill(resultSet, ((Number) _lookupColumnFieldSpec.getDefaultNullValue()).doubleValue());
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = ((Number) lookupObjects[i]).doubleValue();
     }
+    return resultSet;
+  }
 
-    @Override
-    public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        double[] resultSet = new double[lookupObjects.length];
-        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).doubleValue());
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = ((Number)lookupObjects[i]).doubleValue();
-        }
-        return resultSet;
+  @Override
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    String[] resultSet = new String[lookupObjects.length];
+    Arrays.fill(resultSet, _lookupColumnFieldSpec.getDefaultNullValueString());
+    for (int i = 0; i < lookupObjects.length; i++) {
+      if (lookupObjects[i] != null) {
+        resultSet[i] = lookupObjects[i].toString();
+      }
     }
+    return resultSet;
+  }
 
-    @Override
-    public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        String[] resultSet = new String[lookupObjects.length];
-        Arrays.fill(resultSet, _lookupColumnFieldSpec.getDefaultNullValueString());
-        for (int i=0; i<lookupObjects.length; i++) {
-            if (lookupObjects[i] != null) {
-                resultSet[i] = lookupObjects[i].toString();
-            }
-        }
-        return resultSet;
+  @Override
+  public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    byte[][] resultSet = new byte[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (byte[]) lookupObjects[i];
     }
+    return resultSet;
+  }
 
-    @Override
-    public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        byte[][] resultSet = new byte[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (byte[])lookupObjects[i];
-        }
-        return resultSet;
+  @Override
+  public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    int[][] resultSet = new int[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (int[]) lookupObjects[i];
     }
+    return resultSet;
+  }
 
-    @Override
-    public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        int[][] resultSet = new int[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (int[])lookupObjects[i];
-        }
-        return resultSet;
+  @Override
+  public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    long[][] resultSet = new long[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (long[]) lookupObjects[i];
     }
+    return resultSet;
+  }
 
-    @Override
-    public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        long[][] resultSet = new long[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (long[])lookupObjects[i];
-        }
-        return resultSet;
+  @Override
+  public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    float[][] resultSet = new float[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (float[]) lookupObjects[i];
     }
+    return resultSet;
+  }
 
-    @Override
-    public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        float[][] resultSet = new float[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (float[])lookupObjects[i];
-        }
-        return resultSet;
+  @Override
+  public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    double[][] resultSet = new double[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (double[]) lookupObjects[i];
     }
+    return resultSet;
+  }
 
-    @Override
-    public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        double[][] resultSet = new double[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (double[])lookupObjects[i];
-        }
-        return resultSet;
+  @Override
+  public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+    Object[] lookupObjects = lookup(projectionBlock);
+    String[][] resultSet = new String[lookupObjects.length][0];
+    for (int i = 0; i < lookupObjects.length; i++) {
+      resultSet[i] = (String[]) lookupObjects[i];
     }
-
-    @Override
-    public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
-        Object[] lookupObjects = lookup(projectionBlock);
-        String[][] resultSet = new String[lookupObjects.length][0];
-        for (int i=0; i<lookupObjects.length; i++) {
-            resultSet[i] = (String[])lookupObjects[i];
-        }
-        return resultSet;
-    }
+    return resultSet;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -1,0 +1,284 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+
+/**
+ * LOOKUP function take 4 or more arguments:
+ * <ul>
+ *   <li><b>TableName:</b> name of the dimension table which will be used</li>
+ *   <li><b>ColumnName:</b> column name from the dimension table to look up</li>
+ *   <li><b>JoinKey:</b> primary key column name for the dimension table. Note: Only primary key[s] is supported for JoinKey</li>
+ *   <li><b>JoinValue:</b> primary key value</li>
+ *   ...<br>
+ *   *[If the dimension table has more then one primary keys (composite pk)]
+ *     <li><b>JoinKey2</b></li>
+ *     <li><b>JoinValue2</b></li>
+ *   ...
+ * </ul>
+ * <br>
+ * Example:
+ * <pre>{@code select playerName, teamID, lookup('baseballTeams', 'teamName', 'teamID', teamID) from baseballStats limit 10}</pre>
+ * <br>
+ * Above example joins the dimension table 'baseballTeams' into regular table 'baseballStats' on 'teamID' key.
+ * Lookup function returns the value of the column 'teamName'.
+ */
+public class LookupTransformFunction extends BaseTransformFunction {
+    public static final String FUNCTION_NAME = "lookUp";
+    private static final String TABLE_NAME_SUFFIX = "_OFFLINE";
+
+    // Lookup parameters
+    private String _dimTableName;
+    private String _dimColumnName;
+    private final List<String> _joinKeys = new ArrayList<>();
+    private final List<FieldSpec> _joinValueFieldSpecs = new ArrayList<>();
+    private final List<TransformFunction> _joinValueFunctions = new ArrayList<>();
+
+    private DimensionTableDataManager _dataManager;
+    private FieldSpec _lookupColumnFieldSpec;
+
+    @Override
+    public String getName() {
+        return FUNCTION_NAME;
+    }
+
+    @Override
+    public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+        // Check that there are correct number of arguments
+        Preconditions.checkArgument(arguments.size() >= 4,
+            "At least 4 arguments are required for LOOKUP transform function");
+        Preconditions.checkArgument(arguments.size() % 2 == 0,
+            "Should have the same number of JoinKey and JoinValue arguments");
+
+        TransformFunction dimTableNameFunction = arguments.get(0);
+        Preconditions.checkArgument(dimTableNameFunction instanceof LiteralTransformFunction,
+            "First argument must be a literal(string) representing the dimension table name");
+        _dimTableName = ((LiteralTransformFunction) dimTableNameFunction).getLiteral();
+
+        TransformFunction dimColumnFunction = arguments.get(1);
+        Preconditions.checkArgument(dimColumnFunction instanceof LiteralTransformFunction,
+            "Second argument must be a literal(string) representing the column name from dimension table to lookup");
+        _dimColumnName = ((LiteralTransformFunction) dimColumnFunction).getLiteral();
+
+        List<TransformFunction> joinArguments = arguments.subList(2,arguments.size());
+        for (int i=0; i<joinArguments.size()/2; i++) {
+            TransformFunction dimJoinKeyFunction = joinArguments.get((i*2));
+            Preconditions.checkArgument(dimJoinKeyFunction instanceof LiteralTransformFunction,
+                "JoinKey argument must be a literal(string) representing the primary key for the dimension table");
+            _joinKeys.add(((LiteralTransformFunction) dimJoinKeyFunction).getLiteral());
+
+            TransformFunction factJoinValueFunction = joinArguments.get((i*2)+1);
+            TransformResultMetadata factJoinValueFunctionResultMetadata = factJoinValueFunction.getResultMetadata();
+            Preconditions.checkArgument(factJoinValueFunctionResultMetadata.isSingleValue(),
+                "JoinValue argument must be a single value expression");
+            _joinValueFunctions.add(factJoinValueFunction);
+        }
+
+        // Validate lookup table and relevant columns
+        _dataManager = DimensionTableDataManager.getInstanceByTableName(_dimTableName + TABLE_NAME_SUFFIX);
+        Preconditions.checkArgument(_dataManager != null,
+                String.format("Dimension table does not exist: %s", _dimTableName));
+
+        _lookupColumnFieldSpec = _dataManager.getColumnFieldSpec(_dimColumnName);
+        Preconditions.checkArgument(_lookupColumnFieldSpec != null,
+                String.format("Column does not exist in dimension table: %s:%s", _dimTableName, _dimColumnName));
+
+        for (String joinKey: _joinKeys) {
+            FieldSpec pkColumnSpec = _dataManager.getColumnFieldSpec(joinKey);
+            Preconditions.checkArgument(pkColumnSpec != null,
+                    String.format("Primary key column doesn't exist in dimension table: %s:%s",_dimTableName, joinKey));
+            _joinValueFieldSpecs.add(pkColumnSpec);
+        }
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+        return new TransformResultMetadata(_lookupColumnFieldSpec.getDataType(),
+            _lookupColumnFieldSpec.isSingleValueField(),
+            false);
+    }
+
+    private Object[] lookup(ProjectionBlock projectionBlock) {
+        int numPkColumns = _joinKeys.size();
+        int numDocuments = projectionBlock.getNumDocs();
+        Object[][] pkColumns = new Object[numPkColumns][];
+        for (int i=0; i<numPkColumns; i++) {
+            FieldSpec.DataType colType = _joinValueFieldSpecs.get(i).getDataType();
+            TransformFunction tf = _joinValueFunctions.get(i);
+            switch (colType) {
+                case STRING:
+                    pkColumns[i] = tf.transformToStringValuesSV(projectionBlock);
+                    break;
+                case INT:
+                    pkColumns[i] = ArrayUtils.toObject(tf.transformToIntValuesSV(projectionBlock));
+                    break;
+                case LONG:
+                    pkColumns[i] = ArrayUtils.toObject(tf.transformToLongValuesSV(projectionBlock));
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown column type for primary key");
+            }
+        }
+
+        Object[] resultSet = new Object[numDocuments];
+        for (int i=0; i<numDocuments; i++) {
+            // prepare pk
+            Object[] pkValues = new Object[numPkColumns];
+            for (int j=0; j<numPkColumns; j++) {
+                pkValues[j] = pkColumns[j][i];
+            }
+            // lookup
+            GenericRow row = _dataManager.lookupRowByPrimaryKey(new PrimaryKey(pkValues));
+            if (row != null && row.getFieldToValueMap().containsKey(_dimColumnName)) {
+                resultSet[i] = row.getValue(_dimColumnName);
+            }
+        }
+        return resultSet;
+    }
+
+    @Override
+    public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        int[] resultSet = new int[lookupObjects.length];
+        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).intValue());
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = ((Number)lookupObjects[i]).intValue();
+        }
+        return resultSet;
+    }
+
+    @Override
+    public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        long[] resultSet = new long[lookupObjects.length];
+        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).longValue());
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = ((Number)lookupObjects[i]).longValue();
+        }
+        return resultSet;
+    }
+
+    @Override
+    public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        float[] resultSet = new float[lookupObjects.length];
+        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).floatValue());
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = ((Number)lookupObjects[i]).floatValue();
+        }
+        return resultSet;
+    }
+
+    @Override
+    public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        double[] resultSet = new double[lookupObjects.length];
+        Arrays.fill(resultSet, ((Number)_lookupColumnFieldSpec.getDefaultNullValue()).doubleValue());
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = ((Number)lookupObjects[i]).doubleValue();
+        }
+        return resultSet;
+    }
+
+    @Override
+    public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        String[] resultSet = new String[lookupObjects.length];
+        Arrays.fill(resultSet, _lookupColumnFieldSpec.getDefaultNullValueString());
+        for (int i=0; i<lookupObjects.length; i++) {
+            if (lookupObjects[i] != null) {
+                resultSet[i] = lookupObjects[i].toString();
+            }
+        }
+        return resultSet;
+    }
+
+    @Override
+    public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        byte[][] resultSet = new byte[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (byte[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+
+    @Override
+    public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        int[][] resultSet = new int[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (int[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+
+    @Override
+    public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        long[][] resultSet = new long[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (long[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+
+    @Override
+    public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        float[][] resultSet = new float[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (float[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+
+    @Override
+    public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        double[][] resultSet = new double[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (double[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+
+    @Override
+    public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+        Object[] lookupObjects = lookup(projectionBlock);
+        String[][] resultSet = new String[lookupObjects.length][0];
+        for (int i=0; i<lookupObjects.length; i++) {
+            resultSet[i] = (String[])lookupObjects[i];
+        }
+        return resultSet;
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
@@ -166,9 +167,9 @@ public class LookupTransformFunction extends BaseTransformFunction {
           break;
         case BYTES:
           byte[][] primitiveValues = tf.transformToBytesValuesSV(projectionBlock);
-          pkColumns[c] = new Byte[numDocuments][];
+          pkColumns[c] = new ByteArray[numDocuments];
           for (int i = 0; i < numDocuments; i++) {
-            pkColumns[c][i] = ArrayUtils.toObject(primitiveValues[i]);
+            pkColumns[c][i] = new ByteArray(primitiveValues[i]);
           }
           break;
         default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -51,7 +51,7 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
  * <pre>{@code SELECT
  *    baseballStats.playerName,
  *    baseballStats.teamID,
- *    lookup('baseballTeams', 'teamName', 'teamID', baseballStats.teamID)
+ *    LOOKUP('dimBaseballTeams', 'teamName', 'teamID', baseballStats.teamID)
  * FROM
  *    baseballStats
  * LIMIT 10}</pre>

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -92,6 +92,7 @@ public class TransformFunctionFactory {
           put(canonicalize(TransformFunctionType.VALUEIN.getName().toLowerCase()), ValueInTransformFunction.class);
           put(canonicalize(TransformFunctionType.MAPVALUE.getName().toLowerCase()), MapValueTransformFunction.class);
           put(canonicalize(TransformFunctionType.INIDSET.getName().toLowerCase()), InIdSetTransformFunction.class);
+          put(canonicalize(TransformFunctionType.LOOKUP.getName().toLowerCase()), LookupTransformFunction.class);
 
           // Array functions
           put(canonicalize(TransformFunctionType.ARRAYAVERAGE.getName().toLowerCase()), ArrayAverageTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.data.manager.offline;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
@@ -159,6 +160,10 @@ public class DimensionTableDataManagerTest {
     Assert.assertNotNull(spec, "Should return spec for existing column");
     Assert.assertEquals(spec.getDataType(), FieldSpec.DataType.STRING,
         "Should return correct data type for teamName column");
+
+    // Confirm we can read primary column list
+    List<String> pkColumns = mgr.getPrimaryKeyColumns();
+    Assert.assertEquals(pkColumns, Arrays.asList("teamID"), "Should return PK column list");
 
     // Remove the segment
     List<SegmentDataManager> segmentManagers = mgr.acquireAllSegments();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -247,6 +247,27 @@ public abstract class BaseTransformFunctionTest {
     }
   }
 
+  protected void testTransformFunctionMV(TransformFunction transformFunction, long[][] expectedValues) {
+    long[][] longMVValues = transformFunction.transformToLongValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(longMVValues[i], expectedValues[i]);
+    }
+  }
+
+  protected void testTransformFunctionMV(TransformFunction transformFunction, float[][] expectedValues) {
+    float[][] floatMVValues = transformFunction.transformToFloatValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(floatMVValues[i], expectedValues[i]);
+    }
+  }
+
+  protected void testTransformFunctionMV(TransformFunction transformFunction, double[][] expectedValues) {
+    double[][] doubleMVValues = transformFunction.transformToDoubleValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(doubleMVValues[i], expectedValues[i]);
+    }
+  }
+
   protected void testTransformFunctionMV(TransformFunction transformFunction, String[][] expectedValues) {
     String[][] stringMVValues = transformFunction.transformToStringValuesMV(_projectionBlock);
     for (int i = 0; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -34,312 +34,308 @@ import java.util.Map;
 
 import static org.mockito.Mockito.*;
 
+
 public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
-    private static final String TABLE_NAME = "baseballTeams_OFFLINE";
-    private DimensionTableDataManager tableManager;
+  private static final String TABLE_NAME = "baseballTeams_OFFLINE";
+  private DimensionTableDataManager tableManager;
 
-    @BeforeSuite
-    public void setUp() throws Exception {
-        super.setUp();
+  @BeforeSuite
+  public void setUp()
+      throws Exception {
+    super.setUp();
 
-        createTestableTableManager();
+    createTestableTableManager();
+  }
+
+  private void createTestableTableManager() {
+    tableManager = mock(DimensionTableDataManager.class);
+    DimensionTableDataManager.registerDimensionTable(TABLE_NAME, tableManager);
+
+    // Creating a mock table which looks like:
+    // TeamID (PK, str) | TeamName(str) | TeamName_MV(str[]) | TeamInteger(int) | TeamInteger_MV(int[]) | TeamFloat(float) | ...
+    //
+    // All values are dynamically created to be variations of the primary key.
+    // e.g
+    // lookupRowByPrimaryKey(['FOO']) -> (TeamID: 'foo', TeamName: 'teamName_for_foo', TeamInteger: hashCode(['foo']), ...
+    //
+    when(tableManager.getColumnFieldSpec("teamID"))
+        .thenReturn(new DimensionFieldSpec("teamID", FieldSpec.DataType.STRING, true));
+    when(tableManager.getColumnFieldSpec("teamName"))
+        .thenReturn(new DimensionFieldSpec("teamName", FieldSpec.DataType.STRING, true));
+    when(tableManager.getColumnFieldSpec("teamName_MV"))
+        .thenReturn(new DimensionFieldSpec("teamName_MV", FieldSpec.DataType.STRING, false));
+    when(tableManager.getColumnFieldSpec("teamInteger"))
+        .thenReturn(new DimensionFieldSpec("teamInteger", FieldSpec.DataType.INT, true));
+    when(tableManager.getColumnFieldSpec("teamInteger_MV"))
+        .thenReturn(new DimensionFieldSpec("teamInteger_MV", FieldSpec.DataType.INT, false));
+    when(tableManager.getColumnFieldSpec("teamFloat"))
+        .thenReturn(new DimensionFieldSpec("teamFloat", FieldSpec.DataType.FLOAT, true));
+    when(tableManager.getColumnFieldSpec("teamFloat_MV"))
+        .thenReturn(new DimensionFieldSpec("teamFloat_MV", FieldSpec.DataType.FLOAT, false));
+    when(tableManager.getColumnFieldSpec("teamDouble"))
+        .thenReturn(new DimensionFieldSpec("teamDouble", FieldSpec.DataType.DOUBLE, true));
+    when(tableManager.getColumnFieldSpec("teamDouble_MV"))
+        .thenReturn(new DimensionFieldSpec("teamDouble_MV", FieldSpec.DataType.DOUBLE, false));
+    when(tableManager.getColumnFieldSpec("teamLong"))
+        .thenReturn(new DimensionFieldSpec("teamLong", FieldSpec.DataType.LONG, true));
+    when(tableManager.getColumnFieldSpec("teamLong_MV"))
+        .thenReturn(new DimensionFieldSpec("teamLong_MV", FieldSpec.DataType.LONG, false));
+    when(tableManager.getColumnFieldSpec("teamBytes"))
+        .thenReturn(new DimensionFieldSpec("teamNameBytes", FieldSpec.DataType.BYTES, true));
+    when(tableManager.lookupRowByPrimaryKey(any(PrimaryKey.class))).thenAnswer(invocation -> {
+      PrimaryKey key = invocation.getArgument(0);
+      GenericRow row = new GenericRow();
+      row.putValue("teamName", "teamName_for_" + key.toString());
+      row.putValue("teamName_MV",
+          new String[]{"teamName_for_" + key.toString() + "_1", "teamName_for_" + key.toString() + "_2",});
+      row.putValue("teamInteger", key.hashCode());
+      row.putValue("teamInteger_MV", new int[]{key.hashCode(), key.hashCode()});
+      row.putValue("teamFloat", (float) key.hashCode());
+      row.putValue("teamFloat_MV", new float[]{(float) key.hashCode(), (float) key.hashCode()});
+      row.putValue("teamDouble", (double) key.hashCode());
+      row.putValue("teamDouble_MV", new double[]{(double) key.hashCode(), (double) key.hashCode()});
+      row.putValue("teamLong", (long) key.hashCode());
+      row.putValue("teamLong_MV", new long[]{(long) key.hashCode(), (long) key.hashCode()});
+      row.putValue("teamBytes", ("teamBytes_for_" + key.toString()).getBytes());
+      return row;
+    });
+  }
+
+  @Test
+  public void instantiationTests()
+      throws Exception {
+    // Success case
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof LookupTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), LookupTransformFunction.FUNCTION_NAME);
+
+    // Wrong number of arguments
+    Assert.assertThrows(BadQueryRequestException.class, () -> {
+      TransformFunctionFactory
+          .get(QueryContextConverterUtils.getExpression(String.format("lookup('baseballTeams','teamName','teamID')")),
+              _dataSourceMap);
+    });
+
+    // Wrong number of join keys
+    Assert.assertThrows(BadQueryRequestException.class, () -> {
+      TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(
+          String.format("lookup('baseballTeams','teamName','teamID', %s, 'danglingKey')", STRING_SV_COLUMN)),
+          _dataSourceMap);
+    });
+
+    // Non literal tableName argument
+    Assert.assertThrows(BadQueryRequestException.class, () -> {
+      TransformFunctionFactory.get(QueryContextConverterUtils
+              .getExpression(String.format("lookup(%s,'teamName','teamID', %s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+          _dataSourceMap);
+    });
+
+    // Non literal lookup columnName argument
+    Assert.assertThrows(BadQueryRequestException.class, () -> {
+      TransformFunctionFactory.get(QueryContextConverterUtils
+              .getExpression(String.format("lookup('baseballTeams',%s,'teamID',%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+          _dataSourceMap);
+    });
+
+    // Non literal lookup columnName argument
+    Assert.assertThrows(BadQueryRequestException.class, () -> {
+      TransformFunctionFactory.get(QueryContextConverterUtils
+              .getExpression(String.format("lookup('baseballTeams','teamName',%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+          _dataSourceMap);
+    });
+  }
+
+  @Test
+  public void resultDataTypeTest()
+      throws Exception {
+    HashMap<String, FieldSpec.DataType> testCases = new HashMap<String, FieldSpec.DataType>() {{
+      put("teamName", FieldSpec.DataType.STRING);
+      put("teamInteger", FieldSpec.DataType.INT);
+      put("teamFloat", FieldSpec.DataType.FLOAT);
+      put("teamLong", FieldSpec.DataType.LONG);
+      put("teamDouble", FieldSpec.DataType.DOUBLE);
+    }};
+
+    for (Map.Entry<String, FieldSpec.DataType> testCase : testCases.entrySet()) {
+      ExpressionContext expression = QueryContextConverterUtils.getExpression(
+          String.format("lookup('baseballTeams','%s','teamID',%s)", testCase.getKey(), STRING_SV_COLUMN));
+      TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+      Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), testCase.getValue(),
+          String.format("Expecting %s data type for lookup column: '%s'", testCase.getKey(), testCase.getValue()));
+    }
+  }
+
+  @Test
+  public void basicLookupTests()
+      throws Exception {
+    // Lookup col: StringSV
+    // PK: [String]
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[] expectedStringValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedStringValues[i] = String.format("teamName_for_[%s]", _stringSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedStringValues);
+
+    // Lookup col: IntSV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamInteger','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedIntValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedIntValues[i] = (new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode();
+    }
+    testTransformFunction(transformFunction, expectedIntValues);
+
+    // Lookup col: DoubleSV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamDouble','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    double[] expectedDoubleValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedDoubleValues[i] = (double) (new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode();
+    }
+    testTransformFunction(transformFunction, expectedDoubleValues);
+
+    // Lookup col: BytesSV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamBytes','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[][] expectedBytesValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedBytesValues[i] = String.format("teamBytes_for_[%s]", _stringSVValues[i]).getBytes();
+    }
+    testTransformFunction(transformFunction, expectedBytesValues);
+  }
+
+  @Test
+  public void multiValueLookupTests()
+      throws Exception {
+    // Lookup col: StringMV
+    // PK: [String]
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamName_MV','teamID',%s)", STRING_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[][] expectedStringMVValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedStringMVValues[i] =
+          new String[]{String.format("teamName_for_[%s]_1", _stringSVValues[i]), String.format("teamName_for_[%s]_2",
+              _stringSVValues[i]),};
+    }
+    testTransformFunctionMV(transformFunction, expectedStringMVValues);
+
+    // Lookup col: IntegerMV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamInteger_MV','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[][] expectedIntegerMVValues = new int[NUM_ROWS][0];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedIntegerMVValues[i] =
+          new int[]{(new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode(), (new PrimaryKey(
+              new Object[]{_stringSVValues[i]})).hashCode(),};
+    }
+    testTransformFunctionMV(transformFunction, expectedIntegerMVValues);
+
+    // Lookup col: FloatMV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamFloat_MV','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    float[][] expectedFloatMVValues = new float[NUM_ROWS][0];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedFloatMVValues[i] =
+          new float[]{(float) (new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode(), (float) (new PrimaryKey(
+              new Object[]{_stringSVValues[i]})).hashCode(),};
+    }
+    testTransformFunctionMV(transformFunction, expectedFloatMVValues);
+
+    // Lookup col: LongMV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamLong_MV','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    long[][] expectedLongMVValues = new long[NUM_ROWS][0];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedLongMVValues[i] =
+          new long[]{(long) (new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode(), (long) (new PrimaryKey(
+              new Object[]{_stringSVValues[i]})).hashCode(),};
+    }
+    testTransformFunctionMV(transformFunction, expectedLongMVValues);
+
+    // Lookup col: DoubleMV
+    // PK: [String]
+    expression = QueryContextConverterUtils
+        .getExpression(String.format("lookup('baseballTeams','teamDouble_MV','teamID',%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    double[][] expectedDoubleMVValues = new double[NUM_ROWS][0];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedDoubleMVValues[i] =
+          new double[]{(double) (new PrimaryKey(new Object[]{_stringSVValues[i]})).hashCode(), (double) (new PrimaryKey(
+              new Object[]{_stringSVValues[i]})).hashCode(),};
+    }
+    testTransformFunctionMV(transformFunction, expectedDoubleMVValues);
+  }
+
+  @Test
+  public void primaryKeyTypeTest()
+      throws Exception {
+    // preparing simple tables for testing different primary key types (INT, STRING, LONG)
+    Map<String, FieldSpec.DataType> testTables = new HashMap<String, FieldSpec.DataType>() {{
+      put("dimTableWithIntPK_OFFLINE", FieldSpec.DataType.INT);
+      put("dimTableWithStringPK_OFFLINE", FieldSpec.DataType.STRING);
+      put("dimTableWithLongPK_OFFLINE", FieldSpec.DataType.LONG);
+    }};
+    for (Map.Entry<String, FieldSpec.DataType> table : testTables.entrySet()) {
+      DimensionTableDataManager mgr = mock(DimensionTableDataManager.class);
+      DimensionTableDataManager.registerDimensionTable(table.getKey(), mgr);
+      when(mgr.getColumnFieldSpec("primaryColumn"))
+          .thenReturn(new DimensionFieldSpec("primaryColumn", table.getValue(), true));
+      when(mgr.getColumnFieldSpec("lookupColumn"))
+          .thenReturn(new DimensionFieldSpec("lookupColumn", FieldSpec.DataType.STRING, true));
+      when(mgr.lookupRowByPrimaryKey(any(PrimaryKey.class))).thenAnswer(invocation -> {
+        PrimaryKey key = invocation.getArgument(0);
+        GenericRow row = new GenericRow();
+        row.putValue("lookupColumn", "lookup_value_for_" + key.toString());
+        return row;
+      });
     }
 
-    private void createTestableTableManager() {
-        tableManager = mock(DimensionTableDataManager.class);
-        DimensionTableDataManager.registerDimensionTable(TABLE_NAME, tableManager);
-
-        // Creating a mock table which looks like:
-        // TeamID (PK, str) | TeamName(str) | TeamName_MV(str[]) | TeamInteger(int) | TeamInteger_MV(int[]) | TeamFloat(float) | ...
-        //
-        // All values are dynamically created to be variations of the primary key.
-        // e.g
-        // lookupRowByPrimaryKey(['FOO']) -> (TeamID: 'foo', TeamName: 'teamName_for_foo', TeamInteger: hashCode(['foo']), ...
-        //
-        when(tableManager.getColumnFieldSpec("teamID")).thenReturn(
-                new DimensionFieldSpec("teamID", FieldSpec.DataType.STRING, true));
-        when(tableManager.getColumnFieldSpec("teamName")).thenReturn(
-                new DimensionFieldSpec("teamName", FieldSpec.DataType.STRING, true));
-        when(tableManager.getColumnFieldSpec("teamName_MV")).thenReturn(
-                new DimensionFieldSpec("teamName_MV", FieldSpec.DataType.STRING, false));
-        when(tableManager.getColumnFieldSpec("teamInteger")).thenReturn(
-                new DimensionFieldSpec("teamInteger", FieldSpec.DataType.INT, true));
-        when(tableManager.getColumnFieldSpec("teamInteger_MV")).thenReturn(
-                new DimensionFieldSpec("teamInteger_MV", FieldSpec.DataType.INT, false));
-        when(tableManager.getColumnFieldSpec("teamFloat")).thenReturn(
-                new DimensionFieldSpec("teamFloat", FieldSpec.DataType.FLOAT, true));
-        when(tableManager.getColumnFieldSpec("teamFloat_MV")).thenReturn(
-                new DimensionFieldSpec("teamFloat_MV", FieldSpec.DataType.FLOAT, false));
-        when(tableManager.getColumnFieldSpec("teamDouble")).thenReturn(
-                new DimensionFieldSpec("teamDouble", FieldSpec.DataType.DOUBLE, true));
-        when(tableManager.getColumnFieldSpec("teamDouble_MV")).thenReturn(
-                new DimensionFieldSpec("teamDouble_MV", FieldSpec.DataType.DOUBLE, false));
-        when(tableManager.getColumnFieldSpec("teamLong")).thenReturn(
-                new DimensionFieldSpec("teamLong", FieldSpec.DataType.LONG, true));
-        when(tableManager.getColumnFieldSpec("teamLong_MV")).thenReturn(
-                new DimensionFieldSpec("teamLong_MV", FieldSpec.DataType.LONG, false));
-        when(tableManager.getColumnFieldSpec("teamBytes")).thenReturn(
-                new DimensionFieldSpec("teamNameBytes", FieldSpec.DataType.BYTES, true));
-        when(tableManager.lookupRowByPrimaryKey(any(PrimaryKey.class)))
-                .thenAnswer(invocation -> {
-                    PrimaryKey key = invocation.getArgument(0);
-                    GenericRow row = new GenericRow();
-                    row.putValue("teamName", "teamName_for_" + key.toString());
-                    row.putValue("teamName_MV", new String[]{
-                            "teamName_for_" + key.toString() + "_1",
-                            "teamName_for_" + key.toString() + "_2",
-                    });
-                    row.putValue("teamInteger", key.hashCode());
-                    row.putValue("teamInteger_MV", new int[]{key.hashCode(), key.hashCode()});
-                    row.putValue("teamFloat", (float)key.hashCode());
-                    row.putValue("teamFloat_MV", new float[]{(float)key.hashCode(),(float)key.hashCode()});
-                    row.putValue("teamDouble", (double)key.hashCode());
-                    row.putValue("teamDouble_MV", new double[]{(double)key.hashCode(), (double)key.hashCode()});
-                    row.putValue("teamLong", (long)key.hashCode());
-                    row.putValue("teamLong_MV", new long[]{(long)key.hashCode(),(long)key.hashCode()});
-                    row.putValue("teamBytes", ("teamBytes_for_" + key.toString()).getBytes());
-                    return row;
-                });
+    // PK: [Int]
+    ExpressionContext expression = QueryContextConverterUtils.getExpression(
+        String.format("lookup('dimTableWithIntPK', 'lookupColumn', 'primaryColumn', %s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[] expectedResults = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResults[i] = String.format("lookup_value_for_[%s]", _intSVValues[i]);
     }
+    testTransformFunction(transformFunction, expectedResults);
 
-    @Test
-    public void instantiationTests() throws Exception {
-        // Success case
-        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
-        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        Assert.assertTrue(transformFunction instanceof LookupTransformFunction);
-        Assert.assertEquals(transformFunction.getName(), LookupTransformFunction.FUNCTION_NAME);
-
-        // Wrong number of arguments
-        Assert.assertThrows(BadQueryRequestException.class, () -> {
-            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
-                    .format("lookup('baseballTeams','teamName','teamID')")), _dataSourceMap);
-        });
-
-        // Wrong number of join keys
-        Assert.assertThrows(BadQueryRequestException.class, () -> {
-            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
-                    .format("lookup('baseballTeams','teamName','teamID', %s, 'danglingKey')", STRING_SV_COLUMN)),
-                    _dataSourceMap);
-        });
-
-        // Non literal tableName argument
-        Assert.assertThrows(BadQueryRequestException.class, () -> {
-            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
-                            .format("lookup(%s,'teamName','teamID', %s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
-                    _dataSourceMap);
-        });
-
-        // Non literal lookup columnName argument
-        Assert.assertThrows(BadQueryRequestException.class, () -> {
-            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
-                            .format("lookup('baseballTeams',%s,'teamID',%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
-                    _dataSourceMap);
-        });
-
-        // Non literal lookup columnName argument
-        Assert.assertThrows(BadQueryRequestException.class, () -> {
-            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
-                            .format("lookup('baseballTeams','teamName',%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
-                    _dataSourceMap);
-        });
+    // PK: [String]
+    expression = QueryContextConverterUtils.getExpression(
+        String.format("lookup('dimTableWithStringPK', 'lookupColumn', 'primaryColumn', %s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    expectedResults = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResults[i] = String.format("lookup_value_for_[%s]", _stringSVValues[i]);
     }
+    testTransformFunction(transformFunction, expectedResults);
 
-    @Test
-    public void resultDataTypeTest() throws Exception {
-        HashMap<String, FieldSpec.DataType> testCases = new HashMap<String, FieldSpec.DataType>(){{
-            put("teamName", FieldSpec.DataType.STRING);
-            put("teamInteger", FieldSpec.DataType.INT);
-            put("teamFloat", FieldSpec.DataType.FLOAT);
-            put("teamLong", FieldSpec.DataType.LONG);
-            put("teamDouble", FieldSpec.DataType.DOUBLE);
-        }};
-
-        for (Map.Entry<String, FieldSpec.DataType> testCase : testCases.entrySet()) {
-            ExpressionContext expression = QueryContextConverterUtils.getExpression(String
-                    .format("lookup('baseballTeams','%s','teamID',%s)", testCase.getKey(), STRING_SV_COLUMN));
-            TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-            Assert.assertEquals(
-                    transformFunction.getResultMetadata().getDataType(),
-                    testCase.getValue(),
-                    String.format("Expecting %s data type for lookup column: '%s'",
-                            testCase.getKey(), testCase.getValue()));
-        }
+    // PK: [Long]
+    expression = QueryContextConverterUtils.getExpression(
+        String.format("lookup('dimTableWithLongPK', 'lookupColumn', 'primaryColumn', %s)", LONG_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    expectedResults = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedResults[i] = String.format("lookup_value_for_[%s]", _longSVValues[i]);
     }
-
-    @Test
-    public void basicLookupTests() throws Exception {
-        // Lookup col: StringSV
-        // PK: [String]
-        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
-        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        String[] expectedStringValues = new String[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedStringValues[i] = String.format("teamName_for_[%s]", _stringSVValues[i]);
-        }
-        testTransformFunction(transformFunction, expectedStringValues);
-
-        // Lookup col: IntSV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamInteger','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        int[] expectedIntValues = new int[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedIntValues[i] = (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode();
-        }
-        testTransformFunction(transformFunction, expectedIntValues);
-
-        // Lookup col: DoubleSV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamDouble','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        double[] expectedDoubleValues = new double[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedDoubleValues[i] = (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode();
-        }
-        testTransformFunction(transformFunction, expectedDoubleValues);
-
-        // Lookup col: BytesSV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-            .format("lookup('baseballTeams','teamBytes','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        byte[][] expectedBytesValues = new byte[NUM_ROWS][];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedBytesValues[i] = String.format("teamBytes_for_[%s]", _stringSVValues[i]).getBytes();
-        }
-        testTransformFunction(transformFunction, expectedBytesValues);
-    }
-
-    @Test
-    public void multiValueLookupTests() throws Exception {
-        // Lookup col: StringMV
-        // PK: [String]
-        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamName_MV','teamID',%s)", STRING_SV_COLUMN));
-        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        String[][] expectedStringMVValues = new String[NUM_ROWS][];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedStringMVValues[i] = new String[]{
-                    String.format("teamName_for_[%s]_1", _stringSVValues[i]),
-                    String.format("teamName_for_[%s]_2", _stringSVValues[i]),
-            };
-        }
-        testTransformFunctionMV(transformFunction, expectedStringMVValues);
-
-        // Lookup col: IntegerMV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-                .format("lookup('baseballTeams','teamInteger_MV','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        int[][] expectedIntegerMVValues = new int[NUM_ROWS][0];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedIntegerMVValues[i] = new int[]{
-                    (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-                    (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-            };
-        }
-        testTransformFunctionMV(transformFunction, expectedIntegerMVValues);
-
-        // Lookup col: FloatMV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-            .format("lookup('baseballTeams','teamFloat_MV','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        float[][] expectedFloatMVValues = new float[NUM_ROWS][0];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedFloatMVValues[i] = new float[]{
-                (float)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-                (float)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-            };
-        }
-        testTransformFunctionMV(transformFunction, expectedFloatMVValues);
-
-        // Lookup col: LongMV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-            .format("lookup('baseballTeams','teamLong_MV','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        long[][] expectedLongMVValues = new long[NUM_ROWS][0];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedLongMVValues[i] = new long[]{
-                (long)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-                (long)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-            };
-        }
-        testTransformFunctionMV(transformFunction, expectedLongMVValues);
-
-        // Lookup col: DoubleMV
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String
-            .format("lookup('baseballTeams','teamDouble_MV','teamID',%s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        double[][] expectedDoubleMVValues = new double[NUM_ROWS][0];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedDoubleMVValues[i] = new double[]{
-                (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-                (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
-            };
-        }
-        testTransformFunctionMV(transformFunction, expectedDoubleMVValues);
-    }
-
-    @Test
-    public void primaryKeyTypeTest() throws Exception {
-        // preparing simple tables for testing different primary key types (INT, STRING, LONG)
-        Map<String, FieldSpec.DataType> testTables = new HashMap<String, FieldSpec.DataType>(){{
-            put("dimTableWithIntPK_OFFLINE", FieldSpec.DataType.INT);
-            put("dimTableWithStringPK_OFFLINE", FieldSpec.DataType.STRING);
-            put("dimTableWithLongPK_OFFLINE", FieldSpec.DataType.LONG);
-        }};
-        for (Map.Entry<String, FieldSpec.DataType> table: testTables.entrySet()) {
-            DimensionTableDataManager mgr = mock(DimensionTableDataManager.class);
-            DimensionTableDataManager.registerDimensionTable(table.getKey(), mgr);
-            when(mgr.getColumnFieldSpec("primaryColumn")).thenReturn(
-                new DimensionFieldSpec("primaryColumn", table.getValue(), true));
-            when(mgr.getColumnFieldSpec("lookupColumn")).thenReturn(
-                new DimensionFieldSpec("lookupColumn", FieldSpec.DataType.STRING, true));
-            when(mgr.lookupRowByPrimaryKey(any(PrimaryKey.class)))
-                .thenAnswer(invocation -> {
-                    PrimaryKey key = invocation.getArgument(0);
-                    GenericRow row = new GenericRow();
-                    row.putValue("lookupColumn", "lookup_value_for_" + key.toString());
-                    return row;
-                });
-        }
-
-        // PK: [Int]
-        ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format(
-            "lookup('dimTableWithIntPK', 'lookupColumn', 'primaryColumn', %s)", INT_SV_COLUMN));
-        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        String[] expectedResults = new String[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedResults[i] = String.format("lookup_value_for_[%s]", _intSVValues[i]);
-        }
-        testTransformFunction(transformFunction, expectedResults);
-
-        // PK: [String]
-        expression = QueryContextConverterUtils.getExpression(String.format(
-            "lookup('dimTableWithStringPK', 'lookupColumn', 'primaryColumn', %s)", STRING_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        expectedResults = new String[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedResults[i] = String.format("lookup_value_for_[%s]", _stringSVValues[i]);
-        }
-        testTransformFunction(transformFunction, expectedResults);
-
-        // PK: [Long]
-        expression = QueryContextConverterUtils.getExpression(String.format(
-            "lookup('dimTableWithLongPK', 'lookupColumn', 'primaryColumn', %s)", LONG_SV_COLUMN));
-        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-        expectedResults = new String[NUM_ROWS];
-        for (int i=0; i<NUM_ROWS; i++) {
-            expectedResults[i] = String.format("lookup_value_for_[%s]", _longSVValues[i]);
-        }
-        testTransformFunction(transformFunction, expectedResults);
-    }
+    testTransformFunction(transformFunction, expectedResults);
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -1,0 +1,345 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
+import org.apache.pinot.core.query.exception.BadQueryRequestException;
+import org.apache.pinot.core.query.request.context.ExpressionContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
+    private static final String TABLE_NAME = "baseballTeams_OFFLINE";
+    private DimensionTableDataManager tableManager;
+
+    @BeforeSuite
+    public void setUp() throws Exception {
+        super.setUp();
+
+        createTestableTableManager();
+    }
+
+    private void createTestableTableManager() {
+        tableManager = mock(DimensionTableDataManager.class);
+        DimensionTableDataManager.registerDimensionTable(TABLE_NAME, tableManager);
+
+        // Creating a mock table which looks like:
+        // TeamID (PK, str) | TeamName(str) | TeamName_MV(str[]) | TeamInteger(int) | TeamInteger_MV(int[]) | TeamFloat(float) | ...
+        //
+        // All values are dynamically created to be variations of the primary key.
+        // e.g
+        // lookupRowByPrimaryKey(['FOO']) -> (TeamID: 'foo', TeamName: 'teamName_for_foo', TeamInteger: hashCode(['foo']), ...
+        //
+        when(tableManager.getColumnFieldSpec("teamID")).thenReturn(
+                new DimensionFieldSpec("teamID", FieldSpec.DataType.STRING, true));
+        when(tableManager.getColumnFieldSpec("teamName")).thenReturn(
+                new DimensionFieldSpec("teamName", FieldSpec.DataType.STRING, true));
+        when(tableManager.getColumnFieldSpec("teamName_MV")).thenReturn(
+                new DimensionFieldSpec("teamName_MV", FieldSpec.DataType.STRING, false));
+        when(tableManager.getColumnFieldSpec("teamInteger")).thenReturn(
+                new DimensionFieldSpec("teamInteger", FieldSpec.DataType.INT, true));
+        when(tableManager.getColumnFieldSpec("teamInteger_MV")).thenReturn(
+                new DimensionFieldSpec("teamInteger_MV", FieldSpec.DataType.INT, false));
+        when(tableManager.getColumnFieldSpec("teamFloat")).thenReturn(
+                new DimensionFieldSpec("teamFloat", FieldSpec.DataType.FLOAT, true));
+        when(tableManager.getColumnFieldSpec("teamFloat_MV")).thenReturn(
+                new DimensionFieldSpec("teamFloat_MV", FieldSpec.DataType.FLOAT, false));
+        when(tableManager.getColumnFieldSpec("teamDouble")).thenReturn(
+                new DimensionFieldSpec("teamDouble", FieldSpec.DataType.DOUBLE, true));
+        when(tableManager.getColumnFieldSpec("teamDouble_MV")).thenReturn(
+                new DimensionFieldSpec("teamDouble_MV", FieldSpec.DataType.DOUBLE, false));
+        when(tableManager.getColumnFieldSpec("teamLong")).thenReturn(
+                new DimensionFieldSpec("teamLong", FieldSpec.DataType.LONG, true));
+        when(tableManager.getColumnFieldSpec("teamLong_MV")).thenReturn(
+                new DimensionFieldSpec("teamLong_MV", FieldSpec.DataType.LONG, false));
+        when(tableManager.getColumnFieldSpec("teamBytes")).thenReturn(
+                new DimensionFieldSpec("teamNameBytes", FieldSpec.DataType.BYTES, true));
+        when(tableManager.lookupRowByPrimaryKey(any(PrimaryKey.class)))
+                .thenAnswer(invocation -> {
+                    PrimaryKey key = invocation.getArgument(0);
+                    GenericRow row = new GenericRow();
+                    row.putValue("teamName", "teamName_for_" + key.toString());
+                    row.putValue("teamName_MV", new String[]{
+                            "teamName_for_" + key.toString() + "_1",
+                            "teamName_for_" + key.toString() + "_2",
+                    });
+                    row.putValue("teamInteger", key.hashCode());
+                    row.putValue("teamInteger_MV", new int[]{key.hashCode(), key.hashCode()});
+                    row.putValue("teamFloat", (float)key.hashCode());
+                    row.putValue("teamFloat_MV", new float[]{(float)key.hashCode(),(float)key.hashCode()});
+                    row.putValue("teamDouble", (double)key.hashCode());
+                    row.putValue("teamDouble_MV", new double[]{(double)key.hashCode(), (double)key.hashCode()});
+                    row.putValue("teamLong", (long)key.hashCode());
+                    row.putValue("teamLong_MV", new long[]{(long)key.hashCode(),(long)key.hashCode()});
+                    row.putValue("teamBytes", ("teamBytes_for_" + key.toString()).getBytes());
+                    return row;
+                });
+    }
+
+    @Test
+    public void instantiationTests() throws Exception {
+        // Success case
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        Assert.assertTrue(transformFunction instanceof LookupTransformFunction);
+        Assert.assertEquals(transformFunction.getName(), LookupTransformFunction.FUNCTION_NAME);
+
+        // Wrong number of arguments
+        Assert.assertThrows(BadQueryRequestException.class, () -> {
+            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
+                    .format("lookup('baseballTeams','teamName','teamID')")), _dataSourceMap);
+        });
+
+        // Wrong number of join keys
+        Assert.assertThrows(BadQueryRequestException.class, () -> {
+            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
+                    .format("lookup('baseballTeams','teamName','teamID', %s, 'danglingKey')", STRING_SV_COLUMN)),
+                    _dataSourceMap);
+        });
+
+        // Non literal tableName argument
+        Assert.assertThrows(BadQueryRequestException.class, () -> {
+            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
+                            .format("lookup(%s,'teamName','teamID', %s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+                    _dataSourceMap);
+        });
+
+        // Non literal lookup columnName argument
+        Assert.assertThrows(BadQueryRequestException.class, () -> {
+            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
+                            .format("lookup('baseballTeams',%s,'teamID',%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+                    _dataSourceMap);
+        });
+
+        // Non literal lookup columnName argument
+        Assert.assertThrows(BadQueryRequestException.class, () -> {
+            TransformFunctionFactory.get(QueryContextConverterUtils.getExpression(String
+                            .format("lookup('baseballTeams','teamName',%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+                    _dataSourceMap);
+        });
+    }
+
+    @Test
+    public void resultDataTypeTest() throws Exception {
+        HashMap<String, FieldSpec.DataType> testCases = new HashMap<String, FieldSpec.DataType>(){{
+            put("teamName", FieldSpec.DataType.STRING);
+            put("teamInteger", FieldSpec.DataType.INT);
+            put("teamFloat", FieldSpec.DataType.FLOAT);
+            put("teamLong", FieldSpec.DataType.LONG);
+            put("teamDouble", FieldSpec.DataType.DOUBLE);
+        }};
+
+        for (Map.Entry<String, FieldSpec.DataType> testCase : testCases.entrySet()) {
+            ExpressionContext expression = QueryContextConverterUtils.getExpression(String
+                    .format("lookup('baseballTeams','%s','teamID',%s)", testCase.getKey(), STRING_SV_COLUMN));
+            TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+            Assert.assertEquals(
+                    transformFunction.getResultMetadata().getDataType(),
+                    testCase.getValue(),
+                    String.format("Expecting %s data type for lookup column: '%s'",
+                            testCase.getKey(), testCase.getValue()));
+        }
+    }
+
+    @Test
+    public void basicLookupTests() throws Exception {
+        // Lookup col: StringSV
+        // PK: [String]
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        String[] expectedStringValues = new String[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedStringValues[i] = String.format("teamName_for_[%s]", _stringSVValues[i]);
+        }
+        testTransformFunction(transformFunction, expectedStringValues);
+
+        // Lookup col: IntSV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamInteger','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        int[] expectedIntValues = new int[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedIntValues[i] = (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode();
+        }
+        testTransformFunction(transformFunction, expectedIntValues);
+
+        // Lookup col: DoubleSV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamDouble','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        double[] expectedDoubleValues = new double[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedDoubleValues[i] = (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode();
+        }
+        testTransformFunction(transformFunction, expectedDoubleValues);
+
+        // Lookup col: BytesSV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+            .format("lookup('baseballTeams','teamBytes','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        byte[][] expectedBytesValues = new byte[NUM_ROWS][];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedBytesValues[i] = String.format("teamBytes_for_[%s]", _stringSVValues[i]).getBytes();
+        }
+        testTransformFunction(transformFunction, expectedBytesValues);
+    }
+
+    @Test
+    public void multiValueLookupTests() throws Exception {
+        // Lookup col: StringMV
+        // PK: [String]
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamName_MV','teamID',%s)", STRING_SV_COLUMN));
+        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        String[][] expectedStringMVValues = new String[NUM_ROWS][];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedStringMVValues[i] = new String[]{
+                    String.format("teamName_for_[%s]_1", _stringSVValues[i]),
+                    String.format("teamName_for_[%s]_2", _stringSVValues[i]),
+            };
+        }
+        testTransformFunctionMV(transformFunction, expectedStringMVValues);
+
+        // Lookup col: IntegerMV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+                .format("lookup('baseballTeams','teamInteger_MV','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        int[][] expectedIntegerMVValues = new int[NUM_ROWS][0];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedIntegerMVValues[i] = new int[]{
+                    (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+                    (new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+            };
+        }
+        testTransformFunctionMV(transformFunction, expectedIntegerMVValues);
+
+        // Lookup col: FloatMV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+            .format("lookup('baseballTeams','teamFloat_MV','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        float[][] expectedFloatMVValues = new float[NUM_ROWS][0];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedFloatMVValues[i] = new float[]{
+                (float)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+                (float)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+            };
+        }
+        testTransformFunctionMV(transformFunction, expectedFloatMVValues);
+
+        // Lookup col: LongMV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+            .format("lookup('baseballTeams','teamLong_MV','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        long[][] expectedLongMVValues = new long[NUM_ROWS][0];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedLongMVValues[i] = new long[]{
+                (long)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+                (long)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+            };
+        }
+        testTransformFunctionMV(transformFunction, expectedLongMVValues);
+
+        // Lookup col: DoubleMV
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String
+            .format("lookup('baseballTeams','teamDouble_MV','teamID',%s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        double[][] expectedDoubleMVValues = new double[NUM_ROWS][0];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedDoubleMVValues[i] = new double[]{
+                (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+                (double)(new PrimaryKey(new Object[] {_stringSVValues[i]})).hashCode(),
+            };
+        }
+        testTransformFunctionMV(transformFunction, expectedDoubleMVValues);
+    }
+
+    @Test
+    public void primaryKeyTypeTest() throws Exception {
+        // preparing simple tables for testing different primary key types (INT, STRING, LONG)
+        Map<String, FieldSpec.DataType> testTables = new HashMap<String, FieldSpec.DataType>(){{
+            put("dimTableWithIntPK_OFFLINE", FieldSpec.DataType.INT);
+            put("dimTableWithStringPK_OFFLINE", FieldSpec.DataType.STRING);
+            put("dimTableWithLongPK_OFFLINE", FieldSpec.DataType.LONG);
+        }};
+        for (Map.Entry<String, FieldSpec.DataType> table: testTables.entrySet()) {
+            DimensionTableDataManager mgr = mock(DimensionTableDataManager.class);
+            DimensionTableDataManager.registerDimensionTable(table.getKey(), mgr);
+            when(mgr.getColumnFieldSpec("primaryColumn")).thenReturn(
+                new DimensionFieldSpec("primaryColumn", table.getValue(), true));
+            when(mgr.getColumnFieldSpec("lookupColumn")).thenReturn(
+                new DimensionFieldSpec("lookupColumn", FieldSpec.DataType.STRING, true));
+            when(mgr.lookupRowByPrimaryKey(any(PrimaryKey.class)))
+                .thenAnswer(invocation -> {
+                    PrimaryKey key = invocation.getArgument(0);
+                    GenericRow row = new GenericRow();
+                    row.putValue("lookupColumn", "lookup_value_for_" + key.toString());
+                    return row;
+                });
+        }
+
+        // PK: [Int]
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(String.format(
+            "lookup('dimTableWithIntPK', 'lookupColumn', 'primaryColumn', %s)", INT_SV_COLUMN));
+        TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        String[] expectedResults = new String[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedResults[i] = String.format("lookup_value_for_[%s]", _intSVValues[i]);
+        }
+        testTransformFunction(transformFunction, expectedResults);
+
+        // PK: [String]
+        expression = QueryContextConverterUtils.getExpression(String.format(
+            "lookup('dimTableWithStringPK', 'lookupColumn', 'primaryColumn', %s)", STRING_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        expectedResults = new String[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedResults[i] = String.format("lookup_value_for_[%s]", _stringSVValues[i]);
+        }
+        testTransformFunction(transformFunction, expectedResults);
+
+        // PK: [Long]
+        expression = QueryContextConverterUtils.getExpression(String.format(
+            "lookup('dimTableWithLongPK', 'lookupColumn', 'primaryColumn', %s)", LONG_SV_COLUMN));
+        transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+        expectedResults = new String[NUM_ROWS];
+        for (int i=0; i<NUM_ROWS; i++) {
+            expectedResults[i] = String.format("lookup_value_for_[%s]", _longSVValues[i]);
+        }
+        testTransformFunction(transformFunction, expectedResults);
+    }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import java.util.Arrays;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
@@ -59,6 +60,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // e.g
     // lookupRowByPrimaryKey(['FOO']) -> (TeamID: 'foo', TeamName: 'teamName_for_foo', TeamInteger: hashCode(['foo']), ...
     //
+    when(tableManager.getPrimaryKeyColumns()).thenReturn(Arrays.asList("teamID"));
     when(tableManager.getColumnFieldSpec("teamID"))
         .thenReturn(new DimensionFieldSpec("teamID", FieldSpec.DataType.STRING, true));
     when(tableManager.getColumnFieldSpec("teamName"))
@@ -300,6 +302,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     for (Map.Entry<String, FieldSpec.DataType> table : testTables.entrySet()) {
       DimensionTableDataManager mgr = mock(DimensionTableDataManager.class);
       DimensionTableDataManager.registerDimensionTable(table.getKey(), mgr);
+      when(mgr.getPrimaryKeyColumns()).thenReturn(Arrays.asList("primaryColumn"));
       when(mgr.getColumnFieldSpec("primaryColumn"))
           .thenReturn(new DimensionFieldSpec("primaryColumn", table.getValue(), true));
       when(mgr.getColumnFieldSpec("lookupColumn"))

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.util.Arrays;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.pinot.common.utils.PrimitiveArrayUtils;
 import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
 import org.apache.pinot.core.query.exception.BadQueryRequestException;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
@@ -28,6 +29,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -310,12 +312,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
       when(mgr.lookupRowByPrimaryKey(any(PrimaryKey.class))).thenAnswer(invocation -> {
         PrimaryKey key = invocation.getArgument(0);
         GenericRow row = new GenericRow();
-        if (table.getValue() == FieldSpec.DataType.BYTES) {
-          byte[] keyContent = ArrayUtils.toPrimitive((Byte[])(key.getValues()[0])); // assuming one col
-          row.putValue("lookupColumn", String.format("lookup_value_for_[%s]", new String(keyContent) ));
-        } else {
-          row.putValue("lookupColumn", "lookup_value_for_" + key.toString());
-        }
+        row.putValue("lookupColumn", String.format("lookup_value_for_[%s]", key.hashCode()));
         return row;
       });
     }
@@ -326,7 +323,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     String[] expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", _intSVValues[i]);
+      PrimaryKey key = new PrimaryKey(new Object[]{(Integer)_intSVValues[i]});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
 
@@ -336,7 +334,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", _stringSVValues[i]);
+      PrimaryKey key = new PrimaryKey(new Object[]{_stringSVValues[i]});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
 
@@ -346,7 +345,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", _longSVValues[i]);
+      PrimaryKey key = new PrimaryKey(new Object[]{(Long)_longSVValues[i]});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
 
@@ -356,7 +356,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", _floatSVValues[i]);
+      PrimaryKey key = new PrimaryKey(new Object[]{(Float)_floatSVValues[i]});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
 
@@ -366,7 +367,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", _doubleSVValues[i]);
+      PrimaryKey key = new PrimaryKey(new Object[]{(Double)_doubleSVValues[i]});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
 
@@ -376,7 +378,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedResults[i] = String.format("lookup_value_for_[%s]", new String(_bytesSVValues[i]));
+      PrimaryKey key = new PrimaryKey(new Object[]{new ByteArray(_bytesSVValues[i])});
+      expectedResults[i] = String.format("lookup_value_for_[%s]", key.hashCode());
     }
     testTransformFunction(transformFunction, expectedResults);
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
@@ -118,6 +118,13 @@ public class JoinQuickStart
         printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q2)));
         printStatus(Quickstart.Color.GREEN, "***************************************************");
 
+        String q3 = "select playerName, teamID, lookup('dimBaseballTeams', 'teamName', 'teamID', teamID) from baseballStats limit 10";
+        printStatus(Quickstart.Color.YELLOW, "Baseball Stats with joined team names");
+        printStatus(Quickstart.Color.CYAN, "Query : " + q3);
+        printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q3)));
+        printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+
         printStatus(Quickstart.Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
 
     }


### PR DESCRIPTION
## Description

Introducing a new transform function; `LookupTransformFunction` as a part of Join project as described in [Lookup UDF Join In Pinot](https://docs.google.com/document/d/1InWmxbRqwcqIakzvoEWHLxtX4XR9H5L01256EbAUHV8/edit). This is a followup to the addition of `DimensionTableManager` in #6346. 

**LOOKUP** is a regular transform function which uses the previously added DimensionTableDataManager to execute a lookup from a Dimension table. Call signature is as follows:

```
LOOKUP(TableName, ColumnName, JoinKey, JoinValue [, JoinKey2, JoinValue2 ...])
```

**TableName:** name of the dimension table which will be used
**ColumnName:** column name from the dimension table to look up
**JoinKey:** primary key column name for the dimension table. Note: Only primary key is supported for JoinKey
**JoinValue:** primary key value
*If the dimension table has more then one primary keys (composite PK), you can add more keys and values for the rest of the args: **JoinKey2**, **JoinValue2** ... etc.


 **Example Query:**
```sql
SELECT
    baseballStats.playerName,
    baseballStats.teamID,
    LOOKUP('dimBaseballTeams', 'teamName', 'teamID', baseballStats.teamID)
FROM
    baseballStats
LIMIT 10
``` 
Above example joins the dimension table 'baseballTeams' into regular table 'baseballStats' on 'teamID' key. Lookup function returns the value of the column 'teamName'.

To see the function in action you can also fire `JoinQuickstart` and test it as follows:
<img width="2553" alt="Screen Shot 2020-12-23 at 8 04 46 PM" src="https://user-images.githubusercontent.com/212284/103111451-f38dcc00-4601-11eb-8dab-beada1346a5f.png">

## Testing 

- Unit tests are included to cover basic functionality and I also added a sample usage (table creation + query) in `JoinQuickstart`. 
- End to end functionality is also tested in a previous POC pull request [here](https://github.com/cbalci/incubator-pinot/pull/1).

## Documentation

- Comprehensive documentation explaining the usage of 'Dimension' tables is being worked on and will be added to the https://github.com/pinot-contrib/pinot-docs repository in a separate PR.
- LookupTransformFuncion usage and a sample query is added as a JavaDoc .