### PR TITLE
Replace BrokerRequestOptimizer with QueryOptimizer to also optimize the PinotQuery

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
@@ -21,16 +21,13 @@ package org.apache.pinot.broker.request;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.List;
-import org.apache.pinot.core.requesthandler.BrokerRequestOptimizer;
+import java.util.Objects;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.parsers.utils.BrokerRequestComparisonUtils;
-import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -40,155 +37,107 @@ import org.testng.annotations.Test;
  * Please note that this test will load test resources: `pql_queries.list` and `pql_queries.list` under `pinot-common` module.
  */
 public class PqlAndCalciteSqlCompatibilityTest {
-
-  private static final Pql2Compiler COMPILER = new Pql2Compiler();
+  private static final Pql2Compiler PQL_COMPILER = new Pql2Compiler();
+  private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
 
   // OPTIMIZER is used to flatten certain queries with filtering optimization.
   // The reason is that SQL parser will parse the structure into a binary tree mode.
   // PQL parser will flat the case of multiple children under AND/OR.
   // After optimization, both BrokerRequests from PQL and SQL should look the same and be easier to compare.
-  private static final BrokerRequestOptimizer OPTIMIZER = new BrokerRequestOptimizer();
-  private static final Logger LOGGER = LoggerFactory.getLogger(PqlAndCalciteSqlCompatibilityTest.class);
+  private static final QueryOptimizer OPTIMIZER = new QueryOptimizer();
 
   @Test
   public void testSinglePqlAndSqlCompatible() {
-    final String sql =
+    String query =
         "SELECT CarrierDelay, Origin, DayOfWeek FROM mytable WHERE ActualElapsedTime BETWEEN 163 AND 322 OR CarrierDelay IN (17, 266) OR AirlineID IN (19690, 20366) ORDER BY TaxiIn, TailNum LIMIT 1";
-    final String pql =
-        "SELECT CarrierDelay, Origin, DayOfWeek FROM mytable WHERE ActualElapsedTime BETWEEN 163 AND 322 OR CarrierDelay IN (17, 266) OR AirlineID IN (19690, 20366) ORDER BY TaxiIn, TailNum LIMIT 1";
-
-    // PQL
-    LOGGER.info("Trying to compile PQL: {}", pql);
-    // NOTE: SQL is always using upper cases, so we need to make the string to upper case in order to match the parsed identifier name.
-    final BrokerRequest unOptimizedBrokerRequestFromPQL = COMPILER.compileToBrokerRequest(pql);
-    final BrokerRequest brokerRequestFromPQL = OPTIMIZER.optimize(unOptimizedBrokerRequestFromPQL, null);
-    LOGGER.debug("Compiled PQL: PQL: {}, BrokerRequest: {}", pql, brokerRequestFromPQL);
-    brokerRequestFromPQL.unsetPinotQuery();
-
-    //SQL
-    LOGGER.info("Trying to compile SQL: {}", sql);
-    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
-    final BrokerRequest brokerRequestFromSQL =
-        OPTIMIZER.optimize(new PinotQuery2BrokerRequestConverter().convert(pinotQuery), null);
-    LOGGER.debug("Compiled SQL: SQL: {}, PinotQuery: {}, BrokerRequest: {}", sql, pinotQuery, brokerRequestFromSQL);
-
-    // Compare
-    LOGGER.info("Trying to compare BrokerRequest -\nFrom PQL: {}\nFrom SQL: {}", brokerRequestFromPQL,
-        brokerRequestFromSQL);
-    Assert.assertTrue(BrokerRequestComparisonUtils.validate(brokerRequestFromPQL, brokerRequestFromSQL));
+    testPqlSqlCompatibilityHelper(query, query);
   }
 
   @Test
   public void testSinglePqlAndSqlGroupByOrderByCompatible() {
-    final String sql =
+    String query =
         "select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count), group_city DESC limit 100";
-    final String pql =
-        "select group_city, sum(rsvp_count), count(*) from meetupRsvp group by group_city order by sum(rsvp_count), group_city DESC limit 100";
-
-    // PQL
-    LOGGER.info("Trying to compile PQL: {}", pql);
-    // NOTE: SQL is always using upper cases, so we need to make the string to upper case in order to match the parsed identifier name.
-    final BrokerRequest unOptimizedBrokerRequestFromPQL = COMPILER.compileToBrokerRequest(pql);
-    final BrokerRequest brokerRequestFromPQL = OPTIMIZER.optimize(unOptimizedBrokerRequestFromPQL, null);
-    LOGGER.debug("Compiled PQL: PQL: {}, BrokerRequest: {}", pql, brokerRequestFromPQL);
-    brokerRequestFromPQL.unsetPinotQuery();
-
-    //SQL
-    LOGGER.info("Trying to compile SQL: {}", sql);
-    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
-    final BrokerRequest brokerRequestFromSQL =
-        OPTIMIZER.optimize(new PinotQuery2BrokerRequestConverter().convert(pinotQuery), null);
-    LOGGER.debug("Compiled SQL: SQL: {}, PinotQuery: {}, BrokerRequest: {}", sql, pinotQuery, brokerRequestFromSQL);
-
-    // Compare
-    LOGGER.info("Trying to compare BrokerRequest -\nFrom PQL: {}\nFrom SQL: {}", brokerRequestFromPQL,
-        brokerRequestFromSQL);
-    Assert.assertTrue(BrokerRequestComparisonUtils.validate(brokerRequestFromPQL, brokerRequestFromSQL));
+    testPqlSqlCompatibilityHelper(query, query);
   }
 
   @Test
   public void testPqlAndSqlCompatible()
       throws Exception {
-    final BufferedReader brPql = new BufferedReader(new InputStreamReader(
-        PqlAndCalciteSqlCompatibilityTest.class.getClassLoader().getResourceAsStream("pql_queries.list")));
-    final BufferedReader brSql = new BufferedReader(new InputStreamReader(
-        PqlAndCalciteSqlCompatibilityTest.class.getClassLoader().getResourceAsStream("sql_queries.list")));
-    String sql;
-    int seqId = 0;
-    while ((sql = brSql.readLine()) != null) {
-      final String pql = brPql.readLine();
-      try {
-
-        // PQL
-        LOGGER.info("Trying to compile PQL Id - {}, PQL: {}", seqId, pql);
-        final BrokerRequest brokerRequestFromPQL = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(pql), null);
-        LOGGER.debug("Compiled PQL: Id - {}, PQL: {}, BrokerRequest: {}", seqId, pql, brokerRequestFromPQL);
-        brokerRequestFromPQL.unsetPinotQuery();
-
-        //SQL
-        LOGGER.info("Trying to compile SQL Id - {}, SQL: {}", seqId, sql);
-        final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
-        final BrokerRequest brokerRequestFromSQL =
-            OPTIMIZER.optimize(new PinotQuery2BrokerRequestConverter().convert(pinotQuery), null);
-        LOGGER.debug("Compiled SQL: Id - {}, SQL: {}, PinotQuery: {}, BrokerRequest: {}", seqId, sql, pinotQuery,
-            brokerRequestFromSQL);
-
-        // Compare
-        LOGGER.info("Trying to compare BrokerRequest - Id: {}\nFrom PQL: {}\nFrom SQL: {}", seqId, brokerRequestFromPQL,
-            brokerRequestFromSQL);
-        Assert.assertTrue(BrokerRequestComparisonUtils.validate(brokerRequestFromPQL, brokerRequestFromSQL));
-        seqId++;
-      } catch (Exception e) {
-        LOGGER.error("Failed to compare results from \n\tPQL: {}\nand\n\tSQL: {}", pql, sql, e);
-        throw e;
+    try (BufferedReader pqlReader = new BufferedReader(new InputStreamReader(Objects.requireNonNull(
+        PqlAndCalciteSqlCompatibilityTest.class.getClassLoader().getResourceAsStream("pql_queries.list"))));
+        BufferedReader sqlReader = new BufferedReader(new InputStreamReader(Objects.requireNonNull(
+            PqlAndCalciteSqlCompatibilityTest.class.getClassLoader().getResourceAsStream("sql_queries.list"))))) {
+      String pql;
+      while ((pql = pqlReader.readLine()) != null) {
+        String sql = sqlReader.readLine();
+        testPqlSqlCompatibilityHelper(pql, sql);
       }
     }
+  }
+
+  private void testPqlSqlCompatibilityHelper(String pql, String sql) {
+    BrokerRequest pqlBrokerRequest = PQL_COMPILER.compileToBrokerRequest(pql);
+    OPTIMIZER.optimize(pqlBrokerRequest, null);
+    BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sql);
+    OPTIMIZER.optimize(sqlBrokerRequest, null);
+    Assert.assertTrue(BrokerRequestComparisonUtils.validate(pqlBrokerRequest, sqlBrokerRequest));
   }
 
   @Test
   public void testPqlSqlOrderByCompatibility() {
     String pql = "SELECT count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) TOP 10";
-    String sql = "SELECT VALUEIN(mv_col, 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) ORDER BY count(*) LIMIT 10";
+    String sql =
+        "SELECT VALUEIN(mv_col, 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(mv_col, 10790, 16344) ORDER BY count(*) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
 
     pql = "SELECT sum(col1) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') TOP 10";
-    sql = "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), sum(col1) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY sum(col1) LIMIT 10";
+    sql =
+        "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), sum(col1) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY sum(col1) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "sum(col1)");
 
-    pql = "SELECT max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
-    sql = "SELECT DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY max(add(col1,col2)) LIMIT 10";
+    pql =
+        "SELECT max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
+    sql =
+        "SELECT DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), max(add(col1,col2)) FROM Foo GROUP BY DATETIMECONVERT(timeCol, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY max(add(col1,col2)) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(add(col1,col2))");
 
     pql = "SELECT max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS')";
-    sql = "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
+    sql =
+        "SELECT TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(timeCol, 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(div(col1,col2))");
 
     pql = "SELECT count(*) FROM Foo GROUP BY VALUEIN(time, 10790, 16344) TOP 10";
-    sql = "SELECT VALUEIN(\"time\", 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(\"time\", 10790, 16344) ORDER BY count(*) LIMIT 10";
+    sql =
+        "SELECT VALUEIN(\"time\", 10790, 16344), count(*) FROM Foo GROUP BY VALUEIN(\"time\", 10790, 16344) ORDER BY count(*) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
 
     pql = "SELECT count(*) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') TOP 10";
-    sql = "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), count(*) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY count(*) LIMIT 10";
+    sql =
+        "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), count(*) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY count(*) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
 
-    pql = "SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(time, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
-    sql = "SELECT DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), count(*) FROM Foo GROUP BY DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY count(*) LIMIT 10";
+    pql =
+        "SELECT count(*) FROM Foo GROUP BY DATETIMECONVERT(time, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') TOP 10";
+    sql =
+        "SELECT DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), count(*) FROM Foo GROUP BY DATETIMECONVERT(\"time\", '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES') ORDER BY count(*) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "count(*)");
 
     pql = "SELECT max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(time, 'MILLISECONDS', 'SECONDS') TOP 10";
-    sql = "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
+    sql =
+        "SELECT TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS'), max(div(col1,col2)) FROM Foo GROUP BY TIMECONVERT(\"time\", 'MILLISECONDS', 'SECONDS') ORDER BY max(div(col1,col2)) LIMIT 10";
     testPqlSqlOrderByCompatibilityHelper(pql, sql, "max(div(col1,col2))");
   }
 
   private void testPqlSqlOrderByCompatibilityHelper(String pql, String sql, String orderByColumn) {
-    final BrokerRequest brokerRequestFromPQL = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(pql), null);
-    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
-    final BrokerRequest brokerRequestFromSQL =
-        OPTIMIZER.optimize(new PinotQuery2BrokerRequestConverter().convert(pinotQuery), null);
-    Assert.assertTrue(BrokerRequestComparisonUtils.validate(brokerRequestFromPQL, brokerRequestFromSQL, /*ignoreOrderBy*/true));
-    // validate ORDER BY here since brokerRequest from PQL will have order by as NULL and
-    // brokerRequest from SQL will have valid ORDER BY
-    List<SelectionSort> orderBy = brokerRequestFromSQL.getOrderBy();
+    BrokerRequest pqlBrokerRequest = PQL_COMPILER.compileToBrokerRequest(pql);
+    OPTIMIZER.optimize(pqlBrokerRequest, null);
+    BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sql);
+    OPTIMIZER.optimize(sqlBrokerRequest, null);
+    Assert.assertTrue(BrokerRequestComparisonUtils.validate(pqlBrokerRequest, sqlBrokerRequest, /*ignoreOrderBy*/true));
+
+    // Validate ORDER BY here since brokerRequest from PQL will have order by as NULL and brokerRequest from SQL will
+    // have valid ORDER BY
+    List<SelectionSort> orderBy = sqlBrokerRequest.getOrderBy();
     Assert.assertEquals(orderBy.size(), 1);
     SelectionSort sort = orderBy.get(0);
     Assert.assertEquals(sort.getColumn(), orderByColumn);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -52,162 +52,168 @@ public class BrokerRequestToQueryContextConverter {
 
   /**
    * Converts the given {@link BrokerRequest} into a {@link QueryContext}.
-   * <p>Use {@link PinotQuery} if available to avoid the unnecessary parsing of the expressions.
-   * <p>TODO: We cannot use PinotQuery to generate the WHERE clause filter because {@code BrokerRequestOptimizer} only
-   *          optimizes the BrokerRequest but not the PinotQuery.
    */
   public static QueryContext convert(BrokerRequest brokerRequest) {
-    String tableName = brokerRequest.getQuerySource().getTableName();
+    return brokerRequest.getPinotQuery() != null ? convertSQL(brokerRequest) : convertPQL(brokerRequest);
+  }
+
+  private static QueryContext convertSQL(BrokerRequest brokerRequest) {
     PinotQuery pinotQuery = brokerRequest.getPinotQuery();
 
+    // SELECT
     List<ExpressionContext> selectExpressions;
-    Map<ExpressionContext, String> aliasMap;
-    List<ExpressionContext> groupByExpressions = null;
-    int limit;
-    int offset = 0;
-    if (pinotQuery != null) {
-      aliasMap = new HashMap<>();
-      List<Expression> selectList = pinotQuery.getSelectList();
-      selectExpressions = new ArrayList<>(selectList.size());
-      for (Expression thriftExpression : selectList) {
-        ExpressionContext expression;
-        if (thriftExpression.getType() == ExpressionType.FUNCTION && thriftExpression.getFunctionCall().getOperator()
-            .equalsIgnoreCase("AS")) {
-          // Handle alias
-          List<Expression> operands = thriftExpression.getFunctionCall().getOperands();
-          expression = QueryContextConverterUtils.getExpression(operands.get(0));
-          aliasMap.put(expression, operands.get(1).getIdentifier().getName());
-        } else {
-          expression = QueryContextConverterUtils.getExpression(thriftExpression);
-        }
-        selectExpressions.add(expression);
-      }
-      List<Expression> groupByList = pinotQuery.getGroupByList();
-      if (CollectionUtils.isNotEmpty(groupByList)) {
-        groupByExpressions = new ArrayList<>(groupByList.size());
-        for (Expression thriftExpression : groupByList) {
-          groupByExpressions.add(QueryContextConverterUtils.getExpression(thriftExpression));
-        }
-      }
-      limit = pinotQuery.getLimit();
-      offset = pinotQuery.getOffset();
-    } else {
-      // NOTE: Alias is not supported for PQL queries.
-      aliasMap = Collections.emptyMap();
-      Selection selections = brokerRequest.getSelections();
-      if (selections != null) {
-        // Selection query
-        List<String> selectionColumns = selections.getSelectionColumns();
-        selectExpressions = new ArrayList<>(selectionColumns.size());
-        for (String expression : selectionColumns) {
-          selectExpressions.add(QueryContextConverterUtils.getExpression(expression));
-        }
-        // NOTE: Pinot ignores the GROUP-BY clause for selection queries.
-        groupByExpressions = null;
-        limit = brokerRequest.getLimit();
-        offset = selections.getOffset();
-        // Some old Pinot clients set LIMIT and OFFSET in Selection object.
-        // E.g. Presto segment level query.
-        if (limit == 0) {
-          limit = selections.getSize();
-        }
+    Map<ExpressionContext, String> aliasMap = new HashMap<>();
+    List<Expression> selectList = pinotQuery.getSelectList();
+    selectExpressions = new ArrayList<>(selectList.size());
+    for (Expression thriftExpression : selectList) {
+      ExpressionContext expression;
+      if (thriftExpression.getType() == ExpressionType.FUNCTION && thriftExpression.getFunctionCall().getOperator()
+          .equalsIgnoreCase("AS")) {
+        // Handle alias
+        List<Expression> operands = thriftExpression.getFunctionCall().getOperands();
+        expression = QueryContextConverterUtils.getExpression(operands.get(0));
+        aliasMap.put(expression, operands.get(1).getIdentifier().getName());
       } else {
-        // Aggregation query
-        List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
-        selectExpressions = new ArrayList<>(aggregationsInfo.size());
-        for (AggregationInfo aggregationInfo : aggregationsInfo) {
-          String functionName = StringUtils.remove(aggregationInfo.getAggregationType(), '_');
-          List<String> stringExpressions = aggregationInfo.getExpressions();
-          int numArguments = stringExpressions.size();
-          List<ExpressionContext> arguments = new ArrayList<>(numArguments);
-          if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
-            // For DISTINCT query, all arguments are expressions
-            for (String expression : stringExpressions) {
-              arguments.add(QueryContextConverterUtils.getExpression(expression));
-            }
-          } else {
-            // For non-DISTINCT query, only the first argument is expression, others are literals
-            // NOTE: We directly use the string as the literal value because of the legacy behavior of PQL compiler
-            //       treating string literal as identifier in the aggregation function.
-            arguments.add(QueryContextConverterUtils.getExpression(stringExpressions.get(0)));
-            for (int i = 1; i < numArguments; i++) {
-              arguments.add(ExpressionContext.forLiteral(stringExpressions.get(i)));
-            }
-          }
-          FunctionContext function = new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments);
-          selectExpressions.add(ExpressionContext.forFunction(function));
-        }
+        expression = QueryContextConverterUtils.getExpression(thriftExpression);
+      }
+      selectExpressions.add(expression);
+    }
 
-        GroupBy groupBy = brokerRequest.getGroupBy();
-        if (groupBy != null) {
-          // Aggregation group-by query
-          List<String> stringExpressions = groupBy.getExpressions();
-          groupByExpressions = new ArrayList<>(stringExpressions.size());
-          for (String stringExpression : stringExpressions) {
-            groupByExpressions.add(QueryContextConverterUtils.getExpression(stringExpression));
-          }
+    // WHERE
+    FilterContext filter = null;
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      filter = QueryContextConverterUtils.getFilter(pinotQuery.getFilterExpression());
+    }
 
-          // NOTE: Use TOP in GROUP-BY clause as LIMIT for backward-compatibility.
-          limit = (int) groupBy.getTopN();
-        } else {
-          limit = brokerRequest.getLimit();
+    // GROUP BY
+    List<ExpressionContext> groupByExpressions = null;
+    List<Expression> groupByList = pinotQuery.getGroupByList();
+    if (CollectionUtils.isNotEmpty(groupByList)) {
+      groupByExpressions = new ArrayList<>(groupByList.size());
+      for (Expression thriftExpression : groupByList) {
+        groupByExpressions.add(QueryContextConverterUtils.getExpression(thriftExpression));
+      }
+    }
+
+    // ORDER BY
+    List<OrderByExpressionContext> orderByExpressions = null;
+    List<Expression> orderByList = pinotQuery.getOrderByList();
+    if (CollectionUtils.isNotEmpty(orderByList)) {
+      // Deduplicate the order-by expressions
+      orderByExpressions = new ArrayList<>(orderByList.size());
+      Set<ExpressionContext> expressionSet = new HashSet<>();
+      for (Expression orderBy : orderByList) {
+        // NOTE: Order-by is always a Function with the ordering of the Expression
+        Function thriftFunction = orderBy.getFunctionCall();
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(thriftFunction.getOperands().get(0));
+        if (expressionSet.add(expression)) {
+          boolean isAsc = thriftFunction.getOperator().equalsIgnoreCase("ASC");
+          orderByExpressions.add(new OrderByExpressionContext(expression, isAsc));
         }
       }
+    }
+
+    // HAVING
+    FilterContext havingFilter = null;
+    Expression havingExpression = pinotQuery.getHavingExpression();
+    if (havingExpression != null) {
+      havingFilter = QueryContextConverterUtils.getFilter(havingExpression);
+    }
+
+    return new QueryContext.Builder().setTableName(pinotQuery.getDataSource().getTableName())
+        .setSelectExpressions(selectExpressions).setAliasMap(aliasMap).setFilter(filter)
+        .setGroupByExpressions(groupByExpressions).setOrderByExpressions(orderByExpressions)
+        .setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit()).setOffset(pinotQuery.getOffset())
+        .setQueryOptions(pinotQuery.getQueryOptions()).setDebugOptions(pinotQuery.getDebugOptions())
+        .setBrokerRequest(brokerRequest).build();
+  }
+
+  private static QueryContext convertPQL(BrokerRequest brokerRequest) {
+    List<ExpressionContext> selectExpressions;
+    List<ExpressionContext> groupByExpressions = null;
+    int limit = brokerRequest.getLimit();
+    int offset = 0;
+    Selection selections = brokerRequest.getSelections();
+    if (selections != null) {
+      // Selection query
+      List<String> selectionColumns = selections.getSelectionColumns();
+      selectExpressions = new ArrayList<>(selectionColumns.size());
+      for (String expression : selectionColumns) {
+        selectExpressions.add(QueryContextConverterUtils.getExpression(expression));
+      }
+
+      // NOTE: Some old Pinot clients (E.g. Presto segment level query) set LIMIT in Selection object.
+      if (limit == 0) {
+        limit = selections.getSize();
+      }
+
+      offset = selections.getOffset();
+    } else {
+      // Aggregation query
+      List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
+      selectExpressions = new ArrayList<>(aggregationsInfo.size());
+      for (AggregationInfo aggregationInfo : aggregationsInfo) {
+        String functionName = StringUtils.remove(aggregationInfo.getAggregationType(), '_');
+        List<String> stringExpressions = aggregationInfo.getExpressions();
+        int numArguments = stringExpressions.size();
+        List<ExpressionContext> arguments = new ArrayList<>(numArguments);
+        if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
+          // For DISTINCT query, all arguments are expressions
+          for (String expression : stringExpressions) {
+            arguments.add(QueryContextConverterUtils.getExpression(expression));
+          }
+        } else {
+          // For non-DISTINCT query, only the first argument is expression, others are literals
+          // NOTE: We directly use the string as the literal value because of the legacy behavior of PQL compiler
+          //       treating string literal as identifier in the aggregation function.
+          arguments.add(QueryContextConverterUtils.getExpression(stringExpressions.get(0)));
+          for (int i = 1; i < numArguments; i++) {
+            arguments.add(ExpressionContext.forLiteral(stringExpressions.get(i)));
+          }
+        }
+        FunctionContext function = new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments);
+        selectExpressions.add(ExpressionContext.forFunction(function));
+      }
+
+      GroupBy groupBy = brokerRequest.getGroupBy();
+      if (groupBy != null) {
+        // Aggregation group-by query
+        List<String> stringExpressions = groupBy.getExpressions();
+        groupByExpressions = new ArrayList<>(stringExpressions.size());
+        for (String stringExpression : stringExpressions) {
+          groupByExpressions.add(QueryContextConverterUtils.getExpression(stringExpression));
+        }
+
+        // NOTE: Use TOP in GROUP-BY clause as LIMIT for backward-compatibility.
+        limit = (int) groupBy.getTopN();
+      }
+    }
+
+    FilterContext filter = null;
+    FilterQueryTree rootFilterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    if (rootFilterQueryTree != null) {
+      filter = QueryContextConverterUtils.getFilter(rootFilterQueryTree);
     }
 
     List<OrderByExpressionContext> orderByExpressions = null;
-    if (pinotQuery != null) {
-      List<Expression> orderByList = pinotQuery.getOrderByList();
-      if (CollectionUtils.isNotEmpty(orderByList)) {
-        // Deduplicate the order-by expressions
-        orderByExpressions = new ArrayList<>(orderByList.size());
-        Set<ExpressionContext> expressionSet = new HashSet<>();
-        for (Expression orderBy : orderByList) {
-          // NOTE: Order-by is always a Function with the ordering of the Expression
-          Function thriftFunction = orderBy.getFunctionCall();
-          ExpressionContext expression = QueryContextConverterUtils.getExpression(thriftFunction.getOperands().get(0));
-          if (expressionSet.add(expression)) {
-            boolean isAsc = thriftFunction.getOperator().equalsIgnoreCase("ASC");
-            orderByExpressions.add(new OrderByExpressionContext(expression, isAsc));
-          }
-        }
-      }
-    } else {
-      List<SelectionSort> orderBy = brokerRequest.getOrderBy();
-      if (CollectionUtils.isNotEmpty(orderBy)) {
-        // Deduplicate the order-by expressions
-        orderByExpressions = new ArrayList<>(orderBy.size());
-        Set<ExpressionContext> expressionSet = new HashSet<>();
-        for (SelectionSort selectionSort : orderBy) {
-          ExpressionContext expression = QueryContextConverterUtils.getExpression(selectionSort.getColumn());
-          if (expressionSet.add(expression)) {
-            orderByExpressions.add(new OrderByExpressionContext(expression, selectionSort.isIsAsc()));
-          }
+    List<SelectionSort> orderBy = brokerRequest.getOrderBy();
+    if (CollectionUtils.isNotEmpty(orderBy)) {
+      // Deduplicate the order-by expressions
+      orderByExpressions = new ArrayList<>(orderBy.size());
+      Set<ExpressionContext> expressionSet = new HashSet<>();
+      for (SelectionSort selectionSort : orderBy) {
+        ExpressionContext expression = QueryContextConverterUtils.getExpression(selectionSort.getColumn());
+        if (expressionSet.add(expression)) {
+          orderByExpressions.add(new OrderByExpressionContext(expression, selectionSort.isIsAsc()));
         }
       }
     }
 
-    // NOTE: Always use BrokerRequest to generate filter because BrokerRequestOptimizer only optimizes the BrokerRequest
-    //       but not the PinotQuery.
-    FilterContext filter = null;
-    FilterQueryTree root = RequestUtils.generateFilterQueryTree(brokerRequest);
-    if (root != null) {
-      filter = QueryContextConverterUtils.getFilter(root);
-    }
-
-    // NOTE: Always use PinotQuery to generate HAVING filter because PQL does not support HAVING clause.
-    FilterContext havingFilter = null;
-    if (pinotQuery != null) {
-      Expression havingExpression = pinotQuery.getHavingExpression();
-      if (havingExpression != null) {
-        havingFilter = QueryContextConverterUtils.getFilter(havingExpression);
-      }
-    }
-
-    return new QueryContext.Builder().setTableName(tableName).setSelectExpressions(selectExpressions)
-        .setAliasMap(aliasMap).setFilter(filter).setGroupByExpressions(groupByExpressions)
-        .setOrderByExpressions(orderByExpressions).setHavingFilter(havingFilter).setLimit(limit).setOffset(offset)
-        .setQueryOptions(brokerRequest.getQueryOptions()).setDebugOptions(brokerRequest.getDebugOptions())
-        .setBrokerRequest(brokerRequest).build();
+    return new QueryContext.Builder().setTableName(brokerRequest.getQuerySource().getTableName())
+        .setSelectExpressions(selectExpressions).setAliasMap(Collections.emptyMap()).setFilter(filter)
+        .setGroupByExpressions(groupByExpressions).setOrderByExpressions(orderByExpressions).setLimit(limit)
+        .setOffset(offset).setQueryOptions(brokerRequest.getQueryOptions())
+        .setDebugOptions(brokerRequest.getDebugOptions()).setBrokerRequest(brokerRequest).build();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -187,7 +187,7 @@ public abstract class BaseQueriesTest {
     Map<String, String> queryOptions = brokerRequest.getQueryOptions();
     if (queryOptions == null) {
       queryOptions = new HashMap<>();
-      brokerRequest.setQueryOptions(queryOptions);
+      brokerRequest.getPinotQuery().setQueryOptions(queryOptions);
     }
     queryOptions.put(Request.QueryOptionKey.GROUP_BY_MODE, Request.SQL);
     queryOptions.put(Request.QueryOptionKey.RESPONSE_FORMAT, Request.SQL);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -881,7 +881,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       QueryContext pqlQueryContext = QueryContextConverterUtils.getQueryContextFromPQL(pqlQuery);
       BrokerResponseNative pqlResponse = queryServersWithDifferentSegments(pqlQueryContext);
       BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sqlQuery);
-      sqlBrokerRequest.setQueryOptions(Collections.singletonMap("responseFormat", "sql"));
+      sqlBrokerRequest.getPinotQuery().setQueryOptions(Collections.singletonMap("responseFormat", "sql"));
       QueryContext sqlQueryContext = BrokerRequestToQueryContextConverter.convert(sqlBrokerRequest);
       BrokerResponseNative sqlResponse = queryServersWithDifferentSegments(sqlQueryContext);
 


### PR DESCRIPTION
## Description
Currently broker only optimizes the filter in BrokerRequest, but leaves the filter in PinotQuery as is. Because of this, we can only use the filter from the BrokerRequest, which is inefficient because there is no native Expression support. It also blocks the PQL deprecation.

In this PR:
- Attach the time boundary to PinotQuery.
- Replace the BrokerRequestOptimizer with QueryOptimizer to also optimize the filter in PinotQuery.
- in BrokerRequestToQueryContextConverter, use PinotQuery to generate QueryContext for SQL queries.

For backward-compatibility, Broker will optimize the filter in both BrokerRequest and PinotQuery.

## Upgrade Notes
Please upgrade Brokers before Servers