### PR TITLE
Fixing bug for broker time segment pruner(#6189):

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -95,7 +95,7 @@ public class TimeSegmentPruner implements SegmentPruner {
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(numSegments);
     List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
-    for (String segment : segments) {
+    for (String segment : onlineSegments) {
       segments.add(segment);
       segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
     }
@@ -214,6 +214,16 @@ public class TimeSegmentPruner implements SegmentPruner {
         if (filterQueryTree.getColumn().equals(_timeColumn)) {
           long timeStamp = _timeFormatSpec.fromFormatToMillis(filterQueryTree.getValue().get(0));
           return Collections.singletonList(new Interval(timeStamp, timeStamp));
+        }
+        return null;
+      case IN:
+        if (filterQueryTree.getColumn().equals(_timeColumn)) {
+          List<Interval> intervals = new ArrayList<>(filterQueryTree.getValue().size());
+          for (String value: filterQueryTree.getValue()) {
+            long timeStamp = _timeFormatSpec.fromFormatToMillis(value);
+            intervals.add(new Interval(timeStamp, timeStamp));
+          }
+          return intervals;
         }
         return null;
       case RANGE:


### PR DESCRIPTION
  1. Fix bug in init().
  2. Add support for `IN` operator, e.g. `select * from mytable where timeColumn in (2001-01-01, 2021-01-01)`
  3. Add tests for simple date format.
