### PR TITLE
Allow multiple H3 index resolutions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataSource.java
@@ -63,8 +63,7 @@ public interface DataSource {
   InvertedIndexReader<?> getRangeIndex();
 
   /**
-   * Returns the range index for the column if exists, or {@code null} if not.
-   * <p>TODO: Have a separate interface for range index.
+   * Returns the H3 index for the geospatial column if exists, or {@code null} if not.
    */
   @Nullable
   H3IndexReader getH3Index();

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -75,15 +75,28 @@ public class ScalarFunctions {
   }
 
   /**
-   * Saves the geometry object as WKT format.
+   * Converts a Geometry object to a spherical geography object.
    *
    * @param bytes the serialized geometry object
-   * @return the geometry in WKT
+   * @return the geographical object
    */
   @ScalarFunction
   public static byte[] toSphericalGeography(byte[] bytes) {
     Geometry geometry = GeometrySerializer.deserialize(bytes);
     GeometryUtils.setGeography(geometry);
+    return GeometrySerializer.serialize(geometry);
+  }
+
+  /**
+   * Converts a spherical geographical object to a Geometry object.
+   *
+   * @param bytes the serialized geographical object
+   * @return the geometry object
+   */
+  @ScalarFunction
+  public static byte[] toGeometry(byte[] bytes) {
+    Geometry geometry = GeometrySerializer.deserialize(bytes);
+    GeometryUtils.setGeometry(geometry);
     return GeometrySerializer.serialize(geometry);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexCreator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.creator.impl.geospatial;
 
+import com.google.common.collect.Lists;
 import com.uber.h3core.H3Core;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -59,28 +60,30 @@ public class H3IndexCreator implements GeoSpatialIndexCreator {
   private final H3Core _h3Core;
   private File _indexDir;
   private FieldSpec _fieldSpec;
-  private int _resolution;
+  private H3IndexResolution _resolution;
+  private int _lowestResolution;
 
   TreeMap<Long, MutableRoaringBitmap> _h3IndexMap;
 
   int numChunks = 0;
   List<Integer> chunkLengths = new ArrayList<>();
 
-  public H3IndexCreator(File indexDir, FieldSpec fieldSpec, int resolution)
+  public H3IndexCreator(File indexDir, FieldSpec fieldSpec, H3IndexResolution resolution)
       throws IOException {
 
     _indexDir = indexDir;
     _fieldSpec = fieldSpec;
     _resolution = resolution;
     _h3Core = H3Core.newInstance();
-    //todo: initialize this with right size based on the
-    long numHexagons = _h3Core.numHexagons(resolution);
+    _resolution = resolution;
+    _lowestResolution = resolution.getLowestResolution();
     _h3IndexMap = new TreeMap<>();
   }
 
   @Override
   public void add(int docId, double lat, double lon) {
-    Long h3Id = _h3Core.geoToH3(lat, lon, _resolution);
+    // TODO support multiple resolutions
+    Long h3Id = _h3Core.geoToH3(lat, lon, _lowestResolution);
     MutableRoaringBitmap roaringBitmap = _h3IndexMap.get(h3Id);
     if (roaringBitmap == null) {
       roaringBitmap = new MutableRoaringBitmap();
@@ -172,6 +175,7 @@ public class H3IndexCreator implements GeoSpatialIndexCreator {
     //write header file
     headerStream.writeInt(VERSION);
     headerStream.writeInt(writer.getNumUniqueIds());
+    headerStream.writeShort(_resolution.size());
     headerStream.close();
     dictionaryStream.close();
     offsetStream.close();
@@ -299,13 +303,13 @@ public class H3IndexCreator implements GeoSpatialIndexCreator {
     Point point2 = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(37.368832, -122.036346));
     System.out.println("point1.distance(point2) = " + point1.distance(point2));
     System.out.println("sphericalDistance = " + StDistanceFunction.sphericalDistance(point1, point2));
-    System.exit(0);
+//    System.exit(0);
     File indexDir = new File(System.getProperty("java.io.tmpdir"), "h3IndexDir");
     FileUtils.deleteDirectory(indexDir);
     indexDir.mkdirs();
     FieldSpec spec = new DimensionFieldSpec("geo_col", FieldSpec.DataType.STRING, true);
     int resolution = 5;
-    H3IndexCreator creator = new H3IndexCreator(indexDir, spec, resolution);
+    H3IndexCreator creator = new H3IndexCreator(indexDir, spec, new H3IndexResolution(Lists.newArrayList(resolution)));
     Random rand = new Random();
     H3Core h3Core = H3Core.newInstance();
     Map<Long, Integer> map = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexCreator.java
@@ -175,7 +175,7 @@ public class H3IndexCreator implements GeoSpatialIndexCreator {
     //write header file
     headerStream.writeInt(VERSION);
     headerStream.writeInt(writer.getNumUniqueIds());
-    headerStream.writeShort(_resolution.size());
+    headerStream.writeShort(_resolution.serialize());
     headerStream.close();
     dictionaryStream.close();
     offsetStream.close();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexResolution.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexResolution.java
@@ -1,0 +1,53 @@
+package org.apache.pinot.core.segment.creator.impl.geospatial;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Stores the resolutions for an index. There are in total of H3 resolutions https://h3geo.org/#/documentation/core-library/resolution-table
+ * To efficiently serialize the resolutions, we use two bytes for encoding th enabled resolutions. The resolution level
+ * maps to the corresponding bit.
+ */
+public class H3IndexResolution {
+  private short _resolutions;
+
+  public H3IndexResolution(List<Integer> resolutions) {
+    for (int resolution : resolutions) {
+      _resolutions |= 1 << resolution;
+    }
+  }
+
+  /**
+   * Creates the resolutions with the serialized short value
+   * @param resolutions
+   */
+  public H3IndexResolution(short resolutions) {
+    _resolutions = resolutions;
+  }
+
+  /**
+   * @return the encoding of the resolutions into a short value (two bytes)
+   */
+  public short serialize() {
+    return _resolutions;
+  }
+
+  public int size() {
+    return Integer.bitCount(_resolutions);
+  }
+
+  public List<Integer> getResolutions() {
+    List<Integer> res = new ArrayList<>();
+    for (int i = 0; i < 15; i++) {
+      if ((_resolutions & (1 << i)) != 0) {
+        res.add(i);
+      }
+    }
+    return res;
+  }
+
+  public int getLowestResolution() {
+    return Integer.numberOfTrailingZeros(_resolutions);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/H3IndexHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/invertedindex/H3IndexHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.index.loader.invertedindex;
 
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
@@ -27,6 +28,7 @@ import org.apache.pinot.core.geospatial.serde.GeometrySerializer;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
 import org.apache.pinot.core.segment.creator.impl.geospatial.H3IndexCreator;
+import org.apache.pinot.core.segment.creator.impl.geospatial.H3IndexResolution;
 import org.apache.pinot.core.segment.creator.impl.inv.RangeIndexCreator;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.core.segment.index.loader.LoaderUtils;
@@ -153,9 +155,11 @@ public class H3IndexHandler {
   private void handleNonDictionaryBasedColumn(ColumnMetadata columnMetadata)
       throws Exception {
     int numDocs = columnMetadata.getTotalDocs();
+    // TODO set the resolution
     try (ForwardIndexReader forwardIndexReader = getForwardIndexReader(columnMetadata, _segmentWriter);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext();
-        H3IndexCreator h3IndexCreator = new H3IndexCreator(_indexDir, columnMetadata.getFieldSpec(), 5)) {
+        H3IndexCreator h3IndexCreator = new H3IndexCreator(_indexDir, columnMetadata.getFieldSpec(), new H3IndexResolution(
+            Lists.newArrayList(5)))) {
       if (columnMetadata.isSingleValue()) {
         // Single-value column.
         switch (columnMetadata.getDataType()) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexResolutionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/creator/impl/geospatial/H3IndexResolutionTest.java
@@ -1,0 +1,17 @@
+package org.apache.pinot.core.segment.creator.impl.geospatial;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+
+public class H3IndexResolutionTest {
+
+  @Test
+  public void testH3IndexResolution() {
+    H3IndexResolution resolution = new H3IndexResolution(Lists.newArrayList(13, 5, 6));
+    Assert.assertEquals(resolution.size(), 3);
+    Assert.assertEquals(resolution.getLowestResolution(), 5);
+    Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
@@ -129,8 +129,7 @@ public class GenericQuickstart {
 
   public static void main(String[] args)
       throws Exception {
-    String tableDirectoryPath =
-        "/Users/yupeng/gocode/src/code.uber.internal/data/incubator-pinot/pinot-tools/src/main/resources/examples/batch/starbucksStores";
+    String tableDirectoryPath ="";
 //    CSVRecordReader reader = new CSVRecordReader();
 //    reader.init(new File(tableDirectoryPath, "rawdata/data.csv"), Sets.newHashSet("lat", "long", "name", "address"), null);
 //    while (reader.hasNext()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
@@ -130,7 +130,7 @@ public class GenericQuickstart {
   public static void main(String[] args)
       throws Exception {
     String tableDirectoryPath =
-        "/Users/kishoreg/projects/incubator-pinot/pinot-tools/src/main/resources/examples/batch/starbucksStores";
+        "/Users/yupeng/gocode/src/code.uber.internal/data/incubator-pinot/pinot-tools/src/main/resources/examples/batch/starbucksStores";
 //    CSVRecordReader reader = new CSVRecordReader();
 //    reader.init(new File(tableDirectoryPath, "rawdata/data.csv"), Sets.newHashSet("lat", "long", "name", "address"), null);
 //    while (reader.hasNext()) {


### PR DESCRIPTION
Encode the index resolutions (which can be multiple) in two bytes, and save them in the index header. This allows multiple H3 index resolution creation in the index.
