### PR TITLE
additional scalar functions for array type

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -197,6 +197,10 @@
       <artifactId>netty</artifactId>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.sf.jopt-simple</groupId>
       <artifactId>jopt-simple</artifactId>
     </dependency>

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.common.function.scalar;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
@@ -76,5 +79,59 @@ public class ArrayFunctions {
   @ScalarFunction
   public static boolean arrayContainsString(String[] values, String valueToFind) {
     return ArrayUtils.contains(values, valueToFind);
+  }
+
+  @ScalarFunction
+  public static int[] arraySliceInt(int[] values, int start, int end) {
+    return Arrays.copyOfRange(values, start, end);
+  }
+
+  @ScalarFunction
+  public static String[] arraySliceString(String[] values, int start, int end) {
+    return Arrays.copyOfRange(values, start, end);
+  }
+
+  @ScalarFunction
+  public static int[] arrayDistinctInt(int[] values) {
+    return Arrays.stream(values).distinct().toArray();
+  }
+
+  @ScalarFunction
+  public static String[] arrayDistinctString(String[] values) {
+    return Arrays.stream(values).distinct().toArray(String[]::new);
+  }
+
+  @ScalarFunction
+  public static int[] arrayRemoveInt(int[] values, int element) {
+    return ArrayUtils.removeElement(values, element);
+  }
+
+  @ScalarFunction
+  public static String[] arrayRemoveString(String[] values, String element) {
+    return ArrayUtils.removeElement(values, element);
+  }
+
+  @ScalarFunction
+  public static int[] arrayUnionInt(int[] values1, int[] values2) {
+    Set<Integer> set = new HashSet<>(Arrays.asList(ArrayUtils.toObject(values1)));
+    set.addAll(Arrays.asList(ArrayUtils.toObject(values2)));
+    return set.stream().mapToInt(Integer::intValue).toArray();
+  }
+
+  @ScalarFunction
+  public static String[] arrayUnionString(String[] values1, String[] values2) {
+    Set<String> set = new HashSet<>(Arrays.asList(values1));
+    set.addAll(Arrays.asList(values2));
+    return set.stream().toArray(String[]::new);
+  }
+
+  @ScalarFunction
+  public static int[] arrayConcatInt(int[] values1, int[] values2) {
+    return ArrayUtils.addAll(values1, values2);
+  }
+
+  @ScalarFunction
+  public static String[] arrayConcatString(String[] values1, String[] values2) {
+    return ArrayUtils.addAll(values1, values2);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
@@ -93,12 +95,12 @@ public class ArrayFunctions {
 
   @ScalarFunction
   public static int[] arrayDistinctInt(int[] values) {
-    return Arrays.stream(values).distinct().toArray();
+    return new IntLinkedOpenHashSet(values).toIntArray();
   }
 
   @ScalarFunction
   public static String[] arrayDistinctString(String[] values) {
-    return Arrays.stream(values).distinct().toArray(String[]::new);
+    return new ObjectLinkedOpenHashSet<>(values).toArray(new String[0]);
   }
 
   @ScalarFunction
@@ -113,16 +115,16 @@ public class ArrayFunctions {
 
   @ScalarFunction
   public static int[] arrayUnionInt(int[] values1, int[] values2) {
-    Set<Integer> set = new HashSet<>(Arrays.asList(ArrayUtils.toObject(values1)));
-    set.addAll(Arrays.asList(ArrayUtils.toObject(values2)));
-    return set.stream().mapToInt(Integer::intValue).toArray();
+    IntSet set = new IntLinkedOpenHashSet(values1);
+    set.addAll(IntArrayList.wrap(values2));
+    return set.toIntArray();
   }
 
   @ScalarFunction
   public static String[] arrayUnionString(String[] values1, String[] values2) {
-    Set<String> set = new HashSet<>(Arrays.asList(values1));
+    ObjectSet<String> set = new ObjectLinkedOpenHashSet<>(values1);
     set.addAll(Arrays.asList(values2));
-    return set.stream().toArray(String[]::new);
+    return set.toArray(new String[0]);
   }
 
   @ScalarFunction

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -122,10 +122,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -439,8 +439,8 @@ public class InbuiltFunctionsTest {
     inputs.add(
         new Object[]{"array_contains_string(stringArray, '2')", Collections.singletonList("stringArray"), row, true});
 
-    inputs.add(new Object[]{"array_slice_int(intArray, 1, 2)", Collections.singletonList(
-        "intArray"), row, new int[]{2}});
+    inputs
+        .add(new Object[]{"array_slice_int(intArray, 1, 2)", Collections.singletonList("intArray"), row, new int[]{2}});
     inputs.add(new Object[]{"array_slice_int(integerArray, 1, 2)", Collections.singletonList(
         "integerArray"), row, new int[]{2}});
     inputs.add(new Object[]{"array_slice_string(stringArray, 1, 2)", Collections.singletonList(
@@ -461,11 +461,11 @@ public class InbuiltFunctionsTest {
         "stringArray"), row, new String[]{"3", "10", "6", "1", "12"}});
 
     inputs.add(new Object[]{"array_union_int(intArray, intArray)", Lists.newArrayList("intArray",
-        "intArray"), row, new int[]{1, 2, 3, 6, 10, 12}});
+        "intArray"), row, new int[]{3, 2, 10, 6, 1, 12}});
     inputs.add(new Object[]{"array_union_int(integerArray, integerArray)", Lists.newArrayList("integerArray",
-        "integerArray"), row, new int[]{1, 2, 3, 6, 10, 12}});
+        "integerArray"), row, new int[]{3, 2, 10, 6, 1, 12}});
     inputs.add(new Object[]{"array_union_string(stringArray, stringArray)", Lists.newArrayList("stringArray",
-        "stringArray"), row, new String[]{"1", "12", "2", "3", "6", "10"}});
+        "stringArray"), row, new String[]{"3", "2", "10", "6", "1", "12"}});
 
     inputs.add(new Object[]{"array_concat_int(intArray, intArray)", Lists.newArrayList("intArray",
         "intArray"), row, new int[]{3, 2, 10, 6, 1, 12, 3, 2, 10, 6, 1, 12}});

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionsTest.java
@@ -439,6 +439,40 @@ public class InbuiltFunctionsTest {
     inputs.add(
         new Object[]{"array_contains_string(stringArray, '2')", Collections.singletonList("stringArray"), row, true});
 
+    inputs.add(new Object[]{"array_slice_int(intArray, 1, 2)", Collections.singletonList(
+        "intArray"), row, new int[]{2}});
+    inputs.add(new Object[]{"array_slice_int(integerArray, 1, 2)", Collections.singletonList(
+        "integerArray"), row, new int[]{2}});
+    inputs.add(new Object[]{"array_slice_string(stringArray, 1, 2)", Collections.singletonList(
+        "stringArray"), row, new String[]{"2"}});
+
+    inputs.add(new Object[]{"array_distinct_int(intArray)", Collections.singletonList(
+        "intArray"), row, new int[]{3, 2, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_distinct_int(integerArray)", Collections.singletonList(
+        "integerArray"), row, new int[]{3, 2, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_distinct_string(stringArray)", Collections.singletonList(
+        "stringArray"), row, new String[]{"3", "2", "10", "6", "1", "12"}});
+
+    inputs.add(new Object[]{"array_remove_int(intArray, 2)", Collections.singletonList(
+        "intArray"), row, new int[]{3, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_remove_int(integerArray, 2)", Collections.singletonList(
+        "integerArray"), row, new int[]{3, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_remove_string(stringArray, 2)", Collections.singletonList(
+        "stringArray"), row, new String[]{"3", "10", "6", "1", "12"}});
+
+    inputs.add(new Object[]{"array_union_int(intArray, intArray)", Lists.newArrayList("intArray",
+        "intArray"), row, new int[]{1, 2, 3, 6, 10, 12}});
+    inputs.add(new Object[]{"array_union_int(integerArray, integerArray)", Lists.newArrayList("integerArray",
+        "integerArray"), row, new int[]{1, 2, 3, 6, 10, 12}});
+    inputs.add(new Object[]{"array_union_string(stringArray, stringArray)", Lists.newArrayList("stringArray",
+        "stringArray"), row, new String[]{"1", "12", "2", "3", "6", "10"}});
+
+    inputs.add(new Object[]{"array_concat_int(intArray, intArray)", Lists.newArrayList("intArray",
+        "intArray"), row, new int[]{3, 2, 10, 6, 1, 12, 3, 2, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_concat_int(integerArray, integerArray)", Lists.newArrayList("integerArray",
+        "integerArray"), row, new int[]{3, 2, 10, 6, 1, 12, 3, 2, 10, 6, 1, 12}});
+    inputs.add(new Object[]{"array_concat_string(stringArray, stringArray)", Lists.newArrayList("stringArray",
+        "stringArray"), row, new String[]{"3", "2", "10", "6", "1", "12", "3", "2", "10", "6", "1", "12"}});
     return inputs.toArray(new Object[0][]);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -18,10 +18,9 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -451,8 +450,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertFalse(transformFunction.getResultMetadata().isSingleValue());
     int[][] expectedValues = new int[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _intMVValues[i].clone();
-      expectedValues[i] = Arrays.stream(expectedValues[i]).distinct().toArray();
+      expectedValues[i] = new IntLinkedOpenHashSet(_intMVValues[i]).toIntArray();
     }
     testTransformFunctionMV(transformFunction, expectedValues);
   }
@@ -468,8 +466,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertFalse(transformFunction.getResultMetadata().isSingleValue());
     String[][] expectedValues = new String[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _stringMVValues[i].clone();
-      expectedValues[i] = Arrays.stream(expectedValues[i]).distinct().toArray(String[]::new);
+      expectedValues[i] = new ObjectLinkedOpenHashSet<>(_stringMVValues[i]).toArray(new String[0]);
     }
     testTransformFunctionMV(transformFunction, expectedValues);
   }
@@ -510,8 +507,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testArrayUnionIntTransformFunction() {
-    ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionInt");
@@ -519,18 +516,15 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertFalse(transformFunction.getResultMetadata().isSingleValue());
     int[][] expectedValues = new int[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _intMVValues[i].clone();
-      Set<Integer> set = new HashSet<>(Arrays.asList(ArrayUtils.toObject(expectedValues[i])));
-      set.addAll(Arrays.asList(ArrayUtils.toObject(expectedValues[i])));
-      expectedValues[i] = set.stream().mapToInt(Integer::intValue).toArray();
+      expectedValues[i] = new IntLinkedOpenHashSet(_intMVValues[i]).toIntArray();
     }
     testTransformFunctionMV(transformFunction, expectedValues);
   }
 
   @Test
   public void testUnionStringTransformFunction() {
-    ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionString");
@@ -538,18 +532,15 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertFalse(transformFunction.getResultMetadata().isSingleValue());
     String[][] expectedValues = new String[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = _stringMVValues[i].clone();
-      Set<String> set = new HashSet<>(Arrays.asList(expectedValues[i]));
-      set.addAll(Arrays.asList(expectedValues[i]));
-      expectedValues[i] = set.stream().toArray(String[]::new);
+      expectedValues[i] = new ObjectLinkedOpenHashSet<>(_stringMVValues[i]).toArray(new String[0]);
     }
     testTransformFunctionMV(transformFunction, expectedValues);
   }
 
   @Test
   public void testArrayConcatIntTransformFunction() {
-    ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatInt");
@@ -565,8 +556,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testConcatStringTransformFunction() {
-    ExpressionContext expression =
-        QueryContextConverterUtils.getExpression(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    ExpressionContext expression = QueryContextConverterUtils
+        .getExpression(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatString");
@@ -575,9 +566,9 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     String[][] expectedValues = new String[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = _stringMVValues[i].clone();
-      expectedValues[i] = ArrayUtils.addAll(expectedValues[i], expectedValues[i]);;
+      expectedValues[i] = ArrayUtils.addAll(expectedValues[i], expectedValues[i]);
+      ;
     }
     testTransformFunctionMV(transformFunction, expectedValues);
   }
-
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -402,4 +405,179 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     testTransformFunction(transformFunction, expectedValues);
   }
+
+  @Test
+  public void testArraySliceIntTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_slice_int(%s, 1, 3)", INT_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arraySliceInt");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    int[][] expectedValues = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intMVValues[i].clone();
+      expectedValues[i] = Arrays.copyOfRange(expectedValues[i], 1, 3);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArraySliceStringTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_slice_string(%s, 1, 2)", STRING_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arraySliceString");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    String[][] expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _stringMVValues[i].clone();
+      expectedValues[i] = Arrays.copyOfRange(expectedValues[i], 1, 2);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayDistinctIntTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_distinct_int(%s)", INT_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayDistinctInt");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    int[][] expectedValues = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intMVValues[i].clone();
+      expectedValues[i] = Arrays.stream(expectedValues[i]).distinct().toArray();
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayDistinctStringTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_distinct_string(%s)", STRING_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayDistinctString");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    String[][] expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _stringMVValues[i].clone();
+      expectedValues[i] = Arrays.stream(expectedValues[i]).distinct().toArray(String[]::new);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayRemoveIntTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_remove_int(%s, 2)", INT_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayRemoveInt");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    int[][] expectedValues = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intMVValues[i].clone();
+      expectedValues[i] = ArrayUtils.removeElement(expectedValues[i], 2);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayRemoveStringTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_remove_string(%s, 2)", STRING_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayRemoveString");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    String[][] expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _stringMVValues[i].clone();
+      expectedValues[i] = ArrayUtils.removeElement(expectedValues[i], 2);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayUnionIntTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayUnionInt");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    int[][] expectedValues = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intMVValues[i].clone();
+      Set<Integer> set = new HashSet<>(Arrays.asList(ArrayUtils.toObject(expectedValues[i])));
+      set.addAll(Arrays.asList(ArrayUtils.toObject(expectedValues[i])));
+      expectedValues[i] = set.stream().mapToInt(Integer::intValue).toArray();
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testUnionStringTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayUnionString");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    String[][] expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _stringMVValues[i].clone();
+      Set<String> set = new HashSet<>(Arrays.asList(expectedValues[i]));
+      set.addAll(Arrays.asList(expectedValues[i]));
+      expectedValues[i] = set.stream().toArray(String[]::new);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testArrayConcatIntTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayConcatInt");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    int[][] expectedValues = new int[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intMVValues[i].clone();
+      expectedValues[i] = ArrayUtils.addAll(expectedValues[i], expectedValues[i]);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testConcatStringTransformFunction() {
+    ExpressionContext expression =
+        QueryContextConverterUtils.getExpression(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arrayConcatString");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    String[][] expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _stringMVValues[i].clone();
+      expectedValues[i] = ArrayUtils.addAll(expectedValues[i], expectedValues[i]);;
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
 }

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -129,10 +129,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
     </dependency>


### PR DESCRIPTION
Inbuilt functions - Scalar funtions for array columns

select array_concat_int(multi_value_int_field, multi_value_int_field) from airlineStats;
select array_concat_string(multi_value_string_field, multi_value_string_field) from airlineStats;
select array_union_int(multi_value_int_field, multi_value_int_field) from airlineStats;
select array_union_string(multi_value_string_field, multi_value_string_field) from airlineStats;
select array_remove_int(multi_value_int_field, 3) from airlineStats;
select array_remove_string(multi_value_string_field, 'bar') from airlineStats;
select array_distinct_int(multi_value_int_field) from airlineStats;
select array_distinct_string(multi_value_string_field) from airlineStats;
select array_slice_int(multi_value_int_field, 1, 2) from airlineStats;
select array_slice_string(multi_value_string_field, 1, 2) from airlineStats;