### PR TITLE
data gen - use unique output file names in csv mode

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
@@ -110,7 +110,7 @@ public class DataGenerator {
       throws IOException {
     final int numPerFiles = (int) (totalDocs / numFiles);
     for (int i = 0; i < numFiles; i++) {
-      try (FileWriter writer = new FileWriter(outDir + "/output.csv")) {
+      try (FileWriter writer = new FileWriter(String.format("%s/output_%d.csv", outDir, i))) {
         writer.append(StringUtils.join(genSpec.getColumns(), ",")).append('\n');
         for (int j = 0; j < numPerFiles; j++) {
           Object[] values = new Object[genSpec.getColumns().size()];

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
@@ -110,7 +110,7 @@ public class DataGenerator {
       throws IOException {
     final int numPerFiles = (int) (totalDocs / numFiles);
     for (int i = 0; i < numFiles; i++) {
-      try (FileWriter writer = new FileWriter(String.format("%s/output_%d.csv", outDir, i))) {
+      try (FileWriter writer = new FileWriter(new File(outDir, String.format("output_%d.csv", i)))) {
         writer.append(StringUtils.join(genSpec.getColumns(), ",")).append('\n');
         for (int j = 0; j < numPerFiles; j++) {
           Object[] values = new Object[genSpec.getColumns().size()];


### PR DESCRIPTION
## Description
Use the file index when generating csv output from the data generator. This fixes an issue where output files are overridden repeatedly.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
