### PR TITLE
Adding CRON scheduler for Pinot tasks

### DIFF
--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -204,6 +204,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -79,6 +79,7 @@ public class ControllerConf extends PinotConfiguration {
     public static final String STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS =
         "controller.statuschecker.waitForPushTimeInSeconds";
     public static final String TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
+    public static final String PINOT_TASK_MANAGER_SCHEDULER_ENABLED = "controller.task.scheduler.enabled";
     @Deprecated
     // RealtimeSegmentRelocator has been rebranded as SegmentRelocator
     public static final String DEPRECATED_REALTIME_SEGMENT_RELOCATOR_FREQUENCY =
@@ -585,6 +586,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public long getPinotTaskManagerInitialDelaySeconds() {
     return getPeriodicTaskInitialDelayInSeconds();
+  }
+
+  public boolean isPinotTaskManagerSchedulerEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, false);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -21,8 +21,8 @@ package org.apache.pinot.controller.api.resources;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +31,7 @@ import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -40,7 +41,16 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.quartz.CronTrigger;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
+import org.quartz.SchedulerMetaData;
+import org.quartz.SimpleTrigger;
+import org.quartz.Trigger;
+import org.quartz.impl.matchers.GroupMatcher;
 
 
 /**
@@ -171,60 +181,101 @@ public class PinotTaskRestletResource {
   }
 
   @GET
-  @Path("/tasks/cron/schedules")
-  @ApiOperation("Fetch cron tasks schedule")
-  public Map<String, Map<String, String>> getCronSchedules(
-      @ApiParam(value = "Task type") @QueryParam("taskType") String taskType,
-      @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName) {
-    Map<String, Map<String, String>> tableTaskTypeToCronExpressionMap = _pinotTaskManager.getTableTaskTypeToCronExpressionMap();
-    Map<String, Map<String, String>> results = new HashMap<>();
-    for (String table : tableTaskTypeToCronExpressionMap.keySet()) {
-      if (tableName != null && !table.equalsIgnoreCase(table)) {
-        continue;
-      }
-      Map<String, String> taskTypeToCronExpressionMap = tableTaskTypeToCronExpressionMap.get(table);
-      for (String task : taskTypeToCronExpressionMap.keySet()) {
-        if (taskType != null && !task.equalsIgnoreCase(taskType)) {
-          continue;
-        }
-        if (!results.containsKey(table)) {
-          results.put(table, new HashMap<>());
-        }
-        results.get(table).put(task, taskTypeToCronExpressionMap.get(task));
+  @Path("/tasks/scheduler/information")
+  @ApiOperation("Fetch cron scheduler information")
+  public Map<String, Object> getCronSchedulerInformation()
+      throws SchedulerException {
+    Scheduler scheduler = _pinotTaskManager.getScheduler();
+    SchedulerMetaData metaData = scheduler.getMetaData();
+    Map<String, Object> schedulerMetaData = new HashMap<>();
+    schedulerMetaData.put("Version", metaData.getVersion());
+    schedulerMetaData.put("SchedulerName", metaData.getSchedulerName());
+    schedulerMetaData.put("SchedulerInstanceId", metaData.getSchedulerInstanceId());
+    schedulerMetaData.put("getThreadPoolClass", metaData.getThreadPoolClass());
+    schedulerMetaData.put("getThreadPoolSize", metaData.getThreadPoolSize());
+    schedulerMetaData.put("SchedulerClass", metaData.getSchedulerClass());
+    schedulerMetaData.put("Clustered", metaData.isJobStoreClustered());
+    schedulerMetaData.put("JobStoreClass", metaData.getJobStoreClass());
+    schedulerMetaData.put("NumberOfJobsExecuted", metaData.getNumberOfJobsExecuted());
+    schedulerMetaData.put("InStandbyMode", metaData.isInStandbyMode());
+    schedulerMetaData.put("RunningSince", metaData.getRunningSince());
+    List<Map> jobDetails = new ArrayList<>();
+    for (String groupName : scheduler.getJobGroupNames()) {
+      for (JobKey jobKey : scheduler.getJobKeys(GroupMatcher.jobGroupEquals(groupName))) {
+        Map<String, Object> jobMap = new HashMap<>();
+        List<Trigger> triggers = (List<Trigger>) scheduler.getTriggersOfJob(jobKey);
+        jobMap.put("JobKey", jobKey);
+        jobMap.put("NextFireTime", triggers.get(0).getNextFireTime());
+        jobMap.put("PreviousFireTime", triggers.get(0).getPreviousFireTime());
+        jobDetails.add(jobMap);
       }
     }
-    return results;
+    schedulerMetaData.put("JobDetails", jobDetails);
+    return schedulerMetaData;
   }
 
   @GET
-  @Path("/tasks/cron/nextruntimes")
-  @ApiOperation("Fetch cron tasks next runtimes")
-  public Map<String, Map<String, Date>> getCronNextRuntimes(
-      @ApiParam(value = "Task type") @QueryParam("taskType") String taskType,
-      @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName) {
-    try {
-      Map<String, Map<String, Date>> tableTaskTypeToNextRuntimeMap =
-          _pinotTaskManager.getTableTaskTypeToNextRuntimeMap();
-      Map<String, Map<String, Date>> results = new HashMap<>();
-      for (String table : tableTaskTypeToNextRuntimeMap.keySet()) {
-        if (tableName != null && !table.equalsIgnoreCase(table)) {
-          continue;
-        }
-        Map<String, Date> taskTypeToNextRuntimeMap = tableTaskTypeToNextRuntimeMap.get(table);
-        for (String task : taskTypeToNextRuntimeMap.keySet()) {
-          if (taskType != null && !task.equalsIgnoreCase(taskType)) {
-            continue;
-          }
-          if (!results.containsKey(table)) {
-            results.put(table, new HashMap<>());
-          }
-          results.get(table).put(task, taskTypeToNextRuntimeMap.get(task));
-        }
-      }
-      return results;
-    } catch (SchedulerException e) {
-      throw new RuntimeException(e);
+  @Path("/tasks/scheduler/jobKeys")
+  @ApiOperation("Fetch cron scheduler job keys")
+  public List<JobKey> getCronSchedulerJobKeys()
+      throws SchedulerException {
+    List<JobKey> jobKeys = new ArrayList<>();
+    Scheduler scheduler = _pinotTaskManager.getScheduler();
+    for (String group : scheduler.getTriggerGroupNames()) {
+      jobKeys.addAll(scheduler.getJobKeys(GroupMatcher.groupEquals(group)));
     }
+    return jobKeys;
+  }
+
+  @GET
+  @Path("/tasks/scheduler/jobDetails")
+  @ApiOperation("Fetch cron scheduler job keys")
+  public Map<String, Object> getCronSchedulerJobDetails(
+      @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName,
+      @ApiParam(value = "Task type") @QueryParam("taskType") String taskType)
+      throws SchedulerException {
+    Scheduler scheduler = _pinotTaskManager.getScheduler();
+    JobKey jobKey = JobKey.jobKey(tableName, taskType);
+    if (scheduler.checkExists(jobKey)) {
+      throw new NotFoundException(
+          "Unable to find job detail for table name - " + tableName + ", task type - " + taskType);
+    }
+    JobDetail schedulerJobDetail = scheduler.getJobDetail(jobKey);
+    Map<String, Object> jobDetail = new HashMap<>();
+    jobDetail.put("JobKey", schedulerJobDetail.getKey());
+    jobDetail.put("Description", schedulerJobDetail.getDescription());
+    jobDetail.put("JobClass", schedulerJobDetail.getJobClass());
+    JobDataMap jobData = schedulerJobDetail.getJobDataMap();
+    Map<String, String> jobDataMap = new HashMap<>();
+    for (String key : jobData.getKeys()) {
+      jobDataMap.put(key, jobData.get(key).toString());
+    }
+    jobDetail.put("JobDataMap", jobDataMap);
+    List<? extends Trigger> triggers = scheduler.getTriggersOfJob(jobKey);
+    List<Map> triggerMaps = new ArrayList<>();
+    if (!triggers.isEmpty()) {
+      for (Trigger trigger : triggers) {
+        Map<String, Object> triggerMap = new HashMap<>();
+        if (trigger instanceof SimpleTrigger) {
+          SimpleTrigger simpleTrigger = (SimpleTrigger) trigger;
+          triggerMap.put("TriggerType", SimpleTrigger.class.getSimpleName());
+          triggerMap.put("RepeatInterval", simpleTrigger.getRepeatInterval());
+          triggerMap.put("RepeatCount", simpleTrigger.getRepeatCount());
+          triggerMap.put("TimesTriggered", simpleTrigger.getTimesTriggered());
+        } else if (trigger instanceof CronTrigger) {
+          CronTrigger cronTrigger = (CronTrigger) trigger;
+          triggerMap.put("TriggerType", CronTrigger.class.getSimpleName());
+          triggerMap.put("TimeZone", cronTrigger.getTimeZone());
+          triggerMap.put("CronExpression", cronTrigger.getCronExpression());
+          triggerMap.put("ExpressionSummary", cronTrigger.getExpressionSummary());
+          triggerMap.put("NextFireTime", cronTrigger.getNextFireTime());
+          triggerMap.put("PreviousFireTime", cronTrigger.getPreviousFireTime());
+        }
+        triggerMaps.add(triggerMap);
+      }
+    }
+    jobDetail.put("Triggers", triggerMaps);
+    return jobDetail;
   }
 
   @POST

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -236,7 +236,7 @@ public class PinotTaskRestletResource {
       throws SchedulerException {
     Scheduler scheduler = _pinotTaskManager.getScheduler();
     JobKey jobKey = JobKey.jobKey(tableName, taskType);
-    if (scheduler.checkExists(jobKey)) {
+    if (!scheduler.checkExists(jobKey)) {
       throw new NotFoundException(
           "Unable to find job detail for table name - " + tableName + ", task type - " + taskType);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/CronJobScheduleJob.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import org.apache.pinot.controller.LeadControllerManager;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CronJobScheduleJob implements Job {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CronJobScheduleJob.class);
+
+  public CronJobScheduleJob() {
+  }
+
+  @Override
+  public void execute(JobExecutionContext jobExecutionContext)
+      throws JobExecutionException {
+    PinotTaskManager pinotTaskManager = (PinotTaskManager) jobExecutionContext.getJobDetail().getJobDataMap()
+        .get(PinotTaskManager.PINOT_TASK_MANAGER_KEY);
+    LeadControllerManager leadControllerManager =
+        (LeadControllerManager) jobExecutionContext.getJobDetail().getJobDataMap()
+            .get(PinotTaskManager.LEAD_CONTROLLER_MANAGER_KEY);
+    String table = jobExecutionContext.getJobDetail().getKey().getName();
+    String taskType = jobExecutionContext.getJobDetail().getKey().getGroup();
+    if (leadControllerManager.isLeaderForTable(table)) {
+      LOGGER.info("Execute CronJob: table - {}, task - {} at {}", table, taskType, jobExecutionContext.getFireTime());
+      pinotTaskManager.scheduleTask(taskType, table);
+      LOGGER.info("Finished CronJob: table - {}, task - {}, next runtime is {}", table, taskType,
+          jobExecutionContext.getNextFireTime());
+    } else {
+      LOGGER.info("Not Lead, skip processing CronJob: table - {}, task - {}", table, taskType);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -21,10 +21,13 @@ package org.apache.pinot.controller.helix.core.minion;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -36,6 +39,18 @@ import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorRegi
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +64,21 @@ import org.slf4j.LoggerFactory;
 public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotTaskManager.class);
 
+  public final static String PINOT_TASK_MANAGER_KEY = "PinotTaskManager";
+  public final static String LEAD_CONTROLLER_MANAGER_KEY = "LeadControllerManager";
+  private static final String TABLE_CONFIG_PARENT_PATH = "/CONFIGS/TABLE";
+  private static final String TABLE_CONFIG_PATH_PREFIX = "/CONFIGS/TABLE/";
+
+  private final static String SCHEDULE_KEY = "schedule";
+  private final static String TABLE_TASK_TYPE_SPLIT = "\t\t";
+
   private final PinotHelixTaskResourceManager _helixTaskResourceManager;
   private final ClusterInfoAccessor _clusterInfoAccessor;
   private final TaskGeneratorRegistry _taskGeneratorRegistry;
+  private final Map<String, Map<String, String>> _tableTaskTypeToCronExpressionMap = new ConcurrentHashMap<>();
+  private final Map<String, TableTaskSchedulerUpdater> _tableTaskSchedulerUpdaterMap = new ConcurrentHashMap<>();
+
+  private Scheduler _scheduledExecutorService;
 
   public PinotTaskManager(PinotHelixTaskResourceManager helixTaskResourceManager,
       PinotHelixResourceManager helixResourceManager, LeadControllerManager leadControllerManager,
@@ -62,6 +89,255 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     _helixTaskResourceManager = helixTaskResourceManager;
     _clusterInfoAccessor = new ClusterInfoAccessor(helixResourceManager, helixTaskResourceManager, controllerConf);
     _taskGeneratorRegistry = new TaskGeneratorRegistry(_clusterInfoAccessor);
+    try {
+      _scheduledExecutorService = new StdSchedulerFactory().getScheduler();
+      _scheduledExecutorService.start();
+      LOGGER.info("Subscribe to tables change under PropertyStore path: {}", TABLE_CONFIG_PARENT_PATH);
+      _pinotHelixResourceManager.getPropertyStore()
+          .subscribeChildChanges(TABLE_CONFIG_PARENT_PATH, (parentPath, currentChilds) -> {
+            for (String tableWithType : currentChilds) {
+              subscribeTableConfigChanges(tableWithType);
+            }
+            Set<String> tableToDelete = new HashSet(_tableTaskSchedulerUpdaterMap.keySet());
+            tableToDelete.removeAll(currentChilds);
+            if (!tableToDelete.isEmpty()) {
+              LOGGER.info("Found tables to clean up cron task scheduler: {}", tableToDelete);
+              for (String tableWithType : tableToDelete) {
+                cleanUpCronTaskSchedulerForTable(tableWithType);
+              }
+            }
+          });
+      for (String tableWithType : helixResourceManager.getAllTables()) {
+        subscribeTableConfigChanges(tableWithType);
+      }
+    } catch (SchedulerException e) {
+      LOGGER.error("Unable to create a scheduler.", e);
+      _scheduledExecutorService = null;
+    }
+  }
+
+  private String getPropertyStorePathForTable(String tableWithType) {
+    return TABLE_CONFIG_PATH_PREFIX + tableWithType;
+  }
+
+  protected synchronized void cleanupCronTaskScheduler() {
+    try {
+      _scheduledExecutorService.clear();
+    } catch (SchedulerException e) {
+      LOGGER.error("Failed to clear all tasks in scheduler", e);
+    }
+  }
+
+  public synchronized void cleanUpCronTaskSchedulerForTable(String tableWithType) {
+    LOGGER.info("Cleaning up task in scheduler for table {}", tableWithType);
+    TableTaskSchedulerUpdater tableTaskSchedulerUpdater = _tableTaskSchedulerUpdaterMap.get(tableWithType);
+    _pinotHelixResourceManager.getPropertyStore()
+        .unsubscribeDataChanges(getPropertyStorePathForTable(tableWithType), tableTaskSchedulerUpdater);
+    for (String taskType : _tableTaskTypeToCronExpressionMap.get(tableWithType).keySet()) {
+      try {
+        _scheduledExecutorService.deleteJob(JobKey.jobKey(tableWithType, taskType));
+      } catch (SchedulerException e) {
+        LOGGER.error("Failed to delete job for table {}, task type {}", tableWithType, taskType, e);
+      }
+    }
+    _tableTaskSchedulerUpdaterMap.remove(tableWithType);
+  }
+
+  public synchronized void subscribeTableConfigChanges(String tableWithType) {
+    if (_tableTaskSchedulerUpdaterMap.containsKey(tableWithType)) {
+      return;
+    }
+    TableTaskSchedulerUpdater tableTaskSchedulerUpdater = new TableTaskSchedulerUpdater(tableWithType, this);
+    _pinotHelixResourceManager.getPropertyStore()
+        .subscribeDataChanges(getPropertyStorePathForTable(tableWithType), tableTaskSchedulerUpdater);
+    _tableTaskSchedulerUpdaterMap.put(tableWithType, tableTaskSchedulerUpdater);
+    LOGGER.info("Trying to update task schedule for table: {}", tableWithType);
+    try {
+      updateCronTaskScheduler(tableWithType);
+    } catch (Exception e) {
+      LOGGER.error("Got exception during updateCronTaskScheduler for {}", tableWithType, e);
+    }
+  }
+
+  public synchronized void updateCronTaskScheduler(String tableWithType) {
+    if (_scheduledExecutorService == null) {
+      return;
+    }
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableWithType);
+    TableTaskConfig taskConfig = tableConfig.getTaskConfig();
+    if (taskConfig == null) {
+      LOGGER.info("taskConfig is null, trying to remove all the tasks for table {} if any", tableWithType);
+      removeAllTasksFromCronExpressions(tableWithType);
+      return;
+    }
+    Map<String, Map<String, String>> taskTypeConfigsMap = taskConfig.getTaskTypeConfigsMap();
+    if (taskTypeConfigsMap == null) {
+      LOGGER.info("taskTypeConfigsMap is null, trying to remove all the tasks for table {} if any", tableWithType);
+      removeAllTasksFromCronExpressions(tableWithType);
+      return;
+    }
+    Map<String, String> taskToCronExpressionMap = getTaskToCronExpressionMap(taskTypeConfigsMap);
+    LOGGER.info("Got taskToCronExpressionMap {} ", taskToCronExpressionMap);
+    updateCronTaskScheduler(tableWithType, taskToCronExpressionMap);
+  }
+
+  private void updateCronTaskScheduler(String tableWithType, Map<String, String> taskToCronExpressionMap) {
+    if (_scheduledExecutorService == null) {
+      return;
+    }
+    if (_tableTaskTypeToCronExpressionMap.containsKey(tableWithType)) {
+      Map<String, String> existingScheduledTasks = _tableTaskTypeToCronExpressionMap.get(tableWithType);
+      for (String existingTaskType : existingScheduledTasks.keySet()) {
+        // Task should be removed
+        if (!taskToCronExpressionMap.containsKey(existingTaskType)) {
+          try {
+            _scheduledExecutorService.deleteJob(JobKey.jobKey(tableWithType, existingTaskType));
+          } catch (SchedulerException e) {
+            LOGGER.error("Failed to delete scheduled job for table {}, task type {}", tableWithType,
+                existingScheduledTasks, e);
+          }
+          continue;
+        }
+        String existingCronExpression = existingScheduledTasks.get(existingTaskType);
+        String newCronExpression = taskToCronExpressionMap.get(existingTaskType);
+        // Schedule new job
+        if (existingCronExpression == null) {
+          try {
+            scheduleJob(tableWithType, existingTaskType, newCronExpression);
+          } catch (SchedulerException e) {
+            LOGGER.error("Failed to schedule cron task for table {}, task {}, cron expr {}", tableWithType,
+                existingTaskType, newCronExpression, e);
+          }
+          continue;
+        }
+        // Update existing task with new cron expr
+        if (!existingCronExpression.equalsIgnoreCase(newCronExpression)) {
+          try {
+            TriggerKey triggerKey = TriggerKey.triggerKey(tableWithType, existingTaskType);
+            Trigger trigger = TriggerBuilder.newTrigger().withIdentity(triggerKey)
+                .withSchedule(CronScheduleBuilder.cronSchedule(newCronExpression)).build();
+            _scheduledExecutorService.rescheduleJob(triggerKey, trigger);
+          } catch (SchedulerException e) {
+            LOGGER.error("Failed to delete scheduled job for table {}, task type {}", tableWithType,
+                existingScheduledTasks, e);
+          }
+          continue;
+        }
+      }
+    } else {
+      for (String taskType : taskToCronExpressionMap.keySet()) {
+        // Schedule new job
+        String cronExpr = taskToCronExpressionMap.get(taskType);
+        try {
+          scheduleJob(tableWithType, taskType, cronExpr);
+        } catch (SchedulerException e) {
+          LOGGER.error("Failed to schedule cron task for table {}, task {}, cron expr {}", tableWithType, taskType,
+              cronExpr, e);
+        }
+      }
+    }
+    _tableTaskTypeToCronExpressionMap.put(tableWithType, taskToCronExpressionMap);
+  }
+
+  private void scheduleJob(String tableWithType, String taskType, String cronExprStr)
+      throws SchedulerException {
+    if (_scheduledExecutorService == null) {
+      return;
+    }
+    boolean exists = false;
+    try {
+      exists = _scheduledExecutorService.checkExists(JobKey.jobKey(tableWithType, taskType));
+    } catch (SchedulerException e) {
+      LOGGER.error("Failed to check job existence for job key - table: {}, task: {} ", tableWithType, taskType, e);
+    }
+    if (!exists) {
+      LOGGER
+          .info("Trying to put cron expression: {} for table {}, task type: {}", cronExprStr, tableWithType, taskType);
+      Trigger trigger = TriggerBuilder.newTrigger().withIdentity(TriggerKey.triggerKey(tableWithType, taskType))
+          .withSchedule(CronScheduleBuilder.cronSchedule(cronExprStr)).build();
+      JobDataMap jobDataMap = new JobDataMap();
+      jobDataMap.put(PINOT_TASK_MANAGER_KEY, this);
+      jobDataMap.put(LEAD_CONTROLLER_MANAGER_KEY, this._leadControllerManager);
+      JobDetail jobDetail =
+          JobBuilder.newJob(CronJobScheduleJob.class).withIdentity(tableWithType, taskType).setJobData(jobDataMap)
+              .build();
+      try {
+        _scheduledExecutorService.scheduleJob(jobDetail, trigger);
+      } catch (Exception e) {
+        LOGGER.error("Failed to parse Cron expression - " + cronExprStr, e);
+        throw e;
+      }
+      Date nextRuntime = trigger.getNextFireTime();
+      LOGGER
+          .info("Scheduled task for table: {}, task type: {}, next runtime: {}", tableWithType, taskType, nextRuntime);
+    }
+  }
+
+  private Map<String, String> getTaskToCronExpressionMap(Map<String, Map<String, String>> taskTypeConfigsMap) {
+    Map<String, String> taskToCronExpressionMap = new HashMap<>();
+    for (String taskType : taskTypeConfigsMap.keySet()) {
+      Map<String, String> taskTypeConfig = taskTypeConfigsMap.get(taskType);
+      if (taskTypeConfig == null || !taskTypeConfig.containsKey(SCHEDULE_KEY)) {
+        continue;
+      }
+      String cronExprStr = taskTypeConfig.get(SCHEDULE_KEY);
+      if (cronExprStr == null) {
+        continue;
+      }
+      taskToCronExpressionMap.put(taskType, cronExprStr);
+    }
+    return taskToCronExpressionMap;
+  }
+
+  private void removeAllTasksFromCronExpressions(String tableWithType) {
+    Map<String, String> toRemove = _tableTaskTypeToCronExpressionMap.remove(tableWithType);
+    if (toRemove == null) {
+      return;
+    }
+    for (String taskType : toRemove.keySet()) {
+      try {
+        _scheduledExecutorService.deleteJob(JobKey.jobKey(tableWithType, taskType));
+      } catch (SchedulerException e) {
+        LOGGER.error("Got exception when deleting the scheduled job - table {}, task type {}", tableWithType, taskType,
+            e);
+      }
+    }
+  }
+
+  public Map<String, Map<String, Date>> getTableTaskTypeToNextRuntimeMap()
+      throws SchedulerException {
+    Map<String, Map<String, Date>> tableTaskTypeToNextRuntimeMap = new HashMap<>();
+    for (String table : _tableTaskTypeToCronExpressionMap.keySet()) {
+      for (String taskType : _tableTaskTypeToCronExpressionMap.get(table).keySet()) {
+        TriggerKey triggerKey = TriggerKey.triggerKey(table, taskType);
+        Trigger trigger = _scheduledExecutorService.getTrigger(triggerKey);
+        if (trigger == null || trigger.getJobKey() == null) {
+          continue;
+        }
+        Date nextFireTime = trigger.getNextFireTime();
+        if (!tableTaskTypeToNextRuntimeMap.containsKey(table)) {
+          tableTaskTypeToNextRuntimeMap.put(table, new HashMap<>());
+        }
+        tableTaskTypeToNextRuntimeMap.get(table).put(taskType, nextFireTime);
+      }
+    }
+    return tableTaskTypeToNextRuntimeMap;
+  }
+
+  public Map<String, Map<String, String>> getTableTaskTypeToCronExpressionMap() {
+    return _tableTaskTypeToCronExpressionMap;
+  }
+
+  public static String getTableTaskType(String tableWithType, String taskType) {
+    return tableWithType + TABLE_TASK_TYPE_SPLIT + taskType;
+  }
+
+  public static String getTableNameFromTableTaskType(String tableTaskType) {
+    return tableTaskType.split(TABLE_TASK_TYPE_SPLIT, 2)[0];
+  }
+
+  public static String getTaskTypeFromTableTaskType(String tableTaskType) {
+    return tableTaskType.split(TABLE_TASK_TYPE_SPLIT, 2)[1];
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -304,42 +304,6 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     }
   }
 
-  public Map<String, Map<String, Date>> getTableTaskTypeToNextRuntimeMap()
-      throws SchedulerException {
-    Map<String, Map<String, Date>> tableTaskTypeToNextRuntimeMap = new HashMap<>();
-    for (String table : _tableTaskTypeToCronExpressionMap.keySet()) {
-      for (String taskType : _tableTaskTypeToCronExpressionMap.get(table).keySet()) {
-        TriggerKey triggerKey = TriggerKey.triggerKey(table, taskType);
-        Trigger trigger = _scheduledExecutorService.getTrigger(triggerKey);
-        if (trigger == null || trigger.getJobKey() == null) {
-          continue;
-        }
-        Date nextFireTime = trigger.getNextFireTime();
-        if (!tableTaskTypeToNextRuntimeMap.containsKey(table)) {
-          tableTaskTypeToNextRuntimeMap.put(table, new HashMap<>());
-        }
-        tableTaskTypeToNextRuntimeMap.get(table).put(taskType, nextFireTime);
-      }
-    }
-    return tableTaskTypeToNextRuntimeMap;
-  }
-
-  public Map<String, Map<String, String>> getTableTaskTypeToCronExpressionMap() {
-    return _tableTaskTypeToCronExpressionMap;
-  }
-
-  public static String getTableTaskType(String tableWithType, String taskType) {
-    return tableWithType + TABLE_TASK_TYPE_SPLIT + taskType;
-  }
-
-  public static String getTableNameFromTableTaskType(String tableTaskType) {
-    return tableTaskType.split(TABLE_TASK_TYPE_SPLIT, 2)[0];
-  }
-
-  public static String getTaskTypeFromTableTaskType(String tableTaskType) {
-    return tableTaskType.split(TABLE_TASK_TYPE_SPLIT, 2)[1];
-  }
-
   /**
    * Returns the cluster info accessor.
    * <p>Cluster info accessor can be used to initialize the task generator.
@@ -491,5 +455,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
       _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
     }
+  }
+
+  public Scheduler getScheduler() {
+    return _scheduledExecutorService;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TableTaskSchedulerUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TableTaskSchedulerUpdater.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import org.I0Itec.zkclient.IZkDataListener;
+
+
+public class TableTaskSchedulerUpdater implements IZkDataListener {
+  private final String _tableWithType;
+  private final PinotTaskManager _pinotTaskManager;
+
+  public TableTaskSchedulerUpdater(String tableWithType, PinotTaskManager pinotTaskManager) {
+    _tableWithType = tableWithType;
+    _pinotTaskManager = pinotTaskManager;
+  }
+
+  @Override
+  public void handleDataChange(String dataPath, Object data)
+      throws Exception {
+    _pinotTaskManager.updateCronTaskScheduler(_tableWithType);
+  }
+
+  @Override
+  public void handleDataDeleted(String dataPath)
+      throws Exception {
+    _pinotTaskManager.cleanUpCronTaskSchedulerForTable(_tableWithType);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TableTaskSchedulerUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TableTaskSchedulerUpdater.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.controller.helix.core.minion;
 
 import org.I0Itec.zkclient.IZkDataListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class TableTaskSchedulerUpdater implements IZkDataListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableTaskSchedulerUpdater.class);
   private final String _tableWithType;
   private final PinotTaskManager _pinotTaskManager;
 
@@ -33,12 +36,22 @@ public class TableTaskSchedulerUpdater implements IZkDataListener {
   @Override
   public void handleDataChange(String dataPath, Object data)
       throws Exception {
-    _pinotTaskManager.updateCronTaskScheduler(_tableWithType);
+    try {
+      _pinotTaskManager.updateCronTaskScheduler(_tableWithType);
+    } catch (Exception e) {
+      LOGGER.error("Failed to update cron task scheduler for table {}", _tableWithType, e);
+      throw e;
+    }
   }
 
   @Override
   public void handleDataDeleted(String dataPath)
       throws Exception {
-    _pinotTaskManager.cleanUpCronTaskSchedulerForTable(_tableWithType);
+    try {
+      _pinotTaskManager.cleanUpCronTaskSchedulerForTable(_tableWithType);
+    } catch (Exception e) {
+      LOGGER.error("Failed to delete cron task scheduler for table {}", _tableWithType, e);
+      throw e;
+    }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class PinotTaskManagerTest extends ControllerTest {
+
+  private static final String RAW_TABLE_NAME = "myTable";
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    startZk();
+    startController();
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addSingleValueDimension("myMap", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("myMapStr", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("complexMapStr", FieldSpec.DataType.STRING).build();
+    addSchema(schema);
+  }
+
+  @Test
+  public void testPinotTaskManagerSchedulerWithUpdate()
+      throws Exception {
+    PinotTaskManager taskManager = _controllerStarter.getTaskManager();
+    Scheduler scheduler = taskManager.getScheduler();
+    Assert.assertNotNull(scheduler);
+
+    // 1. Add Table
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTaskConfig(
+        new TableTaskConfig(
+            ImmutableMap.of("SegmentGenerationAndPushTask", ImmutableMap.of("schedule", "0 */10 * ? * * *")))).build();
+    addTableConfig(tableConfig);
+    Thread.sleep(2000);
+    List<String> jobGroupNames = scheduler.getJobGroupNames();
+    Assert.assertEquals(jobGroupNames.size(), 1);
+    for (String group : jobGroupNames) {
+      Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.groupEquals(group));
+      for (JobKey jobKey : jobKeys) {
+        JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        Assert.assertEquals(jobDetail.getJobClass(), CronJobScheduleJob.class);
+        Assert.assertEquals(jobDetail.getKey().getName(), RAW_TABLE_NAME + "_OFFLINE");
+        Assert.assertEquals(jobDetail.getKey().getGroup(), MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE);
+        Assert.assertEquals(jobDetail.getJobDataMap().get("PinotTaskManager"), taskManager);
+        Assert.assertEquals(jobDetail.getJobDataMap().get("LeadControllerManager"),
+            _controllerStarter.getLeadControllerManager());
+        List<? extends Trigger> triggersOfJob = scheduler.getTriggersOfJob(jobKey);
+        Assert.assertEquals(triggersOfJob.size(), 1);
+        for (Trigger trigger : triggersOfJob) {
+          Assert.assertTrue(trigger instanceof CronTrigger);
+          Assert.assertEquals(((CronTrigger) trigger).getCronExpression(), "0 */10 * ? * * *");
+        }
+      }
+    }
+
+    // 2. Update table to new schedule
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTaskConfig(
+        new TableTaskConfig(
+            ImmutableMap.of("SegmentGenerationAndPushTask", ImmutableMap.of("schedule", "0 */20 * ? * * *")))).build();
+    updateTableConfig(tableConfig);
+    Thread.sleep(2000);
+    jobGroupNames = scheduler.getJobGroupNames();
+    Assert.assertEquals(jobGroupNames.size(), 1);
+    for (String group : jobGroupNames) {
+      Set<JobKey> jobKeys = scheduler.getJobKeys(GroupMatcher.groupEquals(group));
+      for (JobKey jobKey : jobKeys) {
+        JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        Assert.assertEquals(jobDetail.getJobClass(), CronJobScheduleJob.class);
+        Assert.assertEquals(jobDetail.getKey().getName(), RAW_TABLE_NAME + "_OFFLINE");
+        Assert.assertEquals(jobDetail.getKey().getGroup(), MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE);
+        Assert.assertEquals(jobDetail.getJobDataMap().get("PinotTaskManager"), taskManager);
+        Assert.assertEquals(jobDetail.getJobDataMap().get("LeadControllerManager"),
+            _controllerStarter.getLeadControllerManager());
+        List<? extends Trigger> triggersOfJob = scheduler.getTriggersOfJob(jobKey);
+        Assert.assertEquals(triggersOfJob.size(), 1);
+        for (Trigger trigger : triggersOfJob) {
+          Assert.assertTrue(trigger instanceof CronTrigger);
+          Assert.assertEquals(((CronTrigger) trigger).getCronExpression(), "0 */20 * ? * * *");
+        }
+      }
+    }
+    // 3. Drop table
+    dropOfflineTable(RAW_TABLE_NAME);
+    jobGroupNames = scheduler.getJobGroupNames();
+    Assert.assertTrue(jobGroupNames.isEmpty());
+  }
+
+  @AfterClass
+  public void teardown() {
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -322,7 +322,9 @@ public class GcsPinotFS  extends PinotFS {
               }
             }
           });
-      return builder.build().toArray(new String[0]);
+      String[] listedFiles = builder.build().toArray(new String[0]);
+      LOGGER.info("Listed {} files from URI: {}, is recursive: {}", listedFiles.length, fileUri, recursive);
+      return listedFiles;
     } catch (Throwable t) {
       throw new IOException(t);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
     <scala.version>2.11.11</scala.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.4.0</jsonpath.version>
+    <quartz.version>2.3.0</quartz.version>
     <calcite.version>1.19.0</calcite.version>
     <lucene.version>8.2.0</lucene.version>
     <reflections.version>0.9.11</reflections.version>
@@ -509,6 +510,11 @@
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
         <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.quartz-scheduler</groupId>
+        <artifactId>quartz</artifactId>
+        <version>${quartz.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>


### PR DESCRIPTION
## Description
- Adding a CRON scheduler in PinotTaskManager.
- Adding support in task config to let controller schedule the job based on CRON expression.
- Adding controller API to read cron expression and next runtime:

```
/tasks/scheduler/information
/tasks/scheduler/jobKeys
/tasks/scheduler/jobDetails
```

Sample API calls:
```
curl -X GET "http://localhost:9000/tasks/scheduler/information" -H "accept: application/json" |jq .
{
  "getThreadPoolSize": 10,
  "Version": "2.3.0",
  "SchedulerInstanceId": "NON_CLUSTERED",
  "getThreadPoolClass": "org.quartz.simpl.SimpleThreadPool",
  "Clustered": false,
  "RunningSince": 1610965118837,
  "SchedulerName": "DefaultQuartzScheduler",
  "SchedulerClass": "org.quartz.impl.StdScheduler",
  "NumberOfJobsExecuted": 10,
  "InStandbyMode": false,
  "JobStoreClass": "org.quartz.simpl.RAMJobStore",
  "JobDetails": [
    {
      "JobKey": {
        "name": "githubEvents_OFFLINE",
        "group": "SegmentGenerationAndPushTask"
      },
      "NextFireTime": 1610965680000,
      "PreviousFireTime": 1610965620000
    }
  ]
}
```
```
curl -X GET "http://localhost:9000/tasks/scheduler/jobKeys" -H "accept: application/json" |jq .
[
  {
    "name": "githubEvents_OFFLINE",
    "group": "SegmentGenerationAndPushTask"
  }
]
```
```
➜ curl -X GET  "http://localhost:9000/tasks/scheduler/jobDetails?tableName=githubEvents_OFFLINE&&taskType=SegmentGenerationAndPushTask"  -H "accept: application/json" |jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   729  100   729    0     0  60750      0 --:--:-- --:--:-- --:--:-- 60750
{
  "JobKey": {
    "name": "githubEvents_OFFLINE",
    "group": "SegmentGenerationAndPushTask"
  },
  "JobDataMap": {
    "LeadControllerManager": "org.apache.pinot.controller.LeadControllerManager@343dbb83",
    "PinotTaskManager": "Task: PinotTaskManager, Interval: -1s, Initial Delay: 271s"
  },
  "Description": null,
  "JobClass": "org.apache.pinot.controller.helix.core.minion.CronJobScheduleJob",
  "Triggers": [
    {
      "TriggerType": "CronTrigger",
      "TimeZone": "America/Los_Angeles",
      "CronExpression": "0/30 * * ? * * *",
      "ExpressionSummary": "seconds: 0,30\nminutes: *\nhours: *\ndaysOfMonth: ?\nmonths: *\ndaysOfWeek: *\nlastdayOfWeek: false\nnearestWeekday: false\nNthDayOfWeek: 0\nlastdayOfMonth: false\nyears: *\n",
      "NextFireTime": 1610966640000,
      "PreviousFireTime": 1610966610000
    }
  ]
}
```
Sample config:
```
{
    "tableName": "githubEvents",
    "tableType": "OFFLINE",
    "segmentsConfig": {
        "segmentPushType": "APPEND",
        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
        "schemaName": "githubEvents",
        "replication": "1",
        "timeColumnName": "event_time",
        "timeType": "MILLISECONDS"
    },
    "tenants": {},
    "tableIndexConfig": {
        "starTreeIndexConfigs": [
            {
                "dimensionsSplitOrder": [
                    "type",
                    "repo_id"
                ],
                "skipStarNodeCreationForDimensions": [],
                "functionColumnPairs": [
                    "SUM__pull_request_additions",
                    "SUM__pull_request_deletions",
                    "SUM__pull_request_changed_files",
                    "COUNT__star",
                    "DISTINCT_COUNT_HLL__actor_id"
                ],
                "maxLeafRecords": 1000
            }
        ],
        "enableDynamicStarTreeCreation": true,
        "loadMode": "MMAP",
        "invertedIndexColumns": [],
        "segmentPartitionConfig": {
            "columnPartitionMap": {
                "repo_id": {
                    "functionName": "Murmur",
                    "numPartitions": 1024
                }
            }
        },
        "noDictionaryColumns": []
    },
    "routing": {
        "segmentPrunerTypes": [
            "partition"
        ]
    },
    "metadata": {
        "customConfigs": {}
    },
    "ingestionConfig": {
        "batchIngestionConfig": {
            "segmentIngestionType": "APPEND",
            "segmentIngestionFrequency": "DAILY",
            "batchConfigMaps":[
            {
              "inputDirURI": "s3://my-data/github_flatten/partitioned_by_date/yyyy=2016/mm=1/dd=1/",
              "inputFormat": "parquet",
              "includeFileNamePattern": "glob:**/*.parquet",
              "input.fs.className": "org.apache.pinot.plugin.filesystem.S3PinotFS",
              "input.fs.prop.region": "us-west-2"
            }],
            "segmentNameSpec": {},
            "pushSpec": {}
        },
        "transformConfigs": [
            {
                "columnName": "event_time",
                "transformFunction": "fromDateTime(created_at, \"yyyy-MM-dd'T'HH:mm:ssZ\")"
            }
        ]
    },
    "task": {
        "taskTypeConfigsMap": {
            "SegmentGenerationAndPushTask": {
              "schedule" : "0 * * ? * * *"
        }
      }
    }
}
```
