### PR TITLE
cleanup tar.gz segment files on job exit

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -77,7 +77,8 @@ public class SegmentPushUtils implements Serializable {
         return new URI(scheme, fileURI.getUserInfo(), host, port, fileURI.getPath(), fileURI.getQuery(),
             fileURI.getFragment());
       } catch (URISyntaxException e) {
-        LOGGER.warn("Unable to generate push uri based from dir URI: {} and file URI: {}, directly return file URI.", dirURI, fileURI);
+        LOGGER.warn("Unable to generate push uri based from dir URI: {} and file URI: {}, directly return file URI.",
+            dirURI, fileURI);
         return fileURI;
       }
     }
@@ -134,6 +135,8 @@ public class SegmentPushUtils implements Serializable {
                       segmentName, controllerURI, e);
               throw e;
             }
+          } finally {
+            FileUtils.deleteQuietly(tarFile);
           }
         });
       }
@@ -147,6 +150,7 @@ public class SegmentPushUtils implements Serializable {
         Arrays.toString(segmentUris.subList(0, Math.min(5, segmentUris.size())).toArray()),
         Arrays.toString(spec.getPinotClusterSpecs()));
     for (String segmentUri : segmentUris) {
+      File segmentPath = new File(URI.create(segmentUri).getRawPath());
       for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
         URI controllerURI;
         try {
@@ -183,6 +187,8 @@ public class SegmentPushUtils implements Serializable {
                   tableName, segmentUri, controllerURI, e);
               throw e;
             }
+          } finally {
+            FileUtils.deleteQuietly(segmentPath);
           }
         });
       }
@@ -202,11 +208,11 @@ public class SegmentPushUtils implements Serializable {
    * @param segmentUriToTarPathMap contains the map of segment DownloadURI to segment tar file path
    * @throws Exception
    */
-  public static void sendSegmentUriAndMetadata(SegmentGenerationJobSpec spec, PinotFS fileSystem, Map<String, String> segmentUriToTarPathMap)
+  public static void sendSegmentUriAndMetadata(SegmentGenerationJobSpec spec, PinotFS fileSystem,
+      Map<String, String> segmentUriToTarPathMap)
       throws Exception {
     String tableName = spec.getTableSpec().getTableName();
-    LOGGER.info("Start pushing segment metadata: {} to locations: {} for table {}",
-        segmentUriToTarPathMap,
+    LOGGER.info("Start pushing segment metadata: {} to locations: {} for table {}", segmentUriToTarPathMap,
         Arrays.toString(spec.getPinotClusterSpecs()), tableName);
     for (String segmentUriPath : segmentUriToTarPathMap.keySet()) {
       String tarFilePath = segmentUriToTarPathMap.get(segmentUriPath);
@@ -233,15 +239,17 @@ public class SegmentPushUtils implements Serializable {
           }
           RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
             try {
-              List<Header> headers = ImmutableList.of(
-                  new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath),
-                  new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE, FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+              List<Header> headers = ImmutableList
+                  .of(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath),
+                      new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
+                          FileUploadDownloadClient.FileUploadType.METADATA.toString()));
               // Add table name as a request parameter
               NameValuePair tableNameValuePair =
                   new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName);
               List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
-              SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.uploadSegmentMetadata(FileUploadDownloadClient.getUploadSegmentURI(controllerURI),
-                  segmentName, segmentMetadataFile, headers, parameters, FILE_UPLOAD_DOWNLOAD_CLIENT.DEFAULT_SOCKET_TIMEOUT_MS);
+              SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
+                  .uploadSegmentMetadata(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName,
+                      segmentMetadataFile, headers, parameters, FILE_UPLOAD_DOWNLOAD_CLIENT.DEFAULT_SOCKET_TIMEOUT_MS);
               LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
                   controllerURI, response.getStatusCode(), response.getResponse());
               return true;
@@ -268,12 +276,13 @@ public class SegmentPushUtils implements Serializable {
     }
   }
 
-  public static Map<String, String> getSegmentUriToTarPathMap(URI outputDirURI, String uriPrefix, String uriSuffix, String[] files) {
+  public static Map<String, String> getSegmentUriToTarPathMap(URI outputDirURI, String uriPrefix, String uriSuffix,
+      String[] files) {
     Map<String, String> segmentUriToTarPathMap = new HashMap<>();
     for (String file : files) {
       URI uri = URI.create(file);
       if (uri.getPath().endsWith(Constants.TAR_GZ_FILE_EXT)) {
-        URI updatedURI = SegmentPushUtils.generateSegmentTarURI(outputDirURI, uri, uriPrefix,uriSuffix);
+        URI updatedURI = SegmentPushUtils.generateSegmentTarURI(outputDirURI, uri, uriPrefix, uriSuffix);
         segmentUriToTarPathMap.put(updatedURI.toString(), file);
       }
     }
@@ -293,7 +302,8 @@ public class SegmentPushUtils implements Serializable {
   private static File generateSegmentMetadataFile(PinotFS fileSystem, URI tarFileURI)
       throws Exception {
     String uuid = UUID.randomUUID().toString();
-    File tarFile = new File(FileUtils.getTempDirectory(), "segmentTar-" + uuid + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    File tarFile =
+        new File(FileUtils.getTempDirectory(), "segmentTar-" + uuid + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
     File segmentMetadataDir = new File(FileUtils.getTempDirectory(), "segmentMetadataDir-" + uuid);
     try {
       fileSystem.copyToLocalFile(tarFileURI, tarFile);
@@ -312,7 +322,8 @@ public class SegmentPushUtils implements Serializable {
       TarGzCompressionUtils.untarOneFile(tarFile, V1Constants.SEGMENT_CREATION_META,
           new File(segmentMetadataDir, V1Constants.SEGMENT_CREATION_META));
 
-      File segmentMetadataTarFile = new File(FileUtils.getTempDirectory(), "segmentMetadata-" + uuid + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+      File segmentMetadataTarFile = new File(FileUtils.getTempDirectory(),
+          "segmentMetadata-" + uuid + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
       if (segmentMetadataTarFile.exists()) {
         FileUtils.forceDelete(segmentMetadataTarFile);
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -111,6 +111,11 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private PushJobSpec _pushJobSpec;
 
+  /**
+   * Should clean up output segment on job completion.
+   */
+  private boolean _cleanUpOutputDir;
+
   public ExecutionFrameworkSpec getExecutionFrameworkSpec() {
     return _executionFrameworkSpec;
   }
@@ -246,6 +251,14 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setSegmentCreationJobParallelism(int segmentCreationJobParallelism) {
     _segmentCreationJobParallelism = segmentCreationJobParallelism;
+  }
+
+  public void setCleanUpOutputDir(boolean cleanUpOutputDir) {
+    _cleanUpOutputDir = cleanUpOutputDir;
+  }
+
+  public boolean isCleanUpOutputDir() {
+    return _cleanUpOutputDir;
   }
 }
 


### PR DESCRIPTION
## Description
Remove tar.gz segment files from the output directory on job exit.

**Testing:**
Verified the segment deletion by running pinot locally for jobType `SegmentCreationAndTarPush` and `SegmentCreationAndUriPush`

Issue #6349 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
