### PR TITLE
Fix remaining links to outdated helm chart repos.

### DIFF
--- a/kubernetes/helm/index.yaml
+++ b/kubernetes/helm/index.yaml
@@ -7,7 +7,7 @@ entries:
     dependencies:
     - condition: pinot.zookeeper.enabled,zookeeper.enabled
       name: zookeeper
-      repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+      repository: https://charts.helm.sh/incubator
       version: 2.1.3
     description: Apache Pinot is a realtime distributed OLAP datastore, which is used
       to deliver scalable real time analytics with low latency. It can ingest data
@@ -35,7 +35,7 @@ entries:
     dependencies:
     - condition: pinot.zookeeper.enabled,zookeeper.enabled
       name: zookeeper
-      repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+      repository: https://charts.helm.sh/incubator
       version: 2.1.3
     description: Apache Pinot is a realtime distributed OLAP datastore, which is used
       to deliver scalable real time analytics with low latency. It can ingest data
@@ -63,7 +63,7 @@ entries:
     dependencies:
     - condition: pinot.zookeeper.enabled,zookeeper.enabled
       name: zookeeper
-      repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+      repository: https://charts.helm.sh/incubator
       version: 2.1.3
     description: Apache Pinot is a realtime distributed OLAP datastore, which is used
       to deliver scalable real time analytics with low latency. It can ingest data

--- a/kubernetes/helm/pinot/README.md
+++ b/kubernetes/helm/pinot/README.md
@@ -251,14 +251,14 @@ kubectl get all -n pinot-quickstart
 - For helm v3.0.0
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install -n pinot-quickstart kafka incubator/kafka --set replicas=1
 ```
 
 - For helm v2.12.1
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install --namespace "pinot-quickstart"  --name kafka incubator/kafka --set replicas=1
 ```
 

--- a/kubernetes/helm/pinot/requirements.lock
+++ b/kubernetes/helm/pinot/requirements.lock
@@ -19,7 +19,7 @@
 
 dependencies:
 - name: zookeeper
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repository: https://charts.helm.sh/incubator
   version: 2.1.3
 digest: sha256:12b613c8bde62ba0ff10e39e86c0645829a795c7345904a5de4257f9c5136676
 generated: "2020-04-18T19:26:51.965519+05:30"

--- a/kubernetes/helm/pinot/requirements.yaml
+++ b/kubernetes/helm/pinot/requirements.yaml
@@ -20,5 +20,5 @@
 dependencies:
   - name: zookeeper
     version: 2.1.3
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    repository: https://charts.helm.sh/incubator
     condition: pinot.zookeeper.enabled,zookeeper.enabled

--- a/kubernetes/helm/thirdeye/Chart.lock
+++ b/kubernetes/helm/thirdeye/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 1.6.6
-digest: sha256:6fa8d7b01e421ec3ca2ee257a4aedf58cb3a0e24b7683de7f9299b75bcb25825
-generated: "2020-09-01T11:59:46.921901-07:00"
+digest: sha256:eeb4902062cbccaddabfd3c4ad716b67a42ca42ba134efc807facc60fddb7efe
+generated: "2020-12-29T13:42:21.873195-07:00"

--- a/kubernetes/helm/thirdeye/Chart.yaml
+++ b/kubernetes/helm/thirdeye/Chart.yaml
@@ -20,5 +20,4 @@ maintainers:
 dependencies:
 - name: mysql
   version: 1.6.6
-  repository: https://kubernetes-charts.storage.googleapis.com/
-
+  repository: https://charts.helm.sh/stable

--- a/website/docs/administration/installation/cloud/on-premise.md
+++ b/website/docs/administration/installation/cloud/on-premise.md
@@ -87,14 +87,14 @@ kubectl get all -n pinot-quickstart
 - For helm v2.12.1
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install --namespace "pinot-quickstart"  --name kafka incubator/kafka
 ```
 
 - For helm v3.0.0
 
 ```bash
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm repo add incubator https://charts.helm.sh/incubator
 helm install -n pinot-quickstart kafka incubator/kafka --set replicas=1
 ```
 


### PR DESCRIPTION
## Description
Related to #6381. I grepped through and fixed the rest of the repo to reference the new helm repo locations to match the locations in this [announcement](https://helm.sh/blog/new-location-stable-incubator-charts/).

