### PR TITLE
Adding cluster config to config number of concurrent tasks per instance for minion task: SegmentGenerationAndPushTaskGenerator

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -332,4 +332,8 @@ public class ControllerRequestURLBuilder {
             .collect(Collectors.joining(",", "{", "}"));
     return forIngestFromURI(tableNameWithType, batchConfigMapStr, sourceURIStr);
   }
+
+  public String forClusterConfigs() {
+    return StringUtil.join("/", _baseUrl, "cluster/configs");
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -170,10 +170,7 @@ public class ClusterInfoAccessor {
     HelixConfigScope helixConfigScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
         .forCluster(_pinotHelixResourceManager.getHelixClusterName()).build();
     Map<String, String> configMap =
-        _pinotHelixResourceManager.getHelixAdmin().getConfig(helixConfigScope, Arrays.asList(configName));
-    if (configMap == null || !configMap.containsKey(configName)) {
-      return null;
-    }
-    return configMap.get(configName);
+        _pinotHelixResourceManager.getHelixAdmin().getConfig(helixConfigScope, Collections.singletonList(configName));
+    return configMap != null ? configMap.get(configName) : null;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -162,7 +162,7 @@ public class ClusterInfoAccessor {
   }
 
   /**
-   * Get the cluster config for a given cluster config.
+   * Get the cluster config for a given config name, return null if not found.
    *
    * @return cluster config
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
@@ -156,5 +159,21 @@ public class ClusterInfoAccessor {
    */
   public String getVipUrl() {
     return _controllerConf.generateVipUrl();
+  }
+
+  /**
+   * Get the cluster config for a given cluster config.
+   *
+   * @return cluster config
+   */
+  public String getClusterConfig(String configName) {
+    HelixConfigScope helixConfigScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
+        .forCluster(_pinotHelixResourceManager.getHelixClusterName()).build();
+    Map<String, String> configMap =
+        _pinotHelixResourceManager.getHelixAdmin().getConfig(helixConfigScope, Arrays.asList(configName));
+    if (configMap == null || !configMap.containsKey(configName)) {
+      return null;
+    }
+    return configMap.get(configName);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
@@ -106,11 +106,11 @@ public class SegmentGenerationAndPushTaskGenerator implements PinotTaskGenerator
 
   @Override
   public int getNumConcurrentTasksPerInstance() {
-    String numConcurrentTasksPerInstance = _clusterInfoAccessor
+    String numConcurrentTasksPerInstanceStr = _clusterInfoAccessor
         .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE);
-    if (numConcurrentTasksPerInstance != null) {
+    if (numConcurrentTasksPerInstanceStr != null) {
       try {
-        return Integer.parseInt(numConcurrentTasksPerInstance);
+        return Integer.parseInt(numConcurrentTasksPerInstanceStr);
       } catch (Exception e) {
         LOGGER.error("Failed to parse cluster config: {}",
             MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
@@ -101,6 +102,21 @@ public class SegmentGenerationAndPushTaskGenerator implements PinotTaskGenerator
   @Override
   public String getTaskType() {
     return MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE;
+  }
+
+  @Override
+  public int getNumConcurrentTasksPerInstance() {
+    String numConcurrentTasksPerInstance = _clusterInfoAccessor
+        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE);
+    if (numConcurrentTasksPerInstance != null) {
+      try {
+        return Integer.parseInt(numConcurrentTasksPerInstance);
+      } catch (Exception e) {
+        LOGGER.error("Failed to parse cluster config: {}",
+            MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE, e);
+      }
+    }
+    return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
   }
 
   @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGeneratorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGeneratorTest.java
@@ -18,36 +18,63 @@
  */
 package org.apache.pinot.controller.helix.core.minion.generator;
 
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 /**
  * Tests for {@link SegmentGenerationAndPushTaskGeneratorTest}
  */
-public class SegmentGenerationAndPushTaskGeneratorTest {
+public class SegmentGenerationAndPushTaskGeneratorTest extends ControllerTest {
+  SegmentGenerationAndPushTaskGenerator _generator;
+
+  @BeforeClass
+  public void setup() {
+    int zkPort = 2171;
+    startZk(zkPort);
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.ZK_STR, "localhost:" + zkPort);
+    properties.put(ControllerConf.HELIX_CLUSTER_NAME, SegmentGenerationAndPushTaskGeneratorTest.class.getSimpleName());
+    properties.put(ControllerConf.CONTROLLER_PORT, 28998);
+    startController(properties);
+
+    ClusterInfoAccessor clusterInfoAccessor = _controllerStarter.getTaskManager().getClusterInfoAccessor();
+    _generator = new SegmentGenerationAndPushTaskGenerator();
+    _generator.init(clusterInfoAccessor);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
 
   @Test
-  public void testNumberConcurrentTasksPerInstance() {
-    ClusterInfoAccessor mockClusterInfoProvide = mock(ClusterInfoAccessor.class);
-    when(mockClusterInfoProvide
-        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
-        .thenReturn("5");
-    SegmentGenerationAndPushTaskGenerator generator = new SegmentGenerationAndPushTaskGenerator();
-    generator.init(mockClusterInfoProvide);
-    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 5);
-    when(mockClusterInfoProvide
-        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
-        .thenReturn(null);
-    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 1);
-    when(mockClusterInfoProvide
-        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
-        .thenReturn("abcd");
-    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 1);
+  public void testRealCluster()
+      throws Exception {
+    // Default is 1
+    Assert.assertEquals(_generator.getNumConcurrentTasksPerInstance(), 1);
+
+    // Set config to 5
+    String request = JsonUtils.objectToString(Collections
+        .singletonMap(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE, "5"));
+    sendPostRequest(_controllerRequestURLBuilder.forClusterConfigs(), request);
+    Assert.assertEquals(_generator.getNumConcurrentTasksPerInstance(), 5);
+
+    // Set config to invalid and should still get 1
+    request = JsonUtils.objectToString(Collections
+        .singletonMap(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE,
+            "abcd"));
+    sendPostRequest(_controllerRequestURLBuilder.forClusterConfigs(), request);
+    Assert.assertEquals(_generator.getNumConcurrentTasksPerInstance(), 1);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGeneratorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGeneratorTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion.generator;
+
+import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
+import org.apache.pinot.core.common.MinionConstants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Tests for {@link SegmentGenerationAndPushTaskGeneratorTest}
+ */
+public class SegmentGenerationAndPushTaskGeneratorTest {
+
+  @Test
+  public void testNumberConcurrentTasksPerInstance() {
+    ClusterInfoAccessor mockClusterInfoProvide = mock(ClusterInfoAccessor.class);
+    when(mockClusterInfoProvide
+        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
+        .thenReturn("5");
+    SegmentGenerationAndPushTaskGenerator generator = new SegmentGenerationAndPushTaskGenerator();
+    generator.init(mockClusterInfoProvide);
+    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 5);
+    when(mockClusterInfoProvide
+        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
+        .thenReturn(null);
+    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 1);
+    when(mockClusterInfoProvide
+        .getClusterConfig(MinionConstants.SegmentGenerationAndPushTask.CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE))
+        .thenReturn("abcd");
+    Assert.assertEquals(generator.getNumConcurrentTasksPerInstance(), 1);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -92,6 +92,8 @@ public class MinionConstants {
   // Generate segment and push to controller based on batch ingestion configs
   public static class SegmentGenerationAndPushTask {
     public static final String TASK_TYPE = "SegmentGenerationAndPushTask";
+    public static final String CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE =
+        "pinot.minion.task.generator.SegmentGenerationAndPushTask.numConcurrentTasksPerInstance";
   }
 
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -93,7 +93,7 @@ public class MinionConstants {
   public static class SegmentGenerationAndPushTask {
     public static final String TASK_TYPE = "SegmentGenerationAndPushTask";
     public static final String CONFIG_NUMBER_CONCURRENT_TASKS_PER_INSTANCE =
-        "pinot.minion.task.generator.SegmentGenerationAndPushTask.numConcurrentTasksPerInstance";
+        "SegmentGenerationAndPushTask.numConcurrentTasksPerInstance";
   }
 
 }


### PR DESCRIPTION
## Description

- Adding cluster config: `SegmentGenerationAndPushTask.numConcurrentTasksPerInstance` to config number of concurrent tasks per instance for minion task: SegmentGenerationAndPushTaskGenerator
- Adding new API in ClusterInfoAccessor to fetch cluster config