### PR TITLE
Simplify SegmentGenerationAndPushTask handling getting schema and table config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.controller.helix.core.minion.generator;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
@@ -220,8 +219,8 @@ public class SegmentGenerationAndPushTaskGenerator implements PinotTaskGenerator
     String pushMode = IngestionConfigUtils.getPushMode(batchConfigMap);
 
     Map<String, String> singleFileGenerationTaskConfig = new HashMap<>(batchConfigMap);
-    singleFileGenerationTaskConfig.put(BatchConfigProperties.TABLE_NAME,
-        TableNameBuilder.extractRawTableName(offlineTableName));
+    singleFileGenerationTaskConfig
+        .put(BatchConfigProperties.TABLE_NAME, TableNameBuilder.OFFLINE.tableNameWithType(offlineTableName));
     singleFileGenerationTaskConfig.put(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
     if (outputDirURI != null) {
       URI outputSegmentDirURI = getRelativeOutputPath(inputDirURI, inputFileURI, outputDirURI);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/SegmentGenerationAndPushTaskGenerator.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import org.apache.pinot.controller.helix.ControllerRequestURLBuilder;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -225,10 +226,10 @@ public class SegmentGenerationAndPushTaskGenerator implements PinotTaskGenerator
       URI outputSegmentDirURI = getRelativeOutputPath(inputDirURI, inputFileURI, outputDirURI);
       singleFileGenerationTaskConfig.put(BatchConfigProperties.OUTPUT_SEGMENT_DIR_URI, outputSegmentDirURI.toString());
     }
-    singleFileGenerationTaskConfig.put(BatchConfigProperties.SCHEMA,
-        JsonUtils.objectToString(_clusterInfoAccessor.getTableSchema(offlineTableName)));
-    singleFileGenerationTaskConfig.put(BatchConfigProperties.TABLE_CONFIGS,
-        JsonUtils.objectToString(_clusterInfoAccessor.getTableConfig(offlineTableName)));
+    ControllerRequestURLBuilder controllerRequestURLBuilder =
+        ControllerRequestURLBuilder.baseUrl(_clusterInfoAccessor.getVipUrl());
+    singleFileGenerationTaskConfig.put(BatchConfigProperties.SCHEMA_URI, controllerRequestURLBuilder.forTableSchemaGet(offlineTableName));
+    singleFileGenerationTaskConfig.put(BatchConfigProperties.TABLE_CONFIGS_URI, controllerRequestURLBuilder.forTableGet(offlineTableName));
     singleFileGenerationTaskConfig.put(BatchConfigProperties.SEQUENCE_ID, String.valueOf(sequenceID));
     singleFileGenerationTaskConfig
         .put(BatchConfigProperties.SEGMENT_NAME_GENERATOR_TYPE, BatchConfigProperties.SegmentNameGeneratorType.SIMPLE);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/SegmentGenerationAndPushTaskExecutor.java
@@ -292,7 +292,15 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
           "Missing schema for segment generation job: please set `schema` or `schemaURI` in task config.");
     }
     taskSpec.setSchema(schema);
-    JsonNode tableConfig = JsonUtils.stringToJsonNode(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS));
+    JsonNode tableConfig;
+    if (taskConfigs.containsKey(BatchConfigProperties.TABLE_CONFIGS)) {
+      tableConfig = JsonUtils.stringToJsonNode(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS));
+    } else if (taskConfigs.containsKey(BatchConfigProperties.TABLE_CONFIGS_URI)) {
+      tableConfig = SegmentGenerationUtils.getTableConfig(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS_URI)).toJsonNode();
+    } else {
+      throw new RuntimeException(
+          "Missing schema for segment generation job: please set `tableConfigs` or `tableConfigsURI` in task config.");
+    }
     taskSpec.setTableConfig(tableConfig);
     taskSpec.setSequenceId(Integer.parseInt(taskConfigs.get(BatchConfigProperties.SEQUENCE_ID)));
     SegmentNameGeneratorSpec segmentNameGeneratorSpec = new SegmentNameGeneratorSpec();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -70,7 +70,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
 
   public String run()
       throws Exception {
-    TableConfig tableConfig = JsonUtils.jsonNodeToObject(_taskSpec.getTableConfig(), TableConfig.class);
+    TableConfig tableConfig = _taskSpec.getTableConfig();
     String tableName = tableConfig.getTableName();
     Schema schema = _taskSpec.getSchema();
 
@@ -109,9 +109,8 @@ public class SegmentGenerationTaskRunner implements Serializable {
     return segmentIndexCreationDriver.getSegmentName();
   }
 
-  private SegmentNameGenerator getSegmentNameGenerator()
-      throws IOException {
-    TableConfig tableConfig = JsonUtils.jsonNodeToObject(_taskSpec.getTableConfig(), TableConfig.class);
+  private SegmentNameGenerator getSegmentNameGenerator() {
+    TableConfig tableConfig = _taskSpec.getTableConfig();
     String tableName = tableConfig.getTableName();
 
     Schema schema = _taskSpec.getSchema();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -136,8 +136,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
       taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
       taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI()));
-      taskSpec
-          .setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()).toJsonNode());
+      taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
       taskSpec.setSequenceId(idx);
       taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
       taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -300,8 +300,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
           taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
           taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI()));
-          taskSpec.setTableConfig(
-              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()).toJsonNode());
+          taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -186,7 +186,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
         taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
         taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
         taskSpec.setSchema(schema);
-        taskSpec.setTableConfig(tableConfig.toJsonNode());
+        taskSpec.setTableConfig(tableConfig);
         taskSpec.setSequenceId(i);
         taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
         taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -22,8 +22,6 @@ package org.apache.pinot.spi.ingestion.batch;
  * Defines all the keys used in the batch configs map
  */
 public class BatchConfigProperties {
-
-  public static final String TABLE_CONFIGS = "tableConfigs";
   public static final String TABLE_NAME = "tableName";
 
   public static final String INPUT_DIR_URI = "inputDirURI";
@@ -38,6 +36,8 @@ public class BatchConfigProperties {
   public static final String RECORD_READER_CLASS = "recordReader.className";
   public static final String RECORD_READER_CONFIG_CLASS = "recordReader.configClassName";
   public static final String RECORD_READER_PROP_PREFIX = "recordReader.prop";
+  public static final String TABLE_CONFIGS = "tableConfigs";
+  public static final String TABLE_CONFIGS_URI = "tableConfigsURI";
   public static final String SCHEMA = "schema";
   public static final String SCHEMA_URI = "schemaURI";
   public static final String SEQUENCE_ID = "sequenceId";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -36,7 +37,7 @@ public class SegmentGenerationTaskSpec implements Serializable {
   /**
    * Table config to create segment
    */
-  private JsonNode _tableConfig;
+  private TableConfig _tableConfig;
 
   /**
    * Table schema
@@ -73,11 +74,11 @@ public class SegmentGenerationTaskSpec implements Serializable {
    */
   private Map<String, String> _customProperties = new HashMap<>();
 
-  public JsonNode getTableConfig() {
+  public TableConfig getTableConfig() {
     return _tableConfig;
   }
 
-  public void setTableConfig(JsonNode tableConfig) {
+  public void setTableConfig(TableConfig tableConfig) {
     _tableConfig = tableConfig;
   }
 


### PR DESCRIPTION
## Description
Simplify SegmentGenerationAndPushTaskGenerator by not setting schema and table config, default to using cluster schema/table config.

SegmentGenerationAndPushTaskExecutor will fetch schema/tableConfig following the below priority.
1. Used the schema/tableConfig set in the task config if there is any.
2. Used the schemaURI/tableConfigURI set in the task config to fetch the schema/tableConfig if there is any.
3. Directly fetch the schema/tableConfig from the same cluster.
