### PR TITLE
Always store raw table name in segment metadata

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metadata.ZKMetadata;
 import org.apache.pinot.common.utils.CommonConstants.Segment;
 import org.apache.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private Map<String, String> _customMap;
 
   @Deprecated
-  private String _tableName;
+  private String _rawTableName;
 
   public SegmentZKMetadata() {
   }
@@ -88,7 +89,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _customMap = znRecord.getMapField(Segment.CUSTOM_MAP);
 
     // For backward-compatibility
-    _tableName = znRecord.getSimpleField(Segment.TABLE_NAME);
+    setTableName(znRecord.getSimpleField(Segment.TABLE_NAME));
   }
 
   public String getSegmentName() {
@@ -201,12 +202,12 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
 
   @Deprecated
   public String getTableName() {
-    return _tableName;
+    return _rawTableName;
   }
 
   @Deprecated
   public void setTableName(String tableName) {
-    _tableName = tableName;
+    _rawTableName = tableName != null ? TableNameBuilder.extractRawTableName(tableName) : null;
   }
 
   @Deprecated
@@ -253,13 +254,13 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
         && _segmentType == that._segmentType && _timeUnit == that._timeUnit && Objects
         .equals(_indexVersion, that._indexVersion) && Objects.equals(_partitionMetadata, that._partitionMetadata)
         && Objects.equals(_crypterName, that._crypterName) && Objects.equals(_customMap, that._customMap) && Objects
-        .equals(_tableName, that._tableName);
+        .equals(_rawTableName, that._rawTableName);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(_segmentName, _segmentType, _startTime, _endTime, _timeUnit, _indexVersion, _totalDocs, _crc,
-        _creationTime, _partitionMetadata, _segmentUploadStartTime, _crypterName, _customMap, _tableName);
+        _creationTime, _partitionMetadata, _segmentUploadStartTime, _crypterName, _customMap, _rawTableName);
   }
 
   @Override
@@ -297,8 +298,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
 
     // For backward-compatibility
-    if (_tableName != null) {
-      znRecord.setSimpleField(Segment.TABLE_NAME, _tableName);
+    if (_rawTableName != null) {
+      znRecord.setSimpleField(Segment.TABLE_NAME, _rawTableName);
     }
 
     return znRecord;
@@ -342,8 +343,8 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     }
 
     // For backward-compatibility
-    if (_tableName != null) {
-      configMap.put(Segment.TABLE_NAME, _tableName);
+    if (_rawTableName != null) {
+      configMap.put(Segment.TABLE_NAME, _rawTableName);
     }
 
     return configMap;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -241,7 +241,7 @@ public class PinotSegmentUploadDownloadRestletResource {
         LOGGER.info("Uploading a segment {} to table: {}, push type {}, (Derived from API parameter)", segmentName, tableName, uploadType);
       } else {
         // TODO: remove this when we completely deprecate the table name from segment metadata
-        rawTableName = TableNameBuilder.extractRawTableName(segmentMetadata.getTableName());
+        rawTableName = segmentMetadata.getTableName();
         LOGGER.info("Uploading a segment {} to table: {}, push type {}, (Derived from segment metadata)", segmentName, tableName, uploadType);
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -76,8 +76,8 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
   private static final String REALTIME_TABLE_CONFIG_PROPERTY_STORE_PATH_PATTERN = ".*/TABLE/.*REALTIME";
   private static final String CONTROLLER_LEADER_CHANGE = "CONTROLLER LEADER CHANGE";
 
-  private String _propertyStorePath;
-  private String _tableConfigPath;
+  private final String _propertyStorePath;
+  private final String _tableConfigPath;
   private final PinotHelixResourceManager _pinotHelixResourceManager;
   private ZkClient _zkClient;
   private ControllerMetrics _controllerMetrics;
@@ -248,7 +248,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
           // No, add it
           // Create the realtime segment metadata
           RealtimeSegmentZKMetadata realtimeSegmentMetadataToAdd = new RealtimeSegmentZKMetadata();
-          realtimeSegmentMetadataToAdd.setTableName(TableNameBuilder.extractRawTableName(resourceName));
+          realtimeSegmentMetadataToAdd.setTableName(resourceName);
           realtimeSegmentMetadataToAdd.setSegmentType(SegmentType.REALTIME);
           realtimeSegmentMetadataToAdd.setStatus(Status.IN_PROGRESS);
           realtimeSegmentMetadataToAdd.setSegmentName(segmentId);
@@ -335,8 +335,8 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         String znRecordId = tableConfigZnRecord.getId();
         if (TableNameBuilder.getTableTypeFromTableName(znRecordId) == TableType.REALTIME) {
           TableConfig tableConfig = TableConfigUtils.fromZNRecord(tableConfigZnRecord);
-          StreamConfig metadata = new StreamConfig(tableConfig.getTableName(),
-              IngestionConfigUtils.getStreamConfigMap(tableConfig));
+          StreamConfig metadata =
+              new StreamConfig(tableConfig.getTableName(), IngestionConfigUtils.getStreamConfigMap(tableConfig));
           if (metadata.hasHighLevelConsumerType()) {
             String realtimeTable = tableConfig.getTableName();
             String realtimeSegmentsPathForTable = _propertyStorePath + SEGMENTS_PATH + "/" + realtimeTable;

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -51,6 +51,7 @@ import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +82,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private FileFormat _format = FileFormat.AVRO;
   private String _recordReaderPath = null; //TODO: this should be renamed to recordReaderClass or even better removed
   private String _outDir = null;
-  private String _tableName = null;
+  private String _rawTableName = null;
   private String _segmentName = null;
   private String _segmentNamePostfix = null;
   private String _segmentTimeColumnName = null;
@@ -127,6 +128,7 @@ public class SegmentGeneratorConfig implements Serializable {
     setSchema(schema);
 
     _tableConfig = tableConfig;
+    setTableName(tableConfig.getTableName());
 
     // NOTE: SegmentGeneratorConfig#setSchema doesn't set the time column anymore. timeColumnName is expected to be read from table config.
     String timeColumnName = null;
@@ -436,11 +438,11 @@ public class SegmentGeneratorConfig implements Serializable {
   }
 
   public String getTableName() {
-    return _tableName;
+    return _rawTableName;
   }
 
   public void setTableName(String tableName) {
-    _tableName = tableName;
+    _rawTableName = tableName != null ? TableNameBuilder.extractRawTableName(tableName) : null;
   }
 
   public String getSegmentName() {
@@ -587,7 +589,7 @@ public class SegmentGeneratorConfig implements Serializable {
     if (_segmentName != null) {
       return new FixedSegmentNameGenerator(_segmentName);
     }
-    return new SimpleSegmentNameGenerator(_tableName, _segmentNamePostfix);
+    return new SimpleSegmentNameGenerator(_rawTableName, _segmentNamePostfix);
   }
 
   public void setSegmentNameGenerator(SegmentNameGenerator segmentNameGenerator) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadata.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadata.java
@@ -33,6 +33,10 @@ import org.joda.time.Interval;
 @InterfaceAudience.Private
 public interface SegmentMetadata {
 
+  /**
+   * Returns the raw table name (without the type suffix).
+   */
+  @Deprecated
   String getTableName();
 
   String getTimeColumn();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/metadata/SegmentMetadataImpl.java
@@ -18,20 +18,10 @@
  */
 package org.apache.pinot.core.segment.index.metadata;
 
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.DATETIME_COLUMNS;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.DIMENSIONS;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.METRICS;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_CREATOR_VERSION;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_END_TIME;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_NAME;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_START_TIME;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_TOTAL_DOCS;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.SEGMENT_VERSION;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TABLE_NAME;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_COLUMN_NAME;
-import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_UNIT;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,9 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
-
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -66,16 +54,14 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Preconditions;
+import static org.apache.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.*;
 
 
 public class SegmentMetadataImpl implements SegmentMetadata {
@@ -83,7 +69,6 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
   private final File _indexDir;
   private final Map<String, ColumnMetadata> _columnMetadataMap;
-  private String _tableName;
   private String _segmentName;
   private final Set<String> _allColumns;
   private final Schema _schema;
@@ -107,6 +92,9 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   private long _segmentStartTime;
   private long _segmentEndTime;
   private Map<String, String> _customMap;
+
+  @Deprecated
+  private String _rawTableName;
 
   /**
    * For segments on disk.
@@ -159,7 +147,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     _creationTime = segmentMetadata.getCreationTime();
     setTimeInfo(segmentMetadataPropertiesConfiguration);
     _columnMetadataMap = null;
-    _tableName = segmentMetadata.getTableName();
+    _rawTableName = segmentMetadata.getTableName();
     _segmentName = segmentMetadata.getSegmentName();
     _allColumns = schema.getColumnNames();
     _schema = schema;
@@ -170,7 +158,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   public static PropertiesConfiguration getPropertiesConfiguration(File indexDir) {
     File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
     Preconditions.checkNotNull(metadataFile, "Cannot find segment metadata file under directory: %s", indexDir);
-    
+
     return CommonsConfigurationUtils.fromFile(metadataFile);
   }
 
@@ -244,8 +232,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     addPhysicalColumns(segmentMetadataPropertiesConfiguration.getList(TIME_COLUMN_NAME), _allColumns);
     addPhysicalColumns(segmentMetadataPropertiesConfiguration.getList(DATETIME_COLUMNS), _allColumns);
 
-    //set the table name
-    _tableName = segmentMetadataPropertiesConfiguration.getString(TABLE_NAME);
+    // Set the table name (for backward compatibility)
+    String tableName = segmentMetadataPropertiesConfiguration.getString(TABLE_NAME);
+    if (tableName != null) {
+      _rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    }
 
     // Set segment name.
     _segmentName = segmentMetadataPropertiesConfiguration.getString(SEGMENT_NAME);
@@ -273,8 +264,10 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     setCustomConfigs(segmentMetadataPropertiesConfiguration, _customMap);
   }
 
-  private static void setCustomConfigs(Configuration segmentMetadataPropertiesConfiguration, Map<String, String> customConfigsMap) {
-    Configuration customConfigs = segmentMetadataPropertiesConfiguration.subset(V1Constants.MetadataKeys.Segment.CUSTOM_SUBSET);
+  private static void setCustomConfigs(Configuration segmentMetadataPropertiesConfiguration,
+      Map<String, String> customConfigsMap) {
+    Configuration customConfigs =
+        segmentMetadataPropertiesConfiguration.subset(V1Constants.MetadataKeys.Segment.CUSTOM_SUBSET);
     Iterator<String> customKeysIter = customConfigs.getKeys();
     while (customKeysIter.hasNext()) {
       String key = customKeysIter.next();
@@ -304,7 +297,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
   @Override
   public String getTableName() {
-    return _tableName;
+    return _rawTableName;
   }
 
   @Override

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/io/PinotOutputFormat.java
@@ -32,7 +32,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 /**
@@ -84,7 +83,7 @@ public class PinotOutputFormat<T> extends FileOutputFormat<NullWritable, T> {
     Schema schema = getSchema(job);
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setOutDir(getTempSegmentDir(job) + "/segmentDir");
-    segmentGeneratorConfig.setTableName(TableNameBuilder.extractRawTableName(tableConfig.getTableName()));
+    segmentGeneratorConfig.setTableName(tableConfig.getTableName());
     segmentGeneratorConfig.setFormat(FileFormat.JSON);
     return segmentGeneratorConfig;
   }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -124,8 +124,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(jsonResponse.get("columns").size(), 0);
 
     jsonResponse = JsonUtils.stringToJsonNode(
-        _webTarget.path(segmentMetadataPath)
-            .queryParam("columns", "column1").queryParam("columns", "column2").request()
+        _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2").request()
             .get(String.class));
     Assert.assertEquals(jsonResponse.get("columns").size(), 2);
 
@@ -195,7 +194,7 @@ public class TablesResourceTest extends BaseResourceTest {
     File segmentFile = response.readEntity(File.class);
 
     File tempMetadataDir = new File(FileUtils.getTempDirectory(), "segment_metadata");
-    Assert.assertTrue(tempMetadataDir.mkdirs());
+    FileUtils.forceMkdir(tempMetadataDir);
 
     // Extract metadata.properties
     TarGzCompressionUtils.untarOneFile(segmentFile, V1Constants.MetadataKeys.METADATA_FILE_NAME,
@@ -207,13 +206,14 @@ public class TablesResourceTest extends BaseResourceTest {
 
     // Load segment metadata
     SegmentMetadataImpl metadata = new SegmentMetadataImpl(tempMetadataDir);
-    Assert.assertEquals(tableNameWithType, metadata.getTableName());
+    Assert.assertEquals(metadata.getTableName(), TableNameBuilder.extractRawTableName(tableNameWithType));
 
     FileUtils.forceDelete(tempMetadataDir);
   }
 
   @Test
-  public void testOfflineTableSegmentMetadata() throws Exception {
+  public void testOfflineTableSegmentMetadata()
+      throws Exception {
     IndexSegment defaultSegment = _offlineIndexSegments.get(0);
     String segmentMetadataPath =
         "/tables/" + TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME) + "/segments/" + defaultSegment
@@ -238,10 +238,8 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(jsonResponse.get("columns").size(), 0);
     Assert.assertEquals(jsonResponse.get("indexes").size(), 17);
 
-
     jsonResponse = JsonUtils.stringToJsonNode(
-        _webTarget.path(segmentMetadataPath)
-            .queryParam("columns", "column1").queryParam("columns", "column2").request()
+        _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2").request()
             .get(String.class));
     Assert.assertEquals(jsonResponse.get("columns").size(), 2);
     Assert.assertEquals(jsonResponse.get("indexes").size(), 17);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -43,6 +43,7 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.core.segment.index.readers.ForwardIndexReader;
 import org.apache.pinot.core.segment.index.readers.ForwardIndexReaderContext;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -247,7 +248,8 @@ public class DictionaryToRawIndexConverter {
     PropertiesConfiguration properties = new PropertiesConfiguration(metadataFile);
 
     if (tableName != null) {
-      properties.setProperty(V1Constants.MetadataKeys.Segment.TABLE_NAME, tableName);
+      properties
+          .setProperty(V1Constants.MetadataKeys.Segment.TABLE_NAME, TableNameBuilder.extractRawTableName(tableName));
     }
 
     for (String column : columns) {


### PR DESCRIPTION
## Description
Currently the table name stored in the segment metadata (and ZK metadata) might be raw table name or table name with type suffix. This can cause problem if the caller does not handle the table name conversion correctly (e.g. #6436).
With this PR, we always store raw table name within the segment metadata and ZK metadata to simplify the caller logic.