### PR TITLE
BugFixing: raw table name extracts from segment metadata might contain _OFFLINE suffix

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -241,7 +241,7 @@ public class PinotSegmentUploadDownloadRestletResource {
         LOGGER.info("Uploading a segment {} to table: {}, push type {}, (Derived from API parameter)", segmentName, tableName, uploadType);
       } else {
         // TODO: remove this when we completely deprecate the table name from segment metadata
-        rawTableName = segmentMetadata.getTableName();
+        rawTableName = TableNameBuilder.extractRawTableName(segmentMetadata.getTableName());
         LOGGER.info("Uploading a segment {} to table: {}, push type {}, (Derived from segment metadata)", segmentName, tableName, uploadType);
       }
 


### PR DESCRIPTION
## Description
Fixing the bug that raw table name extract from segment metadata might also contain `_OFFLINE` suffix.

Thanks to @mr-agrwal for reporting this issue.