### PR TITLE
Client-Broker TLS support

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -71,7 +71,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     int brokerQueryPort = brokerConf.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT,
         CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
 
-    Preconditions.checkArgument(brokerQueryPort > 0);
+    Preconditions.checkArgument(brokerQueryPort > 0, "broker client port must be > 0");
     _baseUri = URI.create(String.format("%s://0.0.0.0:%d/", getBrokerClientProtocol(brokerConf), brokerQueryPort));
 
     _httpServer = buildHttpsServer(brokerConf);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -27,13 +27,19 @@ import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.ssl.SSLContextConfigurator;
+import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+
+import static org.apache.pinot.common.utils.CommonConstants.Broker.*;
+import static org.apache.pinot.common.utils.CommonConstants.HTTPS_PROTOCOL;
 
 
 public class BrokerAdminApiApplication extends ResourceConfig {
@@ -58,11 +64,42 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
   }
 
-  public void start(int httpPort) {
-    Preconditions.checkArgument(httpPort > 0);
-    _baseUri = URI.create("http://0.0.0.0:" + httpPort + "/");
-    _httpServer = GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
+  public void start(PinotConfiguration brokerConf) {
+    int brokerQueryPort = brokerConf.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT,
+        CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+    String brokerQueryProtocol = brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_PROTOCOL,
+        DEFAULT_BROKER_CLIENT_PROTOCOL);
+
+    Preconditions.checkArgument(brokerQueryPort > 0);
+    _baseUri = URI.create(String.format("%s://0.0.0.0:%d/", brokerQueryProtocol, brokerQueryPort));
+
+    _httpServer = buildHttpsServer(brokerConf);
     setupSwagger();
+  }
+
+  private HttpServer buildHttpsServer(PinotConfiguration brokerConf) {
+    boolean isSecure = HTTPS_PROTOCOL.equals(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_PROTOCOL));
+
+    if (isSecure) {
+      return GrizzlyHttpServerFactory.createHttpServer(_baseUri, this, true, buildSSLConfig(brokerConf));
+    }
+
+    return GrizzlyHttpServerFactory.createHttpServer(_baseUri, this);
+  }
+
+  private SSLEngineConfigurator buildSSLConfig(PinotConfiguration brokerConf) {
+    SSLContextConfigurator sslContextConfigurator = new SSLContextConfigurator();
+
+    sslContextConfigurator.setKeyStoreFile(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PATH));
+    sslContextConfigurator.setKeyStorePass(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD));
+    sslContextConfigurator.setTrustStoreFile(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PATH));
+    sslContextConfigurator.setTrustStorePass(brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD));
+
+    boolean requiresClientAuth = brokerConf.getProperty(CONFIG_OF_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH,
+        DEFAULT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH);
+
+    return new SSLEngineConfigurator(sslContextConfigurator).setClientMode(false)
+        .setWantClientAuth(requiresClientAuth).setEnabledProtocols(new String[] { "TLSv1.2" });
   }
 
   private void setupSwagger() {
@@ -71,7 +108,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/incubator-pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    beanConfig.setSchemes(new String[] { _baseUri.getScheme() });
     beanConfig.setBasePath(_baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -23,7 +23,8 @@ import io.swagger.jaxrs.config.BeanConfig;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Optional;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -41,6 +42,10 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 
 public class BrokerAdminApiApplication extends ResourceConfig {
+  private static final List<String> SUPPORTED_PROTOCOLS = Arrays.asList(
+      CommonConstants.HTTP_PROTOCOL,
+      CommonConstants.HTTPS_PROTOCOL);
+
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
 
   private URI _baseUri;
@@ -104,9 +109,11 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   }
 
   private static String getBrokerClientProtocol(PinotConfiguration brokerConf) {
-    return Optional.ofNullable(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_CLIENT_PROTOCOL))
-        .filter(CommonConstants.HTTPS_PROTOCOL::equals)
-        .orElse(CommonConstants.HTTP_PROTOCOL);
+    String protocol = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_CLIENT_PROTOCOL,
+        CommonConstants.HTTP_PROTOCOL);
+    Preconditions.checkArgument(SUPPORTED_PROTOCOLS.contains(protocol),
+        "Unsupported broker client protocol '%s'", protocol);
+    return protocol;
   }
 
   private void setupSwagger() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -245,7 +245,7 @@ public class HelixBrokerStarter implements ServiceStartable {
     int brokerQueryPort = _brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT, Helix.DEFAULT_BROKER_QUERY_PORT);
     LOGGER.info("Starting broker admin application on port: {}", brokerQueryPort);
     _brokerAdminApplication = new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics);
-    _brokerAdminApplication.start(brokerQueryPort);
+    _brokerAdminApplication.start(_brokerConf);
 
     LOGGER.info("Initializing cluster change mediator");
     for (ClusterChangeHandler externalViewChangeHandler : _externalViewChangeHandlers) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -178,13 +178,12 @@ public class CommonConstants {
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
 
     public static final String CONFIG_OF_BROKER_CLIENT_PROTOCOL = "pinot.broker.client.protocol";
-    public static final String DEFAULT_BROKER_CLIENT_PROTOCOL = "http";
     public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PATH = "pinot.broker.client.tls.keystore.path";
     public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD = "pinot.broker.client.tls.keystore.password";
     public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PATH = "pinot.broker.client.tls.truststore.path";
     public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD = "pinot.broker.client.tls.truststore.password";
-    public static final String CONFIG_OF_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = "pinot.broker.client.tls.requires_client_auth";
-    public static final boolean DEFAULT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = false;
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_CLIENT_AUTH = "pinot.broker.client.tls.client.auth";
+    public static final boolean DEFAULT_BROKER_CLIENT_TLS_CLIENT_AUTH = false;
 
     public static class Request {
       public static final String PQL = "pql";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -177,6 +177,15 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
 
+    public static final String CONFIG_OF_BROKER_CLIENT_PROTOCOL = "pinot.broker.client.protocol";
+    public static final String DEFAULT_BROKER_CLIENT_PROTOCOL = "http";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PATH = "pinot.broker.client.tls.keystore.path";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_KEYSTORE_PASSWORD = "pinot.broker.client.tls.keystore.password";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PATH = "pinot.broker.client.tls.truststore.path";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_TRUSTSTORE_PASSWORD = "pinot.broker.client.tls.truststore.password";
+    public static final String CONFIG_OF_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = "pinot.broker.client.tls.requires_client_auth";
+    public static final boolean DEFAULT_BROKER_CLIENT_TLS_REQUIRES_CLIENT_AUTH = false;
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -40,6 +40,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   public static final String CONTROLLER_VIP_PORT = "controller.vip.port";
   public static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
+  public static final String CONTROLLER_BROKER_PROTOCOL = "controller.broker.protocol";
   public static final String CONTROLLER_HOST = "controller.host";
   public static final String CONTROLLER_PORT = "controller.port";
   public static final String CONTROLLER_ACCESS_PROTOCOLS = "controller.access.protocols";
@@ -234,6 +235,10 @@ public class ControllerConf extends PinotConfiguration {
     setProperty(CONTROLLER_VIP_PROTOCOL, vipProtocol);
   }
 
+  public void setControllerBrokerProtocol(String protocol) {
+    setProperty(CONTROLLER_BROKER_PROTOCOL, protocol);
+  }
+
   public void setControllerPort(String port) {
     setProperty(CONTROLLER_PORT, port);
   }
@@ -350,6 +355,14 @@ public class ControllerConf extends PinotConfiguration {
 
   public String getControllerVipProtocol() {
     return Optional.ofNullable(getProperty(CONTROLLER_VIP_PROTOCOL))
+
+        .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
+
+        .orElse(CommonConstants.HTTP_PROTOCOL);
+  }
+
+  public String getControllerBrokerProtocol() {
+    return Optional.ofNullable(getProperty(CONTROLLER_BROKER_PROTOCOL))
 
         .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller;
 
+import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,10 @@ import static org.apache.pinot.common.utils.CommonConstants.Controller.DEFAULT_M
 
 
 public class ControllerConf extends PinotConfiguration {
+  public static final List<String> SUPPORTED_PROTOCOLS = Arrays.asList(
+      CommonConstants.HTTP_PROTOCOL,
+      CommonConstants.HTTPS_PROTOCOL);
+
   public static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   public static final String CONTROLLER_VIP_PORT = "controller.vip.port";
   public static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
@@ -354,19 +359,11 @@ public class ControllerConf extends PinotConfiguration {
   }  
 
   public String getControllerVipProtocol() {
-    return Optional.ofNullable(getProperty(CONTROLLER_VIP_PROTOCOL))
-
-        .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
-
-        .orElse(CommonConstants.HTTP_PROTOCOL);
+    return getSupportedProtocol(CONTROLLER_VIP_PROTOCOL);
   }
 
   public String getControllerBrokerProtocol() {
-    return Optional.ofNullable(getProperty(CONTROLLER_BROKER_PROTOCOL))
-
-        .filter(protocol -> CommonConstants.HTTPS_PROTOCOL.equals(protocol))
-
-        .orElse(CommonConstants.HTTP_PROTOCOL);
+    return getSupportedProtocol(CONTROLLER_BROKER_PROTOCOL);
   }
 
   public int getRetentionControllerFrequencyInSeconds() {
@@ -656,5 +653,12 @@ public class ControllerConf extends PinotConfiguration {
       throw new RuntimeException("Invalid time spec '" + timeStr + "' (Valid examples: '3h', '4h30m', '30m')", e);
     }
     return seconds;
+  }
+
+  private String getSupportedProtocol(String property) {
+    String value = getProperty(property, CommonConstants.HTTP_PROTOCOL);
+    Preconditions.checkArgument(SUPPORTED_PROTOCOLS.contains(value),
+        "Unsupported %s protocol '%s'", property, value);
+    return value;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -32,11 +32,14 @@ import org.slf4j.LoggerFactory;
 public class PostQueryCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PostQueryCommand.class.getName());
 
-  @Option(name = "-brokerHost", required = false, metaVar = "<String>", usage = "host name for controller.")
+  @Option(name = "-brokerHost", required = false, metaVar = "<String>", usage = "host name for broker.")
   private String _brokerHost;
 
   @Option(name = "-brokerPort", required = false, metaVar = "<int>", usage = "http port for broker.")
   private String _brokerPort = Integer.toString(CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT);
+
+  @Option(name = "-brokerProtocol", required = false, metaVar = "<String>", usage = "protocol for broker.")
+  private String _brokerProtocol = "http";
 
   @Option(name = "-queryType", required = false, metaVar = "<string>", usage = "Query use sql or pql.")
   private String _queryType = Request.PQL;
@@ -59,7 +62,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
 
   @Override
   public String toString() {
-    return ("PostQuery -brokerHost " + _brokerHost + " -brokerPort " + _brokerPort + " -queryType " + _queryType + " -query " + _query);
+    return ("PostQuery -brokerProtocol " + _brokerProtocol + " -brokerHost " + _brokerHost + " -brokerPort " +
+        _brokerPort + " -queryType " + _queryType + " -query " + _query);
   }
 
   @Override
@@ -82,6 +86,11 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public PostQueryCommand setBrokerProtocol(String protocol) {
+    _brokerProtocol = protocol;
+    return this;
+  }
+
   public PostQueryCommand setQueryType(String queryType) {
     _queryType = queryType;
     return this;
@@ -100,7 +109,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     LOGGER.info("Executing command: " + toString());
 
     String request;
-    String urlString = "http://" + _brokerHost + ":" + _brokerPort + "/query";
+    String urlString = _brokerProtocol + "://" + _brokerHost + ":" + _brokerPort + "/query";
     if (_queryType.toLowerCase().equals(Request.SQL)) {
       urlString += "/sql";
       request = JsonUtils.objectToString(Collections.singletonMap(Request.SQL, _query));


### PR DESCRIPTION
## Description
We add support for TLS-secured client-broker connections, similar to the secure client-controller connection already implemented.

Comprehensive example with modified QuickStart for illustration: https://github.com/apache/incubator-pinot/pull/6413

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes?
**Yes**

## Release Notes
Add support for TLS-secured client-broker connections. Broker TLS can be configured using the following new properties:
- **pinot.broker.client.protocol** (http **OR** https)
- **pinot.broker.client.tls.keystore.path**
- **pinot.broker.client.tls.keystore.password**
- **pinot.broker.client.tls.truststore.path**
- **pinot.broker.client.tls.truststore.password**
- **pinot.broker.client.tls.client.auth**

Furthermore, to enable controller-broker relay requests via https, the controller can be configured to use a specific protocol via:
- **controller.broker.protocol** (http **OR** https)

## Documentation
https://github.com/pinot-contrib/pinot-docs/pull/18

