### PR TITLE
Pinot broker https discussion

### DIFF
--- a/create-certs.sh
+++ b/create-certs.sh
@@ -18,7 +18,7 @@
 #
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DOMAIN="192.168.64.82.xip.io"
+DOMAIN="localhost"
 
 KEY_DIR="$DIR/truststore"
 
@@ -32,10 +32,10 @@ openssl req -x509 -newkey rsa:4096 -days 365 -nodes -keyout "$KEY_DIR/ca-key.pem
 #openssl x509 -in "$KEY_DIR/ca-cert.pem" -noout -text
 
 echo "2. Generate web server's private key and certificate signing request (CSR)"
-openssl req -newkey rsa:4096 -nodes -keyout "$KEY_DIR/key.pem" -out "$KEY_DIR/req.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=*.$DOMAIN/emailAddress=admin@example.com"
+openssl req -newkey rsa:4096 -nodes -keyout "$KEY_DIR/key.pem" -out "$KEY_DIR/req.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=$DOMAIN/emailAddress=admin@example.com"
 
 echo "3. Use CA's private key to sign web server's CSR and get back the signed certificate"
-echo "subjectAltName=DNS:*.$DOMAIN,IP:0.0.0.0" > "$KEY_DIR/ext.cnf"
+echo "subjectAltName=DNS:$DOMAIN,IP:0.0.0.0" > "$KEY_DIR/ext.cnf"
 openssl x509 -req -in "$KEY_DIR/req.pem" -days 60 -CA "$KEY_DIR/ca-cert.pem" -CAkey "$KEY_DIR/ca-key.pem" -CAcreateserial -out "$KEY_DIR/cert.pem" -extfile "$KEY_DIR/ext.cnf"
 
 #echo "Server's signed certificate"

--- a/create-certs.sh
+++ b/create-certs.sh
@@ -19,6 +19,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DOMAIN="localhost"
+IP="192.168.0.126"
 
 KEY_DIR="$DIR/truststore"
 
@@ -32,10 +33,10 @@ openssl req -x509 -newkey rsa:4096 -days 365 -nodes -keyout "$KEY_DIR/ca-key.pem
 #openssl x509 -in "$KEY_DIR/ca-cert.pem" -noout -text
 
 echo "2. Generate web server's private key and certificate signing request (CSR)"
-openssl req -newkey rsa:4096 -nodes -keyout "$KEY_DIR/key.pem" -out "$KEY_DIR/req.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=$DOMAIN/emailAddress=admin@example.com"
+openssl req -newkey rsa:4096 -nodes -keyout "$KEY_DIR/key.pem" -out "$KEY_DIR/req.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=$DOMAIN/emailAddress=admin@localhost"
 
 echo "3. Use CA's private key to sign web server's CSR and get back the signed certificate"
-echo "subjectAltName=DNS:$DOMAIN,IP:0.0.0.0" > "$KEY_DIR/ext.cnf"
+echo "subjectAltName=DNS:$DOMAIN,IP:$IP" > "$KEY_DIR/ext.cnf"
 openssl x509 -req -in "$KEY_DIR/req.pem" -days 60 -CA "$KEY_DIR/ca-cert.pem" -CAkey "$KEY_DIR/ca-key.pem" -CAcreateserial -out "$KEY_DIR/cert.pem" -extfile "$KEY_DIR/ext.cnf"
 
 #echo "Server's signed certificate"

--- a/create-certs.sh
+++ b/create-certs.sh
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DOMAIN="192.168.64.82.xip.io"
+
+KEY_DIR="$DIR/truststore"
+
+mkdir -p $KEY_DIR
+rm $KEY_DIR/*.pem
+
+echo "1. Generate CA's private key and self-signed certificate"
+openssl req -x509 -newkey rsa:4096 -days 365 -nodes -keyout "$KEY_DIR/ca-key.pem" -out "$KEY_DIR/ca-cert.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=*.example.org/emailAddress=admin@example.org"
+
+#echo "CA's self-signed certificate"
+#openssl x509 -in "$KEY_DIR/ca-cert.pem" -noout -text
+
+echo "2. Generate web server's private key and certificate signing request (CSR)"
+openssl req -newkey rsa:4096 -nodes -keyout "$KEY_DIR/key.pem" -out "$KEY_DIR/req.pem" -subj "/C=US/ST=Someplace/L=Somewhere/O=Apache Pinot/OU=Education/CN=*.$DOMAIN/emailAddress=admin@example.com"
+
+echo "3. Use CA's private key to sign web server's CSR and get back the signed certificate"
+echo "subjectAltName=DNS:*.$DOMAIN,IP:0.0.0.0" > "$KEY_DIR/ext.cnf"
+openssl x509 -req -in "$KEY_DIR/req.pem" -days 60 -CA "$KEY_DIR/ca-cert.pem" -CAkey "$KEY_DIR/ca-key.pem" -CAcreateserial -out "$KEY_DIR/cert.pem" -extfile "$KEY_DIR/ext.cnf"
+
+#echo "Server's signed certificate"
+#openssl x509 -in "$KEY_DIR/cert.pem" -noout -text
+
+echo "Verifying certificate"
+openssl verify -CAfile "$KEY_DIR/ca-cert.pem" "$KEY_DIR/cert.pem"
+

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -38,20 +38,12 @@ import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 
+import static org.apache.pinot.common.utils.CommonConstants.Broker.*;
+import static org.apache.pinot.common.utils.CommonConstants.HTTPS_PROTOCOL;
+
 
 public class BrokerAdminApiApplication extends ResourceConfig {
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
-
-  // TODO find a permanent home for broker configuration keys
-  private static final String PINOT_BROKER_CLIENT_PROTOCOL = "pinot.broker.client.protocol";
-  private static final String PINOT_BROKER_CLIENT_TLS_KEYSTORE_PATH = "pinot.broker.client.tls.keystore.path";
-  private static final String PINOT_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD = "pinot.broker.client.tls.keystore.password";
-  private static final String PINOT_BROKER_CLIENT_TLS_TRUSTSTORE_PATH = "pinot.broker.client.tls.truststore.path";
-  private static final String PINOT_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD = "pinot.broker.client.tls.truststore.password";
-  private static final String PINOT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = "pinot.broker.client.tls.requires_client_auth";
-
-  private static final String PROTOCOL_HTTPS = "https";
-  private static final String PROTOCOL_HTTP = "http";
 
   private URI _baseUri;
   private HttpServer _httpServer;
@@ -73,19 +65,20 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   }
 
   public void start(PinotConfiguration brokerConf) {
-    int brokerQueryPort = brokerConf.getProperty(
-        CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+    int brokerQueryPort = brokerConf.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT,
+        CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+    String brokerQueryProtocol = brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_PROTOCOL,
+        DEFAULT_BROKER_CLIENT_PROTOCOL);
 
     Preconditions.checkArgument(brokerQueryPort > 0);
-    _baseUri = URI.create(String.format("%s://0.0.0.0:%d/",
-        brokerConf.getProperty(PINOT_BROKER_CLIENT_PROTOCOL, PROTOCOL_HTTP), brokerQueryPort));
+    _baseUri = URI.create(String.format("%s://0.0.0.0:%d/", brokerQueryProtocol, brokerQueryPort));
 
     _httpServer = buildHttpsServer(brokerConf);
     setupSwagger();
   }
 
   private HttpServer buildHttpsServer(PinotConfiguration brokerConf) {
-    boolean isSecure = PROTOCOL_HTTPS.equals(brokerConf.getProperty(PINOT_BROKER_CLIENT_PROTOCOL, PROTOCOL_HTTP));
+    boolean isSecure = HTTPS_PROTOCOL.equals(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_PROTOCOL));
 
     if (isSecure) {
       return GrizzlyHttpServerFactory.createHttpServer(_baseUri, this, true, buildSSLConfig(brokerConf));
@@ -97,12 +90,13 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   private SSLEngineConfigurator buildSSLConfig(PinotConfiguration brokerConf) {
     SSLContextConfigurator sslContextConfigurator = new SSLContextConfigurator();
 
-    sslContextConfigurator.setKeyStoreFile(brokerConf.getProperty(PINOT_BROKER_CLIENT_TLS_KEYSTORE_PATH));
-    sslContextConfigurator.setKeyStorePass(brokerConf.getProperty(PINOT_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD));
-    sslContextConfigurator.setTrustStoreFile(brokerConf.getProperty(PINOT_BROKER_CLIENT_TLS_TRUSTSTORE_PATH));
-    sslContextConfigurator.setTrustStorePass(brokerConf.getProperty(PINOT_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD));
+    sslContextConfigurator.setKeyStoreFile(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PATH));
+    sslContextConfigurator.setKeyStorePass(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD));
+    sslContextConfigurator.setTrustStoreFile(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PATH));
+    sslContextConfigurator.setTrustStorePass(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD));
 
-    boolean requiresClientAuth = brokerConf.getProperty(PINOT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH, false);
+    boolean requiresClientAuth = brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH,
+        DEFAULT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH);
 
     return new SSLEngineConfigurator(sslContextConfigurator).setClientMode(false)
         .setWantClientAuth(requiresClientAuth).setEnabledProtocols(new String[] { "TLSv1.2" });
@@ -114,7 +108,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    beanConfig.setSchemes(new String[] { _baseUri.getScheme() });
     beanConfig.setBasePath(_baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -245,7 +245,7 @@ public class HelixBrokerStarter implements ServiceStartable {
     int brokerQueryPort = _brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT, Helix.DEFAULT_BROKER_QUERY_PORT);
     LOGGER.info("Starting broker admin application on port: {}", brokerQueryPort);
     _brokerAdminApplication = new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics);
-    _brokerAdminApplication.start(brokerQueryPort);
+    _brokerAdminApplication.start(_brokerConf);
 
     LOGGER.info("Initializing cluster change mediator");
     for (ClusterChangeHandler externalViewChangeHandler : _externalViewChangeHandlers) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -177,6 +177,15 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
 
+    public static final String CONFIG_OF_BROKER_CLIENT_PROTOCOL = "pinot.broker.client.protocol";
+    public static final String DEFAULT_BROKER_CLIENT_PROTOCOL = "http";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PATH = "pinot.broker.client.tls.keystore.path";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD = "pinot.broker.client.tls.keystore.password";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PATH = "pinot.broker.client.tls.truststore.path";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD = "pinot.broker.client.tls.truststore.password";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = "pinot.broker.client.tls.requires_client_auth";
+    public static final boolean DEFAULT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = false;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -40,6 +40,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   public static final String CONTROLLER_VIP_PORT = "controller.vip.port";
   public static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
+  public static final String CONTROLLER_BROKER_PROTOCOL = "controller.broker.protocol";
   public static final String CONTROLLER_HOST = "controller.host";
   public static final String CONTROLLER_PORT = "controller.port";
   public static final String CONTROLLER_ACCESS_PROTOCOLS = "controller.access.protocols";
@@ -234,6 +235,10 @@ public class ControllerConf extends PinotConfiguration {
     setProperty(CONTROLLER_VIP_PROTOCOL, vipProtocol);
   }
 
+  public void setControllerBrokerProtocol(String protocol) {
+    setProperty(CONTROLLER_BROKER_PROTOCOL, protocol);
+  }
+
   public void setControllerPort(String port) {
     setProperty(CONTROLLER_PORT, port);
   }
@@ -350,6 +355,14 @@ public class ControllerConf extends PinotConfiguration {
 
   public String getControllerVipProtocol() {
     return Optional.ofNullable(getProperty(CONTROLLER_VIP_PROTOCOL))
+
+        .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
+
+        .orElse(CommonConstants.HTTP_PROTOCOL);
+  }
+
+  public String getControllerBrokerProtocol() {
+    return Optional.ofNullable(getProperty(CONTROLLER_BROKER_PROTOCOL))
 
         .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -196,10 +196,12 @@ public class PinotQueryResource {
       LOGGER.error("Instance {} not found", instanceId);
       return QueryException.INTERNAL_ERROR.toString();
     }
+
+    // TODO extract protocol from Helix
+    String protocol = "http";
     String hostNameWithPrefix = instanceConfig.getHostName();
-    String url =
-        getQueryURL(hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1), instanceConfig.getPort(),
-            querySyntax);
+    String url = getQueryURL(protocol, hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1),
+        instanceConfig.getPort(), querySyntax);
     ObjectNode requestJson = getRequestJson(query, traceEnabled, queryOptions, querySyntax);
     return sendRequestRaw(url, query, requestJson);
   }
@@ -226,12 +228,12 @@ public class PinotQueryResource {
     return requestJson;
   }
 
-  private String getQueryURL(String hostName, String port, String querySyntax) {
+  private String getQueryURL(String protocol, String hostName, String port, String querySyntax) {
     switch (querySyntax) {
       case CommonConstants.Broker.Request.SQL:
-        return String.format("http://%s:%s/query/sql", hostName, port);
+        return String.format("%s://%s:%s/query/sql", protocol, hostName, port);
       case CommonConstants.Broker.Request.PQL:
-        return String.format("http://%s:%s/query", hostName, port);
+        return String.format("%s://%s:%s/query", protocol, hostName, port);
       default:
         throw new UnsupportedOperationException("Unsupported query syntax - " + querySyntax);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -46,6 +46,7 @@ import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -63,11 +64,15 @@ public class PinotQueryResource {
   private static final Pql2Compiler PQL_QUERY_COMPILER = new Pql2Compiler();
   private static final CalciteSqlCompiler SQL_QUERY_COMPILER = new CalciteSqlCompiler();
   private static final Random RANDOM = new Random();
+
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
 
   @Inject
   AccessControlFactory _accessControlFactory;
+
+  @Inject
+  ControllerConf _controllerConf;
 
   @Deprecated
   @POST
@@ -198,7 +203,7 @@ public class PinotQueryResource {
     }
 
     // TODO extract protocol from Helix
-    String protocol = "http";
+    String protocol = _controllerConf.getControllerBrokerProtocol();
     String hostNameWithPrefix = instanceConfig.getHostName();
     String url = getQueryURL(protocol, hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1),
         instanceConfig.getPort(), querySyntax);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -32,11 +32,14 @@ import org.slf4j.LoggerFactory;
 public class PostQueryCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostQueryCommand.class.getName());
 
-  @Option(name = "-brokerHost", required = false, metaVar = "<String>", usage = "host name for controller.")
+  @Option(name = "-brokerHost", required = false, metaVar = "<String>", usage = "host name for broker.")
   private String _brokerHost;
 
   @Option(name = "-brokerPort", required = false, metaVar = "<int>", usage = "http port for broker.")
   private String _brokerPort = Integer.toString(CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+
+  @Option(name = "-brokerProtocol", required = false, metaVar = "<String>", usage = "protocol for broker.")
+  private String _brokerProtocol = "http";
 
   @Option(name = "-queryType", required = false, metaVar = "<string>", usage = "Query use sql or pql.")
   private String _queryType = Request.PQL;
@@ -59,7 +62,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
 
   @Override
   public String toString() {
-    return ("PostQuery -brokerHost " + _brokerHost + " -brokerPort " + _brokerPort + " -queryType " + _queryType + " -query " + _query);
+    return ("PostQuery -brokerProtocol " + _brokerProtocol + " -brokerHost " + _brokerHost + " -brokerPort " +
+        _brokerPort + " -queryType " + _queryType + " -query " + _query);
   }
 
   @Override
@@ -82,6 +86,11 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public PostQueryCommand setBrokerProtocol(String protocol) {
+    _brokerProtocol = protocol;
+    return this;
+  }
+
   public PostQueryCommand setQueryType(String queryType) {
     _queryType = queryType;
     return this;
@@ -100,7 +109,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     LOGGER.info("Executing command: " + toString());
 
     String request;
-    String urlString = "http://" + _brokerHost + ":" + _brokerPort + "/query";
+    String urlString = _brokerProtocol + "://" + _brokerHost + ":" + _brokerPort + "/query";
     if (_queryType.toLowerCase().equals(Request.SQL)) {
       urlString += "/sql";
       request = JsonUtils.objectToString(Collections.singletonMap(Request.SQL, _query));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -171,6 +171,13 @@ public class QuickstartRunner {
       Properties prop = new Properties();
       prop.put("pinot.broker.client.queryPort", String.valueOf(DEFAULT_BROKER_PORT + i));
 
+      prop.put("pinot.broker.client.protocol", "https");
+      prop.put("pinot.broker.client.tls.keystore.path", "/Users/alex/projects/incubator-pinot/truststore/generated.keystore.jks");
+      prop.put("pinot.broker.client.tls.keystore.password", "changeit");
+      prop.put("pinot.broker.client.tls.truststore.path", "/Users/alex/projects/incubator-pinot/truststore/generated.truststore.jks");
+      prop.put("pinot.broker.client.tls.truststore.password", "changeit");
+      prop.put("pinot.broker.client.tls.requires_client_auth", "false");
+
       try (OutputStream os = new FileOutputStream(configFileName)) {
         prop.store(os, "");
       }
@@ -310,7 +317,7 @@ public class QuickstartRunner {
       throws Exception {
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
     return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort))
-        .setQueryType(CommonConstants.Broker.Request.SQL).setQuery(query).run());
+        .setBrokerProtocol("https").setQueryType(CommonConstants.Broker.Request.SQL).setQuery(query).run());
   }
 
   public static void registerDefaultPinotFS() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
@@ -110,7 +110,7 @@ public class DataGenerator {
       throws IOException {
     final int numPerFiles = (int) (totalDocs / numFiles);
     for (int i = 0; i < numFiles; i++) {
-      try (FileWriter writer = new FileWriter(outDir + "/output.csv")) {
+      try (FileWriter writer = new FileWriter(String.format("%s/output_%d.csv", outDir, i))) {
         writer.append(StringUtils.join(genSpec.getColumns(), ",")).append('\n');
         for (int j = 0; j < numPerFiles; j++) {
           Object[] values = new Object[genSpec.getColumns().size()];

--- a/push-truststore.sh
+++ b/push-truststore.sh
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk-13.0.2.jdk/Contents/Home"
+
+CONFIG_DIR="$DIR/truststore"
+KEY_TOOL=$JAVA_HOME/bin/keytool
+KEYSTORE_PASSWORD="changeit"
+
+TRUST_STORE=$CONFIG_DIR/generated.truststore.jks
+KEY_STORE=$CONFIG_DIR/generated.keystore.jks
+P12_STORE=$CONFIG_DIR/generated.key.p12
+
+echo "removing any old generated files"
+rm -f $TRUST_STORE $KEY_STORE $P12_STORE
+echo "writing trust store"
+
+$KEY_TOOL \
+  -noprompt \
+  -import \
+  -storepass $KEYSTORE_PASSWORD \
+  -keystore $TRUST_STORE \
+  -storetype PKCS12 \
+  -file $CONFIG_DIR/ca-cert.pem
+echo "converting key/cert into PKCS12"
+
+openssl pkcs12 \
+  -export \
+  -in $CONFIG_DIR/cert.pem \
+  -inkey $CONFIG_DIR/key.pem \
+  -out $P12_STORE \
+  -password pass:$KEYSTORE_PASSWORD \
+  -name localhost
+echo "writing key store"
+
+$KEY_TOOL -importkeystore \
+  -deststorepass $KEYSTORE_PASSWORD \
+  -destkeypass $KEYSTORE_PASSWORD \
+  -destkeystore $KEY_STORE \
+  -deststoretype PKCS12 \
+  -srckeystore $P12_STORE \
+  -srcstoretype PKCS12 \
+  -srcstorepass $KEYSTORE_PASSWORD \
+  -srckeypass $KEYSTORE_PASSWORD \
+  -alias localhost


### PR DESCRIPTION
**To be continued here: https://github.com/apache/incubator-pinot/pull/6418**

## Description
We add support for TLS-secured client-broker connections, similar to the secure client-controller connection already implemented.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes?
**Yes**

## Release Notes
Add support for TLS-secured client-broker connections. Broker TLS can be configured using the following new properties:
- **pinot.broker.client.protocol** (http **OR** https)
- **pinot.broker.client.tls.keystore.path**
- **pinot.broker.client.tls.keystore.password**
- **pinot.broker.client.tls.truststore.path**
- **pinot.broker.client.tls.truststore.password**
- **pinot.broker.client.tls.requires_client_auth**

Furthermore, to enable controller-broker relay requests, the controller can be configured to use a specific protocol via:
- **controller.broker.protocol**

## Documentation
**TBD**

If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
