### PR TITLE
use tableNameWithType to delete segments from

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -176,7 +176,7 @@ public class SegmentDeletionManager {
     }
     if (_dataDir != null) {
       String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-      URI fileToMoveURI = URIUtils.getUri(_dataDir, rawTableName, URIUtils.encode(segmentId));
+      URI fileToMoveURI = URIUtils.getUri(_dataDir, tableNameWithType, URIUtils.encode(segmentId));
       URI deletedSegmentDestURI = URIUtils.getUri(_dataDir, DELETED_SEGMENTS, rawTableName, URIUtils.encode(segmentId));
       PinotFS pinotFS = PinotFSFactory.create(fileToMoveURI.getScheme());
 


### PR DESCRIPTION
## Description

Fixes Issue https://github.com/apache/incubator-pinot/issues/6436
Ideally, deletion should look at the segments in the table_name_with_type folder as that is where the segments are stored. This PR is to fix the same.
