### PR TITLE
Fix gcs listFiles

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -58,6 +58,7 @@ public class GcsPinotFS  extends PinotFS {
   public static final String GCP_KEY = "gcpKey";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcsPinotFS.class);
+  private static final String SCHEME = "gs";
   private static final String DELIMITER = "/";
   private static final int BUFFER_SIZE = 128 * 1024;
   private Storage storage;
@@ -130,7 +131,7 @@ public class GcsPinotFS  extends PinotFS {
 
   private URI getBase(URI uri) throws IOException {
     try {
-      return new URI(uri.getScheme(), uri.getHost(), null, null);
+      return new URI(SCHEME, uri.getHost(), DELIMITER, null);
     } catch (URISyntaxException e) {
       throw new IOException(e);
     }
@@ -204,11 +205,11 @@ public class GcsPinotFS  extends PinotFS {
     LOGGER.info("Deleting uri {} force {}", segmentUri, forceDelete);
     try {
       if (!exists(segmentUri)) {
-        return false;
+        return forceDelete;
       }
       if (isDirectory(segmentUri)) {
-        if (!forceDelete) {
-          checkState(isEmptyDirectory(segmentUri), "ForceDelete flag is not set and directory '%s' is not empty", segmentUri);
+        if (!forceDelete && !isEmptyDirectory(segmentUri)) {
+          return false;
         }
         String prefix = normalizeToDirectoryPrefix(segmentUri);
         Page<Blob> page;
@@ -292,7 +293,7 @@ public class GcsPinotFS  extends PinotFS {
   public long length(URI fileUri) throws IOException {
     try {
       checkState(!isPathTerminatedByDelimiter(fileUri), "URI is a directory");
-      Blob blob = getBucket(fileUri).get(fileUri.getPath());
+      Blob blob = getBlob(fileUri);
       checkState(existsBlob(blob), "File '%s' does not exist", fileUri);
       return blob.getSize();
     } catch (Throwable t) {
@@ -313,8 +314,12 @@ public class GcsPinotFS  extends PinotFS {
       }
       page.iterateAll()
           .forEach(blob -> {
-            if (!blob.getName().equals(fileUri.getPath())) {
-              builder.add(blob.getName());
+            if (!blob.getName().equals(prefix)) {
+              try {
+                builder.add(new URI(SCHEME, fileUri.getHost(), DELIMITER + blob.getName(), null).toString());
+              } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+              }
             }
           });
       return builder.build().toArray(new String[0]);


### PR DESCRIPTION
## Description
This pull request fixes issues with deleting files from GcsPinotFS.

The issues this pr resolves:
* The uri was not always guaranteed to be a valid gcs uri, with scheme "gs"
* List files did not always return valid gcs urls
* Delete would fail with an exception if force delete is false and the directory is not empty (should just return false)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
