### PR TITLE
Handle creation of segments with 0 rows 

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -123,7 +123,8 @@ public class EmptySegmentPruner implements SegmentPruner {
    */
   @Override
   public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
-    segments.removeAll(_emptySegments);
-    return segments;
+    Set<String> selectedSegments = new HashSet<>(segments);
+    selectedSegments.removeAll(_emptySegments);
+    return selectedSegments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpruner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code EmptySegmentPruner} prunes segments if they have 0 totalDocs.
+ * Does not prune segments with -1 total docs (that can be either error case or CONSUMING segment)
+ */
+public class EmptySegmentPruner implements SegmentPruner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EmptySegmentPruner.class);
+
+  private final String _tableNameWithType;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String _segmentZKMetadataPathPrefix;
+
+  private final Map<String, Long> _segmentTotalDocsMap = new HashMap<>();
+  private final Set<String> _emptySegments = new HashSet<>();
+
+  public EmptySegmentPruner(TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableNameWithType = tableConfig.getTableName();
+    _propertyStore = propertyStore;
+    _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(_tableNameWithType) + "/";
+  }
+
+  @Override
+  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+    // Bulk load info for all online segments
+    int numSegments = onlineSegments.size();
+    List<String> segments = new ArrayList<>(numSegments);
+    List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
+    for (String segment : onlineSegments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT, false);
+    for (int i = 0; i < numSegments; i++) {
+      String segment = segments.get(i);
+      long totalDocs = extractTotalDocsFromSegmentZKMetaZNRecord(segment, znRecords.get(i));
+      _segmentTotalDocsMap.put(segment, totalDocs);
+      if (totalDocs == 0) {
+        _emptySegments.add(segment);
+      }
+    }
+  }
+
+  private long extractTotalDocsFromSegmentZKMetaZNRecord(String segment, @Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return -1;
+    }
+    return znRecord.getLongField(CommonConstants.Segment.TOTAL_DOCS, -1);
+  }
+
+  @Override
+  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<String> onlineSegments) {
+    // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
+    //       ones. The refreshed segment ZK metadata change won't be picked up.
+    for (String segment : onlineSegments) {
+      _segmentTotalDocsMap.computeIfAbsent(segment, k -> {
+        long totalDocs = extractTotalDocsFromSegmentZKMetaZNRecord(k,
+            _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT));
+        if (totalDocs == 0) {
+          _emptySegments.add(segment);
+        }
+        return totalDocs;
+      });
+    }
+    _segmentTotalDocsMap.keySet().retainAll(onlineSegments);
+    _emptySegments.retainAll(onlineSegments);
+  }
+
+  @Override
+  public synchronized void refreshSegment(String segment) {
+    long totalDocs = extractTotalDocsFromSegmentZKMetaZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+    _segmentTotalDocsMap.put(segment, totalDocs);
+    if (totalDocs == 0) {
+      _emptySegments.add(segment);
+    } else {
+      _emptySegments.remove(segment);
+    }
+  }
+
+  /**
+   * Prune out segments which are empty
+   */
+  @Override
+  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+    Set<String> selectedSegments = new HashSet<>(segments);
+    selectedSegments.removeAll(_emptySegments);
+    return selectedSegments;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -123,8 +123,7 @@ public class EmptySegmentPruner implements SegmentPruner {
    */
   @Override
   public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
-    Set<String> selectedSegments = new HashSet<>(segments);
-    selectedSegments.removeAll(_emptySegments);
-    return selectedSegments;
+    segments.removeAll(_emptySegments);
+    return segments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -48,6 +48,7 @@ public class SegmentPrunerFactory {
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     List<SegmentPruner> segmentPruners = new ArrayList<>();
+    // Always prune out empty segments first
     segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
 
     if (routingConfig != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -47,26 +47,29 @@ public class SegmentPrunerFactory {
   public static List<SegmentPruner> getSegmentPruners(TableConfig tableConfig,
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
+    List<SegmentPruner> segmentPruners = new ArrayList<>();
+    segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
+
     if (routingConfig != null) {
       List<String> segmentPrunerTypes = routingConfig.getSegmentPrunerTypes();
       if (segmentPrunerTypes != null) {
-        List<SegmentPruner> segmentPruners = new ArrayList<>(segmentPrunerTypes.size());
+        List<SegmentPruner> configuredSegmentPruners = new ArrayList<>(segmentPrunerTypes.size());
         for (String segmentPrunerType : segmentPrunerTypes) {
           if (RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE.equalsIgnoreCase(segmentPrunerType)) {
             PartitionSegmentPruner partitionSegmentPruner = getPartitionSegmentPruner(tableConfig, propertyStore);
             if (partitionSegmentPruner != null) {
-              segmentPruners.add(partitionSegmentPruner);
+              configuredSegmentPruners.add(partitionSegmentPruner);
             }
           }
 
           if (RoutingConfig.TIME_SEGMENT_PRUNER_TYPE.equalsIgnoreCase(segmentPrunerType)) {
             TimeSegmentPruner timeSegmentPruner = getTimeSegmentPruner(tableConfig, propertyStore);
             if (timeSegmentPruner != null) {
-              segmentPruners.add(timeSegmentPruner);
+              configuredSegmentPruners.add(timeSegmentPruner);
             }
           }
         }
-        return sortSegmentPruners(segmentPruners);
+        segmentPruners.addAll(sortSegmentPruners(configuredSegmentPruners));
       } else {
         // Handle legacy configs for backward-compatibility
         TableType tableType = tableConfig.getTableType();
@@ -76,12 +79,12 @@ public class SegmentPrunerFactory {
             && LEGACY_PARTITION_AWARE_REALTIME_ROUTING.equalsIgnoreCase(routingTableBuilderName))) {
           PartitionSegmentPruner partitionSegmentPruner = getPartitionSegmentPruner(tableConfig, propertyStore);
           if (partitionSegmentPruner != null) {
-            return Collections.singletonList(getPartitionSegmentPruner(tableConfig, propertyStore));
+            segmentPruners.add(getPartitionSegmentPruner(tableConfig, propertyStore));
           }
         }
       }
     }
-    return Collections.emptyList();
+    return segmentPruners;
   }
 
   @Nullable

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -117,49 +117,64 @@ public class SegmentPrunerTest {
     when(tableConfig.getIndexingConfig()).thenReturn(indexingConfig);
 
     // Routing config is missing
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Segment pruner type is not configured
     RoutingConfig routingConfig = mock(RoutingConfig.class);
     when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Segment partition config is missing
     when(routingConfig.getSegmentPrunerTypes())
         .thenReturn(Collections.singletonList(RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE));
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Column partition config is missing
     Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
     when(indexingConfig.getSegmentPartitionConfig()).thenReturn(new SegmentPartitionConfig(columnPartitionConfigMap));
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Partition-aware segment pruner should be returned
     columnPartitionConfigMap.put(PARTITION_COLUMN, new ColumnPartitionConfig("Modulo", 5));
-    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
-    assertEquals(segmentPruners.size(), 1);
-    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
 
     // Do not allow multiple partition columns
     columnPartitionConfigMap.put("anotherPartitionColumn", new ColumnPartitionConfig("Modulo", 5));
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Should be backward-compatible with legacy config
     columnPartitionConfigMap.remove("anotherPartitionColumn");
     when(routingConfig.getSegmentPrunerTypes()).thenReturn(null);
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
     when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
     when(routingConfig.getRoutingTableBuilderName())
         .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
-    assertEquals(segmentPruners.size(), 1);
-    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
     when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
     when(routingConfig.getRoutingTableBuilderName())
         .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_REALTIME_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
-    assertEquals(segmentPruners.size(), 1);
-    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
   }
 
   @Test
@@ -169,29 +184,37 @@ public class SegmentPrunerTest {
     setSchemaDateTimeFieldSpec(RAW_TABLE_NAME, TimeUnit.HOURS);
 
     // Routing config is missing
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Segment pruner type is not configured
     RoutingConfig routingConfig = mock(RoutingConfig.class);
     when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Validation config is missing
     when(routingConfig.getSegmentPrunerTypes())
         .thenReturn(Collections.singletonList(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE));
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Time column is missing
     SegmentsValidationAndRetentionConfig validationConfig = mock(SegmentsValidationAndRetentionConfig.class);
     when(tableConfig.getValidationConfig()).thenReturn(validationConfig);
-    assertEquals(SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore), Collections.emptySet());
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Time range pruner should be returned
     when(validationConfig.getTimeColumnName()).thenReturn(TIME_COLUMN);
-    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
-    assertEquals(segmentPruners.size(), 1);
-    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
-
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof TimeSegmentPruner);
   }
 
   @Test
@@ -491,6 +514,14 @@ public class SegmentPrunerTest {
     realtimeSegmentZKMetadata.setStartTime(startTime);
     realtimeSegmentZKMetadata.setEndTime(endTime);
     realtimeSegmentZKMetadata.setTimeUnit(unit);
+    ZKMetadataProvider.setRealtimeSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME, realtimeSegmentZKMetadata);
+  }
+
+  private void setRealtimeSegmentZKTotalDocsMetadata(String segment, long totalDocs) {
+    RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = new RealtimeSegmentZKMetadata();
+    realtimeSegmentZKMetadata.setSegmentName(segment);
+    realtimeSegmentZKMetadata.setTotalDocs(totalDocs);
+    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
     ZKMetadataProvider.setRealtimeSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME, realtimeSegmentZKMetadata);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -125,6 +125,13 @@ public class TimeBoundaryManagerTest {
     timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
 
+    // Add new segment with larger end time but 0 total docs, should not update time boundary
+    String segmentEmpty = "segmentEmpty";
+    onlineSegments.add(segmentEmpty);
+    setSegmentZKMetadataWithTotalDocs(rawTableName, segmentEmpty, 6, timeUnit, 0);
+    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
+
     // Add a new segment with smaller end time should not change the time boundary
     String segment2 = "segment2";
     onlineSegments.add(segment2);
@@ -189,6 +196,18 @@ public class TimeBoundaryManagerTest {
     offlineSegmentZKMetadata.setSegmentName(segment);
     offlineSegmentZKMetadata.setEndTime(timeUnit.convert(endTimeInDays, TimeUnit.DAYS));
     offlineSegmentZKMetadata.setTimeUnit(timeUnit);
+    ZKMetadataProvider
+        .setOfflineSegmentZKMetadata(_propertyStore, TableNameBuilder.OFFLINE.tableNameWithType(rawTableName),
+            offlineSegmentZKMetadata);
+  }
+
+  private void setSegmentZKMetadataWithTotalDocs(String rawTableName, String segment, int endTimeInDays,
+      TimeUnit timeUnit, long totalDocs) {
+    OfflineSegmentZKMetadata offlineSegmentZKMetadata = new OfflineSegmentZKMetadata();
+    offlineSegmentZKMetadata.setSegmentName(segment);
+    offlineSegmentZKMetadata.setEndTime(timeUnit.convert(endTimeInDays, TimeUnit.DAYS));
+    offlineSegmentZKMetadata.setTimeUnit(timeUnit);
+    offlineSegmentZKMetadata.setTotalDocs(totalDocs);
     ZKMetadataProvider
         .setOfflineSegmentZKMetadata(_propertyStore, TableNameBuilder.OFFLINE.tableNameWithType(rawTableName),
             offlineSegmentZKMetadata);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -512,6 +512,11 @@ public class PinotLLCRealtimeSegmentManager {
           "start/end time information is not correctly written to the segment for table: " + realtimeTableName);
       committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
       committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());
+    } else {
+      // Set current time as start/end time if total docs is 0
+      long now = System.currentTimeMillis();
+      committingSegmentZKMetadata.setStartTime(now);
+      committingSegmentZKMetadata.setEndTime(now);
     }
     committingSegmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);
     committingSegmentZKMetadata.setIndexVersion(segmentMetadata.getVersion());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -507,10 +507,12 @@ public class PinotLLCRealtimeSegmentManager {
     committingSegmentZKMetadata.setDownloadUrl(isPeerURL(committingSegmentDescriptor.getSegmentLocation())
         ? CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD : committingSegmentDescriptor.getSegmentLocation());
     committingSegmentZKMetadata.setCrc(Long.valueOf(segmentMetadata.getCrc()));
-    Preconditions.checkNotNull(segmentMetadata.getTimeInterval(),
-        "start/end time information is not correctly written to the segment for table: " + realtimeTableName);
-    committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
-    committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());
+    if (segmentMetadata.getTotalDocs() > 0) {
+      Preconditions.checkNotNull(segmentMetadata.getTimeInterval(),
+          "start/end time information is not correctly written to the segment for table: " + realtimeTableName);
+      committingSegmentZKMetadata.setStartTime(segmentMetadata.getTimeInterval().getStartMillis());
+      committingSegmentZKMetadata.setEndTime(segmentMetadata.getTimeInterval().getEndMillis());
+    }
     committingSegmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);
     committingSegmentZKMetadata.setIndexVersion(segmentMetadata.getVersion());
     committingSegmentZKMetadata.setTotalDocs(segmentMetadata.getTotalDocs());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/utils/SegmentMetadataMockUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/utils/SegmentMetadataMockUtils.java
@@ -53,12 +53,12 @@ public class SegmentMetadataMockUtils {
 
   public static SegmentMetadata mockSegmentMetadata(String tableName) {
     String uniqueNumericString = Long.toString(System.nanoTime());
-    return mockSegmentMetadata(tableName, tableName + uniqueNumericString, 0, uniqueNumericString);
+    return mockSegmentMetadata(tableName, tableName + uniqueNumericString, 100, uniqueNumericString);
   }
 
   public static SegmentMetadata mockSegmentMetadata(String tableName, String segmentName) {
     String uniqueNumericString = Long.toString(System.nanoTime());
-    return mockSegmentMetadata(tableName, segmentName, 0, uniqueNumericString);
+    return mockSegmentMetadata(tableName, segmentName, 100, uniqueNumericString);
   }
 
   public static RealtimeSegmentZKMetadata mockRealtimeSegmentZKMetadata(String tableName, String segmentName,
@@ -90,7 +90,7 @@ public class SegmentMetadataMockUtils {
     SegmentMetadata segmentMetadata = Mockito.mock(SegmentMetadata.class);
     Mockito.when(segmentMetadata.getTableName()).thenReturn(tableName);
     Mockito.when(segmentMetadata.getName()).thenReturn(segmentName);
-    Mockito.when(segmentMetadata.getTotalDocs()).thenReturn(0);
+    Mockito.when(segmentMetadata.getTotalDocs()).thenReturn(10);
     Mockito.when(segmentMetadata.getCrc()).thenReturn(Long.toString(System.nanoTime()));
     Mockito.when(segmentMetadata.getPushTime()).thenReturn(Long.MIN_VALUE);
     Mockito.when(segmentMetadata.getRefreshTime()).thenReturn(Long.MIN_VALUE);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/readers/PinotSegmentRecordReader.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,23 +76,19 @@ public class PinotSegmentRecordReader implements RecordReader {
     try {
       SegmentMetadata segmentMetadata = _immutableSegment.getSegmentMetadata();
       _numDocs = segmentMetadata.getTotalDocs();
-      if (schema == null) {
-        // In order not to expose virtual columns to client, schema shouldn't be fetched from segmentMetadata;
-        // otherwise the original metadata will be modified. Hence, initialize a new schema.
-        _schema = new SegmentMetadataImpl(indexDir).getSchema();
-        Collection<String> columnNames = _schema.getColumnNames();
-        _columnReaderMap = new HashMap<>(columnNames.size());
-        if (_numDocs > 0) {
+      // In order not to expose virtual columns to client, schema shouldn't be fetched from segmentMetadata;
+      // otherwise the original metadata will be modified. Hence, initialize a new schema.
+      _schema = schema == null ? new SegmentMetadataImpl(indexDir).getSchema() : schema;
+      if (_numDocs > 0) {
+        _columnReaderMap = new HashMap<>();
+        if (schema == null) {
+          Collection<String> columnNames = _schema.getColumnNames();
           for (String columnName : columnNames) {
             _columnReaderMap.put(columnName, new PinotSegmentColumnReader(_immutableSegment, columnName));
           }
-        }
-      } else {
-        _schema = schema;
-        Schema segmentSchema = segmentMetadata.getSchema();
-        Collection<FieldSpec> fieldSpecs = _schema.getAllFieldSpecs();
-        _columnReaderMap = new HashMap<>(fieldSpecs.size());
-        if (_numDocs > 0) {
+        } else {
+          Schema segmentSchema = segmentMetadata.getSchema();
+          Collection<FieldSpec> fieldSpecs = _schema.getAllFieldSpecs();
           for (FieldSpec fieldSpec : fieldSpecs) {
             String columnName = fieldSpec.getName();
             FieldSpec segmentFieldSpec = segmentSchema.getFieldSpecFor(columnName);
@@ -101,12 +98,15 @@ public class PinotSegmentRecordReader implements RecordReader {
             _columnReaderMap.put(columnName, new PinotSegmentColumnReader(_immutableSegment, columnName));
           }
         }
-      }
-      // Initialize sorted doc ids
-      if (sortOrder != null && !sortOrder.isEmpty() && _numDocs > 0) {
-        _docIdsInSortedColumnOrder =
-            new PinotSegmentSorter(_numDocs, _schema, _columnReaderMap).getSortedDocIds(sortOrder);
+        // Initialize sorted doc ids
+        if (sortOrder != null && !sortOrder.isEmpty()) {
+          _docIdsInSortedColumnOrder =
+              new PinotSegmentSorter(_numDocs, _schema, _columnReaderMap).getSortedDocIds(sortOrder);
+        } else {
+          _docIdsInSortedColumnOrder = null;
+        }
       } else {
+        _columnReaderMap = Collections.emptyMap();
         _docIdsInSortedColumnOrder = null;
       }
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/EmptyIndexSegment.java
@@ -30,7 +30,6 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
 import org.apache.pinot.core.segment.index.readers.ForwardIndexReader;
 import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.core.segment.index.readers.ValidDocIndexReader;
-import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
@@ -44,11 +43,9 @@ import org.slf4j.LoggerFactory;
 public class EmptyIndexSegment implements ImmutableSegment {
   private static final Logger LOGGER = LoggerFactory.getLogger(EmptyIndexSegment.class);
 
-  private final SegmentDirectory _segmentDirectory;
   private final SegmentMetadataImpl _segmentMetadata;
 
-  public EmptyIndexSegment(SegmentDirectory segmentDirectory, SegmentMetadataImpl segmentMetadata) {
-    _segmentDirectory = segmentDirectory;
+  public EmptyIndexSegment(SegmentMetadataImpl segmentMetadata) {
     _segmentMetadata = segmentMetadata;
   }
 
@@ -82,13 +79,6 @@ public class EmptyIndexSegment implements ImmutableSegment {
 
   @Override
   public void destroy() {
-    String segmentName = getSegmentName();
-    LOGGER.info("Trying to destroy segment : {}", segmentName);
-    try {
-      _segmentDirectory.close();
-    } catch (Exception e) {
-      LOGGER.error("Failed to close segment directory: {}. Continuing with error.", _segmentDirectory, e);
-    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/EmptyIndexSegment.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.indexsegment.immutable;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.segment.index.datasource.EmptyDataSource;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.core.segment.index.readers.ForwardIndexReader;
+import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
+import org.apache.pinot.core.segment.index.readers.ValidDocIndexReader;
+import org.apache.pinot.core.segment.store.SegmentDirectory;
+import org.apache.pinot.core.startree.v2.StarTreeV2;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Immutable segment impl for empty segment
+ * Such an IndexSegment contains only the metadata, and no indexes
+ */
+public class EmptyIndexSegment implements ImmutableSegment {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EmptyIndexSegment.class);
+
+  private final SegmentDirectory _segmentDirectory;
+  private final SegmentMetadataImpl _segmentMetadata;
+
+  public EmptyIndexSegment(SegmentDirectory segmentDirectory, SegmentMetadataImpl segmentMetadata) {
+    _segmentDirectory = segmentDirectory;
+    _segmentMetadata = segmentMetadata;
+  }
+
+  @Override
+  public String getSegmentName() {
+    return _segmentMetadata.getName();
+  }
+
+  @Override
+  public SegmentMetadataImpl getSegmentMetadata() {
+    return _segmentMetadata;
+  }
+
+  @Override
+  public DataSource getDataSource(String column) {
+    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+    Preconditions.checkNotNull(columnMetadata,
+        "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
+    return new EmptyDataSource(columnMetadata);
+  }
+
+  @Override
+  public Set<String> getColumnNames() {
+    return _segmentMetadata.getSchema().getColumnNames();
+  }
+
+  @Override
+  public Set<String> getPhysicalColumnNames() {
+    return _segmentMetadata.getSchema().getPhysicalColumnNames();
+  }
+
+  @Override
+  public void destroy() {
+    String segmentName = getSegmentName();
+    LOGGER.info("Trying to destroy segment : {}", segmentName);
+    try {
+      _segmentDirectory.close();
+    } catch (Exception e) {
+      LOGGER.error("Failed to close segment directory: {}. Continuing with error.", _segmentDirectory, e);
+    }
+  }
+
+  @Override
+  public List<StarTreeV2> getStarTrees() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ValidDocIndexReader getValidDocIndex() {
+    return null;
+  }
+
+  @Override
+  public GenericRow getRecord(int docId, GenericRow reuse) {
+    // NOTE: Use PinotSegmentRecordReader to read immutable segment
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Dictionary getDictionary(String column) {
+    return null;
+  }
+
+  @Override
+  public ForwardIndexReader getForwardIndex(String column) {
+    return null;
+  }
+
+  @Override
+  public InvertedIndexReader getInvertedIndex(String column) {
+    return null;
+  }
+
+  @Override
+  public long getSegmentSizeBytes() {
+    return 0;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -116,9 +116,9 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     Preconditions.checkNotNull(columnMetadata,
         "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
     if (_indexContainerMap.containsKey(column)) {
-      return new ImmutableDataSource(columnMetadata);
-    } else {
       return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
+    } else {
+      return new ImmutableDataSource(columnMetadata);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -115,7 +115,11 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
     Preconditions.checkNotNull(columnMetadata,
         "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
-    return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
+    if (_indexContainerMap.containsKey(column)) {
+      return new ImmutableDataSource(columnMetadata);
+    } else {
+      return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
-import org.apache.pinot.core.segment.index.datasource.EmptyDataSource;
 import org.apache.pinot.core.segment.index.datasource.ImmutableDataSource;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
@@ -116,11 +115,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
     Preconditions.checkNotNull(columnMetadata,
         "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
-    if (_indexContainerMap.containsKey(column)) {
-      return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
-    } else {
-      return new EmptyDataSource(columnMetadata);
-    }
+    return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.realtime.impl.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
+import org.apache.pinot.core.segment.index.datasource.EmptyDataSource;
 import org.apache.pinot.core.segment.index.datasource.ImmutableDataSource;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
@@ -118,7 +119,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     if (_indexContainerMap.containsKey(column)) {
       return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
     } else {
-      return new ImmutableDataSource(columnMetadata);
+      return new EmptyDataSource(columnMetadata);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -135,7 +135,7 @@ public class ImmutableSegmentLoader {
           new StarTreeIndexContainer(SegmentDirectoryPaths.findSegmentDirectory(indexDir), segmentMetadata,
               indexContainerMap, readMode);
     }
-    
+
     ImmutableSegmentImpl segment =
         new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
     LOGGER.info("Successfully loaded segment {} with readMode: {}", segmentName, readMode);

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -105,13 +105,16 @@ public class ImmutableSegmentLoader {
     // Load the segment
     ReadMode readMode = indexLoadingConfig.getReadMode();
     SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, readMode);
-    Map<String, ColumnIndexContainer> indexContainerMap = new HashMap<>();
-    StarTreeIndexContainer starTreeIndexContainer = null;
 
     if (segmentMetadata.getTotalDocs() > 0) {
+
+      Map<String, ColumnIndexContainer> indexContainerMap = new HashMap<>();
+      StarTreeIndexContainer starTreeIndexContainer = null;
+
       SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();
       for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
-        indexContainerMap.put(entry.getKey(), new PhysicalColumnIndexContainer(segmentReader, entry.getValue(), indexLoadingConfig, indexDir));
+        indexContainerMap.put(entry.getKey(),
+            new PhysicalColumnIndexContainer(segmentReader, entry.getValue(), indexLoadingConfig, indexDir));
       }
 
       // Instantiate virtual columns
@@ -133,11 +136,12 @@ public class ImmutableSegmentLoader {
             new StarTreeIndexContainer(SegmentDirectoryPaths.findSegmentDirectory(indexDir), segmentMetadata,
                 indexContainerMap, readMode);
       }
+      ImmutableSegmentImpl segment =
+          new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
+      LOGGER.info("Successfully loaded segment {} with readMode: {}", segmentName, readMode);
+      return segment;
+    } else {
+      return new EmptyIndexSegment(segmentDirectory, segmentMetadata);
     }
-
-    ImmutableSegmentImpl segment =
-        new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTreeIndexContainer);
-    LOGGER.info("Successfully loaded segment {} with readMode: {}", segmentName, readMode);
-    return segment;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -40,7 +40,8 @@ public class RealtimeSegmentRecordReader implements RecordReader {
   public RealtimeSegmentRecordReader(MutableSegmentImpl realtimeSegment, @Nullable String sortedColumn) {
     _realtimeSegment = realtimeSegment;
     _numDocs = realtimeSegment.getNumDocsIndexed();
-    _sortedDocIdIterationOrder = sortedColumn != null ? realtimeSegment.getSortedDocIdIterationOrderWithSortedColumn(sortedColumn) : null;
+    _sortedDocIdIterationOrder = sortedColumn != null && realtimeSegment.getNumDocsIndexed() > 0 ? realtimeSegment
+        .getSortedDocIdIterationOrderWithSortedColumn(sortedColumn) : null;
   }
 
   public int[] getSortedDocIdIterationOrder() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -127,6 +127,9 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
     this.schema = schema;
     this.totalDocs = segmentIndexCreationInfo.getTotalDocs();
+    if (totalDocs == 0) {
+      return;
+    }
 
     Collection<FieldSpec> fieldSpecs = schema.getAllFieldSpecs();
     Set<String> invertedIndexColumns = new HashSet<>();
@@ -531,7 +534,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     properties.setProperty(SEGMENT_TOTAL_DOCS, String.valueOf(totalDocs));
 
     // Write time related metadata (start time, end time, time unit)
-    if (timeColumnName != null) {
+    if (timeColumnName != null && totalDocs > 0) {
       ColumnIndexCreationInfo timeColumnIndexCreationInfo = indexCreationInfoMap.get(timeColumnName);
       if (timeColumnIndexCreationInfo != null) {
         long startTime;
@@ -656,10 +659,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     }
 
     // NOTE: Min/max could be null for real-time aggregate metrics.
-    Object min = columnIndexCreationInfo.getMin();
-    Object max = columnIndexCreationInfo.getMax();
-    if (min != null && max != null) {
-      addColumnMinMaxValueInfo(properties, column, min.toString(), max.toString());
+    if (totalDocs > 0) {
+      Object min = columnIndexCreationInfo.getMin();
+      Object max = columnIndexCreationInfo.getMax();
+      if (min != null && max != null) {
+        addColumnMinMaxValueInfo(properties, column, min.toString(), max.toString());
+      }
     }
 
     String defaultNullValue = columnIndexCreationInfo.getDefaultNullValue().toString();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/EmptyDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/EmptyDataSource.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.datasource;
+
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.common.DataSourceMetadata;
+import org.apache.pinot.core.data.partition.PartitionFunction;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * The {@code EmptyImmutableDataSource} class is the data source for a column in the immutable segment with 0 rows.
+ */
+public class EmptyDataSource extends BaseDataSource {
+
+  public EmptyDataSource(ColumnMetadata columnMetadata) {
+    super(new EmptyDataSourceMetadata(columnMetadata), null, null, null, null, null, null, null, null, null, null);
+  }
+
+  private static class EmptyDataSourceMetadata implements DataSourceMetadata {
+    final FieldSpec _fieldSpec;
+
+    EmptyDataSourceMetadata(ColumnMetadata columnMetadata) {
+      _fieldSpec = columnMetadata.getFieldSpec();
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return 0;
+    }
+
+    @Override
+    public int getNumValues() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return -1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/ImmutableDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/ImmutableDataSource.java
@@ -40,10 +40,6 @@ public class ImmutableDataSource extends BaseDataSource {
         columnIndexContainer.getNullValueVector());
   }
 
-  public ImmutableDataSource(ColumnMetadata columnMetadata) {
-    super(new ImmutableDataSourceMetadata(columnMetadata), null, null, null, null, null, null, null, null, null, null);
-  }
-
   private static class ImmutableDataSourceMetadata implements DataSourceMetadata {
     final FieldSpec _fieldSpec;
     final boolean _sorted;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/ImmutableDataSource.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/datasource/ImmutableDataSource.java
@@ -40,6 +40,10 @@ public class ImmutableDataSource extends BaseDataSource {
         columnIndexContainer.getNullValueVector());
   }
 
+  public ImmutableDataSource(ColumnMetadata columnMetadata) {
+    super(new ImmutableDataSourceMetadata(columnMetadata), null, null, null, null, null, null, null, null, null, null);
+  }
+
   private static class ImmutableDataSourceMetadata implements DataSourceMetadata {
     final FieldSpec _fieldSpec;
     final boolean _sorted;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/readers/RecordReaderSampleDataTest.java
@@ -51,6 +51,9 @@ public class RecordReaderSampleDataTest {
   private static final File JSON_SAMPLE_DATA_FILE = new File(Preconditions
       .checkNotNull(RecordReaderSampleDataTest.class.getClassLoader().getResource("data/test_sample_data.json"))
       .getFile());
+  private static final File JSON_EMPTY_DATA_FILE = new File(Preconditions
+      .checkNotNull(RecordReaderSampleDataTest.class.getClassLoader().getResource("data/test_empty_data.json"))
+      .getFile());
   private final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension("column1", FieldSpec.DataType.LONG)
       .addSingleValueDimension("column2", FieldSpec.DataType.INT)
       .addSingleValueDimension("column3", FieldSpec.DataType.STRING)
@@ -103,6 +106,15 @@ public class RecordReaderSampleDataTest {
         }
       }
       assertEquals(numRecords, 10001);
+    }
+  }
+
+  @Test
+  public void testRecordReaderEmptyFile()
+      throws Exception {
+    try (RecordReader jsonRecordReader = RecordReaderFactory
+        .getRecordReader(FileFormat.JSON, JSON_EMPTY_DATA_FILE, SCHEMA.getColumnNames(), null)) {
+      Assert.assertFalse(jsonRecordReader.hasNext());
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.index.creator;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.data.readers.GenericRowRecordReader;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
@@ -93,6 +94,9 @@ public class SegmentGenerationWithNoRecordsTest {
     File segmentDir = buildSegment(_tableConfig, _schema);
     SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
     Assert.assertEquals(metadata.getTotalDocs(), 0);
+    Assert.assertEquals(metadata.getTimeColumn(), DATE_TIME_COLUMN);
+    Assert.assertEquals(metadata.getTimeUnit(), TimeUnit.MILLISECONDS);
+    Assert.assertEquals(metadata.getStartTime(), metadata.getEndTime());
     Assert.assertTrue(metadata.getAllColumns().containsAll(_schema.getColumnNames()));
     PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(segmentDir);
     Assert.assertFalse(segmentRecordReader.hasNext());

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.index.creator;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.util.Collections;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.readers.GenericRowRecordReader;
+import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
+import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import org.apache.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.core.segment.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests segment generation for empty files
+ */
+public class SegmentGenerationWithNoRecordsTest {
+  private static final String STRING_COLUMN1 = "string_col1";
+  private static final String STRING_COLUMN2 = "string_col2";
+  private static final String STRING_COLUMN3 = "string_col3";
+  private static final String STRING_COLUMN4 = "string_col4";
+  private static final String LONG_COLUMN1 = "long_col1";
+  private static final String LONG_COLUMN2 = "long_col2";
+  private static final String LONG_COLUMN3 = "long_col3";
+  private static final String LONG_COLUMN4 = "long_col4";
+  private static final String MV_INT_COLUMN = "mv_col";
+  private static final String DATE_TIME_COLUMN = "date_time_col";
+  private static final String SEGMENT_DIR_NAME =
+      FileUtils.getTempDirectoryPath() + File.separator + "segmentNoRecordsTest";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private Schema _schema;
+  private TableConfig _tableConfig;
+
+  @BeforeClass
+  public void setup() {
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName(DATE_TIME_COLUMN)
+        .setInvertedIndexColumns(Lists.newArrayList(STRING_COLUMN1)).setSortedColumn(LONG_COLUMN1)
+        .setRangeIndexColumns(Lists.newArrayList(STRING_COLUMN2))
+        .setNoDictionaryColumns(Lists.newArrayList(LONG_COLUMN2)).setVarLengthDictionaryColumns(Lists.newArrayList(STRING_COLUMN3))
+        .setOnHeapDictionaryColumns(Lists.newArrayList(LONG_COLUMN3)).build();
+    _schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(STRING_COLUMN1, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN2, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN3, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN4, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(LONG_COLUMN1, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(LONG_COLUMN2, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(LONG_COLUMN3, FieldSpec.DataType.LONG)
+        .addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
+        .addMetric(LONG_COLUMN4, FieldSpec.DataType.LONG)
+        .addDateTime(DATE_TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+  }
+
+  @BeforeMethod
+  public void reset() {
+    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
+  }
+
+  @Test
+  public void testNumDocs()
+      throws Exception {
+    File segmentDir = buildSegment(_tableConfig, _schema);
+    SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
+    Assert.assertEquals(metadata.getTotalDocs(), 0);
+    Assert.assertTrue(metadata.getAllColumns().containsAll(_schema.getColumnNames()));
+    PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(segmentDir);
+    Assert.assertFalse(segmentRecordReader.hasNext());
+  }
+
+  private File buildSegment(final TableConfig tableConfig, final Schema schema)
+      throws Exception {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(SEGMENT_DIR_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(Collections.emptyList()));
+    driver.build();
+    driver.getOutputDirectory().deleteOnExit();
+    return driver.getOutputDirectory();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNoRecordsTest.java
@@ -67,6 +67,7 @@ public class SegmentGenerationWithNoRecordsTest {
         .setRangeIndexColumns(Lists.newArrayList(STRING_COLUMN2))
         .setNoDictionaryColumns(Lists.newArrayList(LONG_COLUMN2)).setVarLengthDictionaryColumns(Lists.newArrayList(STRING_COLUMN3))
         .setOnHeapDictionaryColumns(Lists.newArrayList(LONG_COLUMN3)).build();
+    _tableConfig.getIndexingConfig().setEnableDefaultStarTree(true);
     _schema = new Schema.SchemaBuilder()
         .addSingleValueDimension(STRING_COLUMN1, FieldSpec.DataType.STRING)
         .addSingleValueDimension(STRING_COLUMN2, FieldSpec.DataType.STRING)

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -127,6 +127,9 @@ public class RealtimeSegmentConverterTest {
     converter.build(SegmentVersion.v3, null);
     SegmentMetadataImpl metadata = new SegmentMetadataImpl(new File(outputDir, segmentName));
     Assert.assertEquals(metadata.getTotalDocs(), 0);
+    Assert.assertEquals(metadata.getTimeColumn(), DATE_TIME_COLUMN);
+    Assert.assertEquals(metadata.getTimeUnit(), TimeUnit.MILLISECONDS);
+    Assert.assertEquals(metadata.getStartTime(), metadata.getEndTime());
     Assert.assertTrue(metadata.getAllColumns().containsAll(schema.getColumnNames()));
     System.out.println(outputDir);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -18,16 +18,26 @@
  */
 package org.apache.pinot.realtime.converter;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.io.File;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
+import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
+import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.core.realtime.converter.RealtimeSegmentConverter;
+import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
+import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
@@ -35,6 +45,23 @@ import org.testng.annotations.Test;
 
 
 public class RealtimeSegmentConverterTest {
+
+  private static final String STRING_COLUMN1 = "string_col1";
+  private static final String STRING_COLUMN2 = "string_col2";
+  private static final String STRING_COLUMN3 = "string_col3";
+  private static final String STRING_COLUMN4 = "string_col4";
+  private static final String LONG_COLUMN1 = "long_col1";
+  private static final String LONG_COLUMN2 = "long_col2";
+  private static final String LONG_COLUMN3 = "long_col3";
+  private static final String LONG_COLUMN4 = "long_col4";
+  private static final String MV_INT_COLUMN = "mv_col";
+  private static final String DATE_TIME_COLUMN = "date_time_col";
+
+  private static final File TMP_DIR = new File(FileUtils.getTempDirectory(), RealtimeSegmentConverterTest.class.getName());
+
+  public void setup() {
+    Preconditions.checkState(TMP_DIR.mkdirs());
+  }
 
   @Test
   public void testNoVirtualColumnsInSchema() {
@@ -46,5 +73,72 @@ public class RealtimeSegmentConverterTest {
     Assert.assertEquals(schema.getColumnNames().size(), 5);
     Schema newSchema = RealtimeSegmentConverter.getUpdatedSchema(schema);
     Assert.assertEquals(newSchema.getColumnNames().size(), 2);
+  }
+
+  @Test
+  public void testNoRecordsIndexed()
+      throws Exception {
+
+    File tmpDir = new File(TMP_DIR, "tmp_" + System.currentTimeMillis());
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName(DATE_TIME_COLUMN)
+        .setInvertedIndexColumns(Lists.newArrayList(STRING_COLUMN1)).setSortedColumn(LONG_COLUMN1)
+        .setRangeIndexColumns(Lists.newArrayList(STRING_COLUMN2))
+        .setNoDictionaryColumns(Lists.newArrayList(LONG_COLUMN2)).setVarLengthDictionaryColumns(Lists.newArrayList(STRING_COLUMN3))
+        .setOnHeapDictionaryColumns(Lists.newArrayList(LONG_COLUMN3)).build();
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(STRING_COLUMN1, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN2, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN3, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(STRING_COLUMN4, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(LONG_COLUMN1, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(LONG_COLUMN2, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(LONG_COLUMN3, FieldSpec.DataType.LONG)
+        .addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
+        .addMetric(LONG_COLUMN4, FieldSpec.DataType.LONG)
+        .addDateTime(DATE_TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+
+    String tableNameWithType = tableConfig.getTableName();
+    String segmentName = "testTable__0__0__123456";
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
+        new RealtimeSegmentConfig.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)
+            .setStreamName(tableNameWithType).setSchema(schema).setTimeColumnName(DATE_TIME_COLUMN)
+            .setCapacity(1000).setAvgNumMultiValues(3)
+            .setNoDictionaryColumns(Sets.newHashSet(LONG_COLUMN2))
+            .setVarLengthDictionaryColumns(Sets.newHashSet(STRING_COLUMN3))
+            .setInvertedIndexColumns(Sets.newHashSet(STRING_COLUMN1))
+            .setRealtimeSegmentZKMetadata(getRealtimeSegmentZKMetadata(segmentName))
+            .setOffHeap(true).setMemoryManager(new DirectMemoryManager(segmentName))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
+
+    // create mutable segment impl
+    MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), null);
+
+    File outputDir = new File(tmpDir, "outputDir");
+    RealtimeSegmentConverter converter =
+        new RealtimeSegmentConverter(mutableSegmentImpl, outputDir.getAbsolutePath(), schema,
+            tableNameWithType, tableConfig, segmentName, indexingConfig.getSortedColumn().get(0),
+            indexingConfig.getInvertedIndexColumns(), null, null, indexingConfig.getNoDictionaryColumns(),
+            indexingConfig.getVarLengthDictionaryColumns(), false);
+
+    converter.build(SegmentVersion.v3, null);
+    SegmentMetadataImpl metadata = new SegmentMetadataImpl(new File(outputDir, segmentName));
+    Assert.assertEquals(metadata.getTotalDocs(), 0);
+    Assert.assertTrue(metadata.getAllColumns().containsAll(schema.getColumnNames()));
+    System.out.println(outputDir);
+  }
+
+  private RealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String segmentName) {
+    RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = new RealtimeSegmentZKMetadata();
+    realtimeSegmentZKMetadata.setCreationTime(System.currentTimeMillis());
+    realtimeSegmentZKMetadata.setSegmentName(segmentName);
+    return realtimeSegmentZKMetadata;
+  }
+
+  public void destroy() {
+    FileUtils.deleteQuietly(TMP_DIR);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/segments/v1/creator/SegmentTestUtils.java
@@ -94,6 +94,16 @@ public class SegmentTestUtils {
     return segmentGeneratorConfig;
   }
 
+  public static SegmentGeneratorConfig getSegmentGeneratorConfig(File inputFile, FileFormat inputFormat, File outputDir,
+      String tableName, TableConfig tableConfig, Schema schema) {
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setInputFilePath(inputFile.getAbsolutePath());
+    segmentGeneratorConfig.setOutDir(outputDir.getAbsolutePath());
+    segmentGeneratorConfig.setFormat(inputFormat);
+    segmentGeneratorConfig.setTableName(tableName);
+    return segmentGeneratorConfig;
+  }
+
   public static Schema extractSchemaFromAvroWithoutTime(File avroFile)
       throws IOException {
     DataFileStream<GenericRecord> dataStream =


### PR DESCRIPTION
## Description
https://github.com/apache/incubator-pinot/issues/6453
Do not fail segment creation if data source has 0 rows. Works for both offline and realtime tables.

Motivation: While working on the Kinesis connector, we added a new segment completion threshold - shard reached end of life. In this case, it is possible that the consuming segment consumes no rows, and it then forced to stop the segment. To handle this, as described in the issue above, we want to handle building empty segments in Pinot. The other approach considered was doing special handling for empty segment commit during segment commit, wherein we remove the entries from ZK and IS. The building empty segment approach is better than that, because: 
1. We would complicate the segment completion protocol too much, by adding a lot of special casing for totalDocs==0. 
2. If we allow the segment, and then delete it later, there would be a lot of special casing in the stream implementation to make sure we don't end up creating it yet again after deleting. The stream implementation is relying on current metadata to decide which shards to include, but if we delete it, the stream will keep giving us that shard again.
3. Now that we have filter spec, we could end up filtering all rows, and then we would error out instead of handling it gracefully.
4. This is a very rare occurrence. It will never even happen for realtime streams which rely only on time/rows thresholds.


This PR simply adds some checks for totalDocs throughout the segment build and load path. This PR will not at all affect the regular case, of records > 0. In case of totalDocs 0, the start and end time will be set as the current time.
An EmptySegmentPruner prunes these segments out on the broker side.
The ValidSegmentsPruner prunes these segments out on the server side.
TimeBoundaryManager will consider these segments as endTime -1


## Release Notes
Creating a segment with 0 rows in the data file will not fail anymore.
