### PR TITLE
[TE] limit reflection scanning range

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -59,7 +59,7 @@
     <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
     <commons-conf2.version>2.7</commons-conf2.version>
     <commons-collection4.version>4.1</commons-collection4.version>
-    <classgraph.version>4.8.84</classgraph.version>
+    <classgraph.version>4.8.90</classgraph.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>

--- a/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-dashboard/src/main/java/org/apache/pinot/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -52,6 +52,8 @@ import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseSessionResource;
 import org.apache.pinot.thirdeye.dashboard.resources.v2.RootCauseTemplateResource;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
 import org.apache.pinot.thirdeye.model.download.ModelDownloaderManager;
 import org.apache.pinot.thirdeye.tracking.RequestStatisticsLogger;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
@@ -103,14 +105,16 @@ public class ThirdEyeDashboardApplication
       corsFilter.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
     }
 
+    if (config.getComponentPackageList() != null) {
+      DetectionRegistry.setPackageList(config.getComponentPackageList());
+      DetectionAlertRegistry.setPackageList(config.getComponentPackageList());
+    }
     super.initDAOs();
-
     try {
       ThirdEyeCacheRegistry.initializeCaches(config);
     } catch (Exception e) {
       LOG.error("Exception while loading caches", e);
     }
-
 
     final JerseyEnvironment jersey = env.jersey();
     injector = Guice.createInjector(new ThirdEyeDashboardModule(config, env, DAO_REGISTRY));

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -37,6 +37,8 @@ import org.apache.pinot.thirdeye.datalayer.dto.SessionDTO;
 import org.apache.pinot.thirdeye.datasource.DAORegistry;
 import org.apache.pinot.thirdeye.datasource.ThirdEyeCacheRegistry;
 import org.apache.pinot.thirdeye.datasource.pinot.resources.PinotDataSourceResource;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionAlertRegistry;
+import org.apache.pinot.thirdeye.detection.annotation.registry.DetectionRegistry;
 import org.apache.pinot.thirdeye.model.download.ModelDownloaderManager;
 import org.apache.pinot.thirdeye.scheduler.DetectionCronScheduler;
 import org.apache.pinot.thirdeye.scheduler.SubscriptionCronScheduler;
@@ -100,9 +102,14 @@ public class ThirdEyeAnomalyApplication
   public void run(final ThirdEyeAnomalyConfiguration config, final Environment env)
       throws Exception {
     LOG.info("Starting ThirdeyeAnomalyApplication : Scheduler {} Worker {}", config.isScheduler(), config.isWorker());
+    if (config.getComponentPackageList() != null) {
+      DetectionRegistry.setPackageList(config.getComponentPackageList());
+      DetectionAlertRegistry.setPackageList(config.getComponentPackageList());
+    }
     super.initDAOs();
     try {
       ThirdEyeCacheRegistry.initializeCaches(config);
+
     } catch (Exception e) {
       LOG.error("Exception while loading caches", e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/ThirdEyeConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/common/ThirdEyeConfiguration.java
@@ -57,6 +57,11 @@ public class ThirdEyeConfiguration extends Configuration {
   private boolean cors = false;
 
   /**
+   * Package names where component classes are stored
+   */
+  private List<String> componentPackageList;
+
+  /**
    * Convert relative path to absolute URL
    *
    * Supported cases:
@@ -175,5 +180,13 @@ public class ThirdEyeConfiguration extends Configuration {
 
   public void setModelDownloaderConfig(List<ModelDownloaderConfiguration> modelDownloaderConfig) {
     this.modelDownloaderConfig = modelDownloaderConfig;
+  }
+
+  public List<String> getComponentPackageList() {
+    return componentPackageList;
+  }
+
+  public void setComponentPackageList(List<String> componentPackageList) {
+    this.componentPackageList = componentPackageList;
   }
 }


### PR DESCRIPTION
This PR is to limit scanning range of reflection for component classes, so that the memory footprint of JVM is reduced. 