### PR TITLE
[INFRA] Cancel the previous builds

### DIFF
--- a/.github/workflows/pinot_tests-workflow-run.yml
+++ b/.github/workflows/pinot_tests-workflow-run.yml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 name: Cancelling Duplicates
 on:
   workflow_run:

--- a/.github/workflows/pinot_tests-workflow-run.yml
+++ b/.github/workflows/pinot_tests-workflow-run.yml
@@ -29,14 +29,7 @@ jobs:
     name: "Cancel duplicate workflow runs"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        name: checkout potiuk/cancel-workflow-runs
-        with:
-          repository: potiuk/cancel-workflow-runs
-          path: ./build/.actions/potiuk/cancel-workflow-runs
-          ref: 953e057dc81d3458935a18d1184c386b0f6b5738 # @master
-          fetch-depth: 1
-      - uses: ./build/.actions/potiuk/cancel-workflow-runs
+      - uses: potiuk/cancel-workflow-runs@953e057dc81d3458935a18d1184c386b0f6b5738
         name: "Cancel duplicate workflow runs"
         with:
           cancelMode: allDuplicates

--- a/.github/workflows/pinot_tests-workflow-run.yml
+++ b/.github/workflows/pinot_tests-workflow-run.yml
@@ -1,0 +1,25 @@
+name: Cancelling Duplicates
+on:
+  workflow_run:
+    workflows: 
+      - 'Pinot Tests'
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: checkout potiuk/cancel-workflow-runs
+        with:
+          repository: potiuk/cancel-workflow-runs
+          path: ./build/.actions/potiuk/cancel-workflow-runs
+          ref: 953e057dc81d3458935a18d1184c386b0f6b5738 # @master
+          fetch-depth: 1
+      - uses: ./build/.actions/potiuk/cancel-workflow-runs
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Description
This PR aims to reduce the GitHub Action usage by canceling the previous build. In most case, the last commit is meaningful.

We want to support fork as well, so we have to use workflow_run, so this change will only take effect after merging.

>  If you use forks, you should create a separate "Cancelling" workflow_run triggered workflow. The workflow_run should be responsible for all canceling actions. The examples below show the possible ways the action can be utilized.

https://github.com/potiuk/cancel-workflow-runs#usage

> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_run

Similar PRs in other Apache projects;
Apache Spark: https://github.com/apache/spark/pull/31104
Apache Pulsar: https://github.com/apache/pulsar/pull/9159

INfRA Mailing lists discussion: https://lists.apache.org/thread.html/r5303eec41cc1dfc51c15dbe44770e37369330f9644ef09813f649120%40%3Cbuilds.apache.org%3E 

@potiuk Can I ask for a review?

## Upgrade Notes
N/A
## Release Notes
N/A
## Documentation
N/A