### PR TITLE
[TE] fix heatmap not displaying when dot in metric name

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/heatmap-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/heatmap-chart/component.js
@@ -94,7 +94,7 @@ export default Component.extend({
     if (!dimensions.length) { return; }
 
     dimensions.forEach((dimension) => {
-      const dimensionPlaceHolderId = `#${dimension}-heatmap-placeholder`;
+      const dimensionPlaceHolderId = `#${dimension}-heatmap-placeholder`.replace(/\./g, '\\.');
       const children = cells[dimension]
         .filter(({ size }) => size)
         .map(cell => {


### PR DESCRIPTION
## Description
In Thirdeye:
The Bigquery datasource allows metric to contain dots in their name. eg: "device.browser" 
The `.` symbol is not managed correctly in the JS code of the heatmap, resulting in the heatmap not being displayed for a metric containing a point.

This PR fixes the problem by escaping the `.` character.

Before: 
<img width="911" alt="Capture d’écran 2021-01-19 à 16 24 43" src="https://user-images.githubusercontent.com/27781189/105203933-f36ee680-5b43-11eb-9902-eedac5732be1.png">

After: 
<img width="897" alt="Capture d’écran 2021-01-20 à 16 36 52" src="https://user-images.githubusercontent.com/27781189/105203889-e7832480-5b43-11eb-9891-32cc040b278c.png">


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
NO

Does this PR fix a zero-downtime upgrade introduced earlier?
NO

Does this PR otherwise need attention when creating release notes? Things to consider:
NO