### PR TITLE
Dimension table storage quota config and validation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -145,7 +145,7 @@ public class ControllerConf extends PinotConfiguration {
   // If it's set to false, existing HLC realtime tables will stop consumption, and creation of new HLC tables will be disallowed.
   // Please make sure there is no HLC table running in the cluster before disallowing it.
   public static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
-  private static final String DIM_TABLE_MAX_SIZE = "controller.dimTable.maxSize";
+  public static final String DIM_TABLE_MAX_SIZE = "controller.dimTable.maxSize";
 
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_LOCAL = "controller.storage.factory.class.file";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -145,6 +145,7 @@ public class ControllerConf extends PinotConfiguration {
   // If it's set to false, existing HLC realtime tables will stop consumption, and creation of new HLC tables will be disallowed.
   // Please make sure there is no HLC table running in the cluster before disallowing it.
   public static final String ALLOW_HLC_TABLES = "controller.allow.hlc.tables";
+  private static final String DIM_TABLE_MAX_SIZE = "controller.dimTable.maxSize";
 
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_LOCAL = "controller.storage.factory.class.file";
@@ -165,6 +166,7 @@ public class ControllerConf extends PinotConfiguration {
   private static final String DEFAULT_CONTROLLER_MODE = ControllerMode.DUAL.name();
   private static final String DEFAULT_LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY =
       AutoRebalanceStrategy.class.getName();
+  private static final String DEFAULT_DIM_TABLE_MAX_SIZE = "200M";
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
@@ -253,6 +255,14 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setZkStr(String zkStr) {
     setProperty(ZK_STR, zkStr);
+  }
+
+  public void setDimTableMaxSize(String size) {
+    setProperty(DIM_TABLE_MAX_SIZE, size);
+  }
+
+  public String getDimTableMaxSize() {
+    return getProperty(DIM_TABLE_MAX_SIZE, DEFAULT_DIM_TABLE_MAX_SIZE);
   }
 
   // A boolean to decide whether Jersey API should be the primary one. For now, we set this to be false,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -476,11 +476,13 @@ public class PinotTableRestletResource {
 
       if (quotaConfig == null) {
         // set a default storage quota
+        LOGGER.info("Assigning default storage quota for dimension table: {}", tableConfig.getTableName());
         tableConfig.setQuotaConfig(
             new QuotaConfig(maxAllowedSize, null));
       } else {
         if (quotaConfig.getStorage() == null) {
           // set a default storage quota and keep the RPS value
+          LOGGER.info("Assigning default storage quota for dimension table: {}", tableConfig.getTableName());
           tableConfig.setQuotaConfig(
               new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond())
           );

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -60,6 +60,7 @@ import org.apache.pinot.controller.recommender.RecommenderDriver;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.util.ReplicationUtils;
 import org.apache.pinot.core.util.TableConfigUtils;
+import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableStats;
@@ -68,6 +69,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.config.table.tuner.TableConfigTuner;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.quartz.CronScheduleBuilder;
@@ -144,6 +146,7 @@ public class PinotTableRestletResource {
     String tableName = tableConfig.getTableName();
     try {
       ensureMinReplicas(tableConfig);
+      ensureStorageQuotaConstraints(tableConfig);
       verifyTableConfigs(tableConfig);
       _pinotHelixResourceManager.addTable(tableConfig);
       // TODO: validate that table was created successfully
@@ -367,6 +370,7 @@ public class PinotTableRestletResource {
       }
 
       ensureMinReplicas(tableConfig);
+      ensureStorageQuotaConstraints(tableConfig);
       verifyTableConfigs(tableConfig);
       _pinotHelixResourceManager.updateTableConfig(tableConfig);
     } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
@@ -461,6 +465,37 @@ public class PinotTableRestletResource {
             "Invalid value for replicasPerPartition: '" + replicasPerPartitionStr + "'", e);
       }
     }
+  }
+
+  private void ensureStorageQuotaConstraints(TableConfig tableConfig) {
+    // Dim tables must adhere to cluster level storage size limits
+    if (tableConfig.isDimTable()) {
+      QuotaConfig quotaConfig = tableConfig.getQuotaConfig();
+      String maxAllowedSize = this._controllerConf.getDimTableMaxSize();
+      long maxAllowedSizeInBytes = DataSizeUtils.toBytes(maxAllowedSize);
+
+      if (quotaConfig == null) {
+        // set a default storage quota
+        tableConfig.setQuotaConfig(
+            new QuotaConfig(maxAllowedSize, null));
+      } else {
+        if (quotaConfig.getStorage() == null) {
+          // set a default storage quota and keep the RPS value
+          tableConfig.setQuotaConfig(
+              new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond())
+          );
+        } else {
+          if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
+            LOGGER.error("quota exceeded max");
+            throw new PinotHelixResourceManager.InvalidTableConfigException(
+                "Invalid value for table storage quota. Max allowed is " + maxAllowedSize
+            );
+          }
+        }
+      }
+    }
+
+    LOGGER.error("Successfully returning from storage quota ensurance");
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -471,25 +471,27 @@ public class PinotTableRestletResource {
     // Dim tables must adhere to cluster level storage size limits
     if (tableConfig.isDimTable()) {
       QuotaConfig quotaConfig = tableConfig.getQuotaConfig();
-      String maxAllowedSize = this._controllerConf.getDimTableMaxSize();
+      String maxAllowedSize = _controllerConf.getDimTableMaxSize();
       long maxAllowedSizeInBytes = DataSizeUtils.toBytes(maxAllowedSize);
 
       if (quotaConfig == null) {
         // set a default storage quota
-        LOGGER.info("Assigning default storage quota for dimension table: {}", tableConfig.getTableName());
         tableConfig.setQuotaConfig(
             new QuotaConfig(maxAllowedSize, null));
+        LOGGER.info("Assigning default storage quota ({}) for dimension table: {}",
+            maxAllowedSize, tableConfig.getTableName());
       } else {
         if (quotaConfig.getStorage() == null) {
           // set a default storage quota and keep the RPS value
-          LOGGER.info("Assigning default storage quota for dimension table: {}", tableConfig.getTableName());
           tableConfig.setQuotaConfig(
-              new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond())
-          );
+              new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond()));
+          LOGGER.info("Assigning default storage quota ({}) for dimension table: {}",
+              maxAllowedSize, tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
             throw new PinotHelixResourceManager.InvalidTableConfigException(
-                "Invalid value for table storage quota. Max allowed is " + maxAllowedSize
+                String.format("Invalid storage quota: %d, max allowed size: %d",
+                    quotaConfig.getStorageInBytes(), maxAllowedSizeInBytes)
             );
           }
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -486,7 +486,6 @@ public class PinotTableRestletResource {
           );
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
-            LOGGER.error("quota exceeded max");
             throw new PinotHelixResourceManager.InvalidTableConfigException(
                 "Invalid value for table storage quota. Max allowed is " + maxAllowedSize
             );
@@ -494,8 +493,6 @@ public class PinotTableRestletResource {
         }
       }
     }
-
-    LOGGER.error("Successfully returning from storage quota ensurance");
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -117,6 +117,7 @@ public abstract class ControllerTestUtils {
   protected static HelixManager _helixManager;
   protected static HelixAdmin _helixAdmin;
   protected static HelixDataAccessor _helixDataAccessor;
+  protected static ControllerConf _controllerConfig;
 
   protected static ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
@@ -153,14 +154,14 @@ public abstract class ControllerTestUtils {
   public static void startController(Map<String, Object> properties) {
     Preconditions.checkState(_controllerStarter == null);
 
-    ControllerConf config = new ControllerConf(properties);
+    _controllerConfig = new ControllerConf(properties);
 
-    _controllerPort = Integer.valueOf(config.getControllerPort());
+    _controllerPort = Integer.valueOf(_controllerConfig.getControllerPort());
     _controllerBaseApiUrl = "http://localhost:" + _controllerPort;
     _controllerRequestURLBuilder = ControllerRequestURLBuilder.baseUrl(_controllerBaseApiUrl);
-    _controllerDataDir = config.getDataDir();
+    _controllerDataDir = _controllerConfig.getDataDir();
 
-    _controllerStarter = getControllerStarter(config);
+    _controllerStarter = getControllerStarter(_controllerConfig);
     _controllerStarter.start();
     _helixResourceManager = _controllerStarter.getHelixResourceManager();
     _helixManager = _controllerStarter.getHelixControllerManager();
@@ -193,6 +194,10 @@ public abstract class ControllerTestUtils {
 
   protected static ControllerStarter getControllerStarter(ControllerConf config) {
     return new ControllerStarter(config);
+  }
+
+  public static ControllerConf getControllerConfig() {
+    return _controllerConfig;
   }
 
   public static void stopController() {
@@ -449,7 +454,7 @@ public abstract class ControllerTestUtils {
   /**
    * Add a schema to the controller.
    */
-  protected static void addSchema(Schema schema) throws IOException {
+  public static void addSchema(Schema schema) throws IOException {
     String url = _controllerRequestURLBuilder.forSchemaCreate();
     PostMethod postMethod = sendMultipartPostRequest(url, schema.toSingleLineJsonString());
     assertEquals(postMethod.getStatusCode(), 200);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -20,11 +20,8 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-<<<<<<< Updated upstream
 import com.google.common.collect.ImmutableMap;
-=======
 import com.google.common.collect.Lists;
->>>>>>> Stashed changes
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -304,8 +301,6 @@ public class PinotTableRestletResourceTest {
     String tableConfigString = ControllerTestUtils.sendGetRequest(ControllerTestUtils.getControllerRequestURLBuilder().forTableGet(tableName));
     return JsonUtils.jsonNodeToObject(JsonUtils.stringToJsonNode(tableConfigString).get(tableType), TableConfig.class);
   }
-
-
 
   @Test
   public void testUpdateTableConfig() throws Exception {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.function.Consumer;
-import javax.naming.ldap.Control;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.controller.ControllerTestUtils;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;


### PR DESCRIPTION
## Description
Adding some validation logic to ensure Dimension table sizes are properly constrained. This is a follow up to the [introduction of Dimension tables](https://github.com/apache/incubator-pinot/pull/6286) and https://github.com/apache/incubator-pinot/pull/6346 . In current implementation, dimension tables are fully loaded into heap memory, so this change is to prevent users from accidentally loading very large tables and disrupting the server.
Changes include:
- New controller config key: "controller.dimTable.maxSize"
- Default value if no config is provided: DEFAULT_DIM_TABLE_MAX_SIZE = "200M"
- Validation and enforcement logic in table creation flow (`PinotTableRestletResource`), such that the default max value is applied if no storage config exists for dimension tables. 

**Note:** I looked into enforcing this constraint in `TableConfigUtils.validate()` however it didn't work out due to package dependency issues. We need `ControllerConf` values for the validation but `TableConfigUtils` cannot depend on `ControllerConf` due to package structure.

## Testing
- Controller tests are updated to include different scenarios.
