### PR TITLE
Remove the usage of deprecated range delimiter

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -74,6 +74,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Broker;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.helix.TableCache;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -1300,7 +1301,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     // Use -1 to prevent collision with other filters
     timeFilterQuery.setId(-1);
     timeFilterQuery.setColumn(timeColumn);
-    String filterValue = isOfflineRequest ? "(*\t\t" + timeValue + "]" : "(" + timeValue + "\t\t*)";
+    String filterValue = isOfflineRequest ? Range.LOWER_UNBOUNDED + timeValue + Range.UPPER_INCLUSIVE
+        : Range.LOWER_EXCLUSIVE + timeValue + Range.UPPER_UNBOUNDED;
     timeFilterQuery.setValue(Collections.singletonList(filterValue));
     timeFilterQuery.setOperator(FilterOperator.RANGE);
     timeFilterQuery.setNestedFilterQueryIds(Collections.emptyList());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -39,6 +39,7 @@ import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -58,11 +59,6 @@ public class TimeSegmentPruner implements SegmentPruner {
   private static final long MIN_START_TIME = 0;
   private static final long MAX_END_TIME = Long.MAX_VALUE;
   private static final Interval DEFAULT_INTERVAL = new Interval(MIN_START_TIME, MAX_END_TIME);
-  private static final char DELIMITER = '\0';
-  private static final String LEGACY_DELIMITER = "\t\t";
-  private static final char START_INCLUSIVE = '(';
-  private static final char END_INCLUSIVE = ')';
-  private static final String UNBOUNDED = "*";
 
   private final String _tableNameWithType;
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
@@ -127,7 +123,8 @@ public class TimeSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<String> onlineSegments) {
     // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
     //       ones. The refreshed segment ZK metadata change won't be picked up.
     for (String segment : onlineSegments) {
@@ -138,10 +135,10 @@ public class TimeSegmentPruner implements SegmentPruner {
     _intervalTree = new IntervalTree<>(_intervalMap);
   }
 
-
   @Override
   public synchronized void refreshSegment(String segment) {
-    Interval interval = extractIntervalFromSegmentZKMetaZNRecord(segment, _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+    Interval interval = extractIntervalFromSegmentZKMetaZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
     _intervalMap.put(segment, interval);
     _intervalTree = new IntervalTree<>(_intervalMap);
   }
@@ -219,7 +216,7 @@ public class TimeSegmentPruner implements SegmentPruner {
       case IN:
         if (filterQueryTree.getColumn().equals(_timeColumn)) {
           List<Interval> intervals = new ArrayList<>(filterQueryTree.getValue().size());
-          for (String value: filterQueryTree.getValue()) {
+          for (String value : filterQueryTree.getValue()) {
             long timeStamp = _timeFormatSpec.fromFormatToMillis(value);
             intervals.add(new Interval(timeStamp, timeStamp));
           }
@@ -333,19 +330,22 @@ public class TimeSegmentPruner implements SegmentPruner {
     long startTime = MIN_START_TIME;
     long endTime = MAX_END_TIME;
     String intervalExpression = intervalExpressions.get(0);
-    boolean startInclusive = intervalExpression.charAt(0) == START_INCLUSIVE;
-    boolean endInclusive = intervalExpression.charAt(intervalExpression.length() - 1) == END_INCLUSIVE;
-    String interval = intervalExpression.substring(1, intervalExpression.length() - 1);
-    String[] split = StringUtils.split(interval, DELIMITER);
-    if (split.length != 2) {
-      split = StringUtils.split(interval, LEGACY_DELIMITER);
+    int length = intervalExpression.length();
+    boolean startExclusive = intervalExpression.charAt(0) == Range.LOWER_EXCLUSIVE;
+    boolean endExclusive = intervalExpression.charAt(length - 1) == Range.UPPER_EXCLUSIVE;
+    String interval = intervalExpression.substring(1, length - 1);
+    String[] split = StringUtils.split(interval, Range.DELIMITER);
+    if (!split[0].equals(Range.UNBOUNDED)) {
+      startTime = _timeFormatSpec.fromFormatToMillis(split[0]);
+      if (startExclusive) {
+        startTime++;
+      }
     }
-
-    if (!split[0].equals(UNBOUNDED)) {
-      startTime = startInclusive? _timeFormatSpec.fromFormatToMillis(split[0]) + 1 : _timeFormatSpec.fromFormatToMillis(split[0]);
-    }
-    if (!split[1].equals(UNBOUNDED)) {
-      endTime = endInclusive ? _timeFormatSpec.fromFormatToMillis(split[1]) - 1 : _timeFormatSpec.fromFormatToMillis(split[1]);
+    if (!split[1].equals(Range.UNBOUNDED)) {
+      endTime = _timeFormatSpec.fromFormatToMillis(split[1]);
+      if (endExclusive) {
+        endTime--;
+      }
     }
 
     if (startTime > endTime) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
@@ -52,32 +52,32 @@ public class RangeMergeOptimizerTest {
   @Test
   public void testRangeIntersection() {
     // One range within another
-    testRangeOptimizer("(1\t\t100)", "(10\t\t20]", "(10\t\t20]");
+    testRangeOptimizer("(1\000100)", "(10\00020]", "(10\00020]");
 
     // One range within another, and one range is unbounded
-    testRangeOptimizer("(*\t\t*)", "[1\t\t2)", "[1\t\t2)");
+    testRangeOptimizer("(*\000*)", "[1\0002)", "[1\0002)");
 
     // One range with unbounded lower
-    testRangeOptimizer("(*\t\t5]", "[1\t\t20)", "[1\t\t5]");
+    testRangeOptimizer("(*\0005]", "[1\00020)", "[1\0005]");
 
     // One range with unbounded upper
-    testRangeOptimizer("(5\t\t*)", "[1\t\t20)", "(5\t\t20)");
+    testRangeOptimizer("(5\000*)", "[1\00020)", "(5\00020)");
 
     // Partial overlap
-    testRangeOptimizer("(1\t\t10]", "[5\t\t20)", "[5\t\t10]");
+    testRangeOptimizer("(1\00010]", "[5\00020)", "[5\00010]");
 
     // No overlap
-    testRangeOptimizer("(1\t\t10]", "[20\t\t30)", "[20\t\t10]");
+    testRangeOptimizer("(1\00010]", "[20\00030)", "[20\00010]");
 
     // Single point overlap
-    testRangeOptimizer("(1\t\t10]", "[10\t\t30)", "[10\t\t10]");
+    testRangeOptimizer("(1\00010]", "[10\00030)", "[10\00010]");
 
     // Redundant case
-    testRangeOptimizer("(*\t\t10]", "(*\t\t30)", "(*\t\t10]");
+    testRangeOptimizer("(*\00010]", "(*\00030)", "(*\00010]");
 
     // Extreme values
-    testRangeOptimizer(String.format("(*\t\t%d)", Long.MAX_VALUE), String.format("(%d\t\t*)", Long.MIN_VALUE),
-        String.format("(%d\t\t%d)", Long.MIN_VALUE, Long.MAX_VALUE));
+    testRangeOptimizer(String.format("(*\000%d)", Long.MAX_VALUE), String.format("(%d\000*)", Long.MIN_VALUE),
+        String.format("(%d\000%d)", Long.MIN_VALUE, Long.MAX_VALUE));
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -444,5 +444,16 @@ public class CommonConstants {
         public static final String NON_STREAMING = "nonStreaming";
       }
     }
+
+    public static class Range {
+      public static final char DELIMITER = '\0';
+      public static final char LOWER_EXCLUSIVE = '(';
+      public static final char LOWER_INCLUSIVE = '[';
+      public static final char UPPER_EXCLUSIVE = ')';
+      public static final char UPPER_INCLUSIVE = ']';
+      public static final String UNBOUNDED = "*";
+      public static final String LOWER_UNBOUNDED = LOWER_EXCLUSIVE + UNBOUNDED + DELIMITER;
+      public static final String UPPER_UNBOUNDED = DELIMITER + UNBOUNDED + UPPER_EXCLUSIVE;
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/utils/ParserUtils.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 
 
@@ -145,26 +146,21 @@ public class ParserUtils {
     boolean treatLiteralAsIdentifier = true;
 
     if (FilterKind.LESS_THAN == filterKind) {
-
       String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
-      rangeExpression = "(*\t\t" + value + ")";
+      rangeExpression = Range.LOWER_UNBOUNDED + value + Range.UPPER_EXCLUSIVE;
     } else if (FilterKind.LESS_THAN_OR_EQUAL == filterKind) {
-
       String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
-      rangeExpression = "(*\t\t" + value + "]";
+      rangeExpression = Range.LOWER_UNBOUNDED + value + Range.UPPER_INCLUSIVE;
     } else if (FilterKind.GREATER_THAN == filterKind) {
-
       String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
-      rangeExpression = "(" + value + "\t\t*)";
+      rangeExpression = Range.LOWER_EXCLUSIVE + value + Range.UPPER_UNBOUNDED;
     } else if (FilterKind.GREATER_THAN_OR_EQUAL == filterKind) {
-
       String value = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
-      rangeExpression = "[" + value + "\t\t*)";
+      rangeExpression = Range.LOWER_INCLUSIVE + value + Range.UPPER_UNBOUNDED;
     } else if (FilterKind.BETWEEN == filterKind) {
-
       String left = standardizeExpression(operands.get(1), treatLiteralAsIdentifier);
       String right = standardizeExpression(operands.get(2), treatLiteralAsIdentifier);
-      rangeExpression = "[" + left + "\t\t" + right + "]";
+      rangeExpression = Range.LOWER_INCLUSIVE + left + Range.DELIMITER + right + Range.UPPER_INCLUSIVE;
     } else {
       throw new UnsupportedOperationException("Unknown Filter Kind:" + filterKind);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BetweenPredicateAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BetweenPredicateAstNode.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
@@ -59,9 +60,9 @@ public class BetweenPredicateAstNode extends PredicateAstNode {
       try {
         LiteralAstNode left = (LiteralAstNode) getChildren().get(0);
         LiteralAstNode right = (LiteralAstNode) getChildren().get(1);
-        return new FilterQueryTree(_identifier,
-            Collections.singletonList("[" + left.getValueAsString() + "\t\t" + right.getValueAsString() + "]"),
-            FilterOperator.RANGE, null);
+        return new FilterQueryTree(_identifier, Collections.singletonList(
+            Range.LOWER_INCLUSIVE + left.getValueAsString() + Range.DELIMITER + right.getValueAsString()
+                + Range.UPPER_INCLUSIVE), FilterOperator.RANGE, null);
       } catch (ClassCastException e) {
         throw new Pql2CompilationException(
             "BETWEEN clause was expecting two literal AST nodes, got " + getChildren().get(0) + " and " + getChildren()

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/ComparisonPredicateAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/ComparisonPredicateAstNode.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
@@ -88,27 +89,27 @@ public class ComparisonPredicateAstNode extends PredicateAstNode {
     }
     if ("<".equals(_operand)) {
       if (identifierIsOnLeft) {
-        comparison = "(*\t\t" + value + ")";
+        comparison = Range.LOWER_UNBOUNDED + value + Range.UPPER_EXCLUSIVE;
       } else {
-        comparison = "(" + value + "\t\t*)";
+        comparison = Range.LOWER_EXCLUSIVE + value + Range.UPPER_UNBOUNDED;
       }
     } else if ("<=".equals(_operand)) {
       if (identifierIsOnLeft) {
-        comparison = "(*\t\t" + value + "]";
+        comparison = Range.LOWER_UNBOUNDED + value + Range.UPPER_INCLUSIVE;
       } else {
-        comparison = "[" + value + "\t\t*)";
+        comparison = Range.LOWER_INCLUSIVE + value + Range.UPPER_UNBOUNDED;
       }
     } else if (">".equals(_operand)) {
       if (identifierIsOnLeft) {
-        comparison = "(" + value + "\t\t*)";
+        comparison = Range.LOWER_EXCLUSIVE + value + Range.UPPER_UNBOUNDED;
       } else {
-        comparison = "(*\t\t" + value + "*)";
+        comparison = Range.LOWER_UNBOUNDED + value + Range.UPPER_EXCLUSIVE;
       }
     } else if (">=".equals(_operand)) {
       if (identifierIsOnLeft) {
-        comparison = "[" + value + "\t\t*)";
+        comparison = Range.LOWER_INCLUSIVE + value + Range.UPPER_UNBOUNDED;
       } else {
-        comparison = "(*\t\t" + value + "*)";
+        comparison = Range.LOWER_UNBOUNDED + value + Range.UPPER_INCLUSIVE;
       }
     }
     return comparison;

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -101,7 +101,7 @@ public class Pql2CompilerTest {
     BrokerRequest brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where a > 1");
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "a");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.RANGE);
-    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(1\t\t*)");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(1\000*)");
     // Test PinotQuery
     Function func = brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
@@ -111,7 +111,7 @@ public class Pql2CompilerTest {
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where b < 100");
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "b");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.RANGE);
-    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(*\t\t100)");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(*\000100)");
     // Test PinotQuery
     func = brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
@@ -121,7 +121,7 @@ public class Pql2CompilerTest {
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where c >= 10");
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "c");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.RANGE);
-    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "[10\t\t*)");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "[10\000*)");
     // Test PinotQuery
     func = brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
@@ -131,7 +131,7 @@ public class Pql2CompilerTest {
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where d <= 50");
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "d");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.RANGE);
-    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(*\t\t50]");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "(*\00050]");
     // Test PinotQuery
     func = brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
@@ -141,7 +141,7 @@ public class Pql2CompilerTest {
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where e BETWEEN 70 AND 80");
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "e");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.RANGE);
-    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "[70\t\t80]");
+    Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "[70\00080]");
     // Test PinotQuery
     func = brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
@@ -120,7 +120,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
    * {@link RangePredicate} for details.
    */
   private static Range getRange(String rangeString, DataType dataType) {
-    String[] split = StringUtils.split(rangeString, RangePredicate.LEGACY_DELIMITER);
+    String[] split = StringUtils.split(rangeString, RangePredicate.DELIMITER);
     String lower = split[0];
     boolean lowerInclusive = lower.charAt(0) == RangePredicate.LOWER_INCLUSIVE;
     String stringLowerBound = lower.substring(1);
@@ -340,8 +340,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
         stringBuilder.append(_lowerInclusive ? RangePredicate.LOWER_INCLUSIVE : RangePredicate.LOWER_EXCLUSIVE);
         stringBuilder.append(_lowerBound.toString());
       }
-      // TODO: Switch to RangePredicate.DELIMITER after releasing 0.6.0
-      stringBuilder.append(RangePredicate.LEGACY_DELIMITER);
+      stringBuilder.append(RangePredicate.DELIMITER);
       if (_upperBound == null) {
         stringBuilder.append(RangePredicate.UNBOUNDED).append(RangePredicate.UPPER_EXCLUSIVE);
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/RangePredicate.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/predicate/RangePredicate.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.request.context.predicate;
 
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.utils.CommonConstants.Query.Range;
 import org.apache.pinot.core.query.request.context.ExpressionContext;
 
 
@@ -28,14 +29,15 @@ import org.apache.pinot.core.query.request.context.ExpressionContext;
  * <p>Pinot uses RANGE to represent '>', '>=', '<', '<=', BETWEEN so that intersection of multiple ranges can be merged.
  */
 public class RangePredicate implements Predicate {
-  public static final char DELIMITER = '\0';
-  // TODO: Remove the legacy delimiter after releasing 0.6.0
-  public static final String LEGACY_DELIMITER = "\t\t";
-  public static final char LOWER_INCLUSIVE = '[';
-  public static final char LOWER_EXCLUSIVE = '(';
-  public static final char UPPER_INCLUSIVE = ']';
-  public static final char UPPER_EXCLUSIVE = ')';
-  public static final String UNBOUNDED = "*";
+  public static final char DELIMITER = Range.DELIMITER;
+  public static final char LOWER_EXCLUSIVE = Range.LOWER_EXCLUSIVE;
+  public static final char LOWER_INCLUSIVE = Range.LOWER_INCLUSIVE;
+  public static final char UPPER_EXCLUSIVE = Range.UPPER_EXCLUSIVE;
+  public static final char UPPER_INCLUSIVE = Range.UPPER_INCLUSIVE;
+  public static final String UNBOUNDED = Range.UNBOUNDED;
+
+  // For backward-compatibility
+  private static final String LEGACY_DELIMITER = "\t\t";
 
   private final ExpressionContext _lhs;
   private final boolean _lowerInclusive;

--- a/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/RangeMergeOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/RangeMergeOptimizer.java
@@ -145,8 +145,7 @@ public class RangeMergeOptimizer extends FilterQueryTreeOptimizer {
       }
     }
 
-    // TODO: Switch to RangePredicate.DELIMITER after releasing 0.5.0
-    stringBuilder.append(RangePredicate.LEGACY_DELIMITER);
+    stringBuilder.append(RangePredicate.DELIMITER);
 
     String upperBound1 = predicate1.getUpperBound();
     String upperBound2 = predicate2.getUpperBound();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryRangePredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryRangePredicateEvaluatorTest.java
@@ -34,42 +34,42 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testIntPredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\t\t10]", FieldSpec.DataType.INT);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\00010]", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i >= -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10]", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(-10\00010]", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i > -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10)", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(-10\00010)", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i > -10 && i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*]", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("[10\000*]", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i >= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV(i), (i > 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.INT);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV(i));
     }
@@ -77,7 +77,7 @@ public class NoDictionaryRangePredicateEvaluatorTest {
     Assert.assertTrue(predicateEvaluator.applySV(Integer.MAX_VALUE));
 
     predicateEvaluator =
-        buildRangePredicate(String.format("(%d\t\t%d)", Integer.MIN_VALUE, Integer.MAX_VALUE), FieldSpec.DataType.INT);
+        buildRangePredicate(String.format("(%d\000%d)", Integer.MIN_VALUE, Integer.MAX_VALUE), FieldSpec.DataType.INT);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV(i));
     }
@@ -87,42 +87,42 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testLongPredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\t\t10]", FieldSpec.DataType.LONG);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\00010]", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i >= -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10]", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(-10\00010]", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i > -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10)", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(-10\00010)", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i > -10 && i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*)", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("[10\000*)", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i >= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((long) i), (i > 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.LONG);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((long) i));
     }
@@ -130,7 +130,7 @@ public class NoDictionaryRangePredicateEvaluatorTest {
     Assert.assertTrue(predicateEvaluator.applySV(Long.MAX_VALUE));
 
     predicateEvaluator =
-        buildRangePredicate(String.format("(%d\t\t%d)", Long.MIN_VALUE, Long.MAX_VALUE), FieldSpec.DataType.LONG);
+        buildRangePredicate(String.format("(%d\000%d)", Long.MIN_VALUE, Long.MAX_VALUE), FieldSpec.DataType.LONG);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((long) i));
     }
@@ -140,42 +140,42 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testFloatPredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\t\t10]", FieldSpec.DataType.FLOAT);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\00010]", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i >= -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10]", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(-10\00010]", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i > -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(-10\00010)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i > -10 && i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i <= 10), "Value: " + i);
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("[10\000*)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i >= 10), "Value: " + i);
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i > 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((float) i));
     }
@@ -183,7 +183,7 @@ public class NoDictionaryRangePredicateEvaluatorTest {
     Assert.assertTrue(predicateEvaluator.applySV(Float.POSITIVE_INFINITY));
 
     predicateEvaluator =
-        buildRangePredicate(String.format("(%f\t\t%f)", Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY),
+        buildRangePredicate(String.format("(%f\000%f)", Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY),
             FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((float) i));
@@ -194,42 +194,42 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testDoublePredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\t\t10]", FieldSpec.DataType.DOUBLE);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\00010]", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((double) i), (i >= -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10]", FieldSpec.DataType.DOUBLE);
+    predicateEvaluator = buildRangePredicate("(-10\00010]", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((double) i), (i > -10 && i <= 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10)", FieldSpec.DataType.DOUBLE);
+    predicateEvaluator = buildRangePredicate("(-10\00010)", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((double) i), (i > -10 && i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.DOUBLE);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((double) i), (i <= 10), "Value: " + i);
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.DOUBLE);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((double) i), (i < 10));
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("[10\000*)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i >= 10), "Value: " + i);
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.FLOAT);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.FLOAT);
     for (int i = -20; i < 20; i++) {
       Assert.assertEquals(predicateEvaluator.applySV((float) i), (i > 10));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.DOUBLE);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((double) i));
     }
@@ -237,7 +237,7 @@ public class NoDictionaryRangePredicateEvaluatorTest {
     Assert.assertTrue(predicateEvaluator.applySV(Double.POSITIVE_INFINITY));
 
     predicateEvaluator =
-        buildRangePredicate(String.format("(%f\t\t%f)", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY),
+        buildRangePredicate(String.format("(%f\000%f)", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY),
             FieldSpec.DataType.DOUBLE);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV((double) i));
@@ -248,51 +248,51 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testStringPredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\t\t10]", FieldSpec.DataType.STRING);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[-10\00010]", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert
           .assertEquals(predicateEvaluator.applySV(value), (value.compareTo("-10") >= 0 && value.compareTo("10") <= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10]", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(-10\00010]", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert
           .assertEquals(predicateEvaluator.applySV(value), (value.compareTo("-10") > 0 && value.compareTo("10") <= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(-10\t\t10)", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(-10\00010)", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert.assertEquals(predicateEvaluator.applySV(value), (value.compareTo("-10") > 0 && value.compareTo("10") < 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert.assertEquals(predicateEvaluator.applySV(value), (value.compareTo("10") <= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert.assertEquals(predicateEvaluator.applySV(value), (value.compareTo("10") < 0));
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*)", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("[10\000*)", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert.assertEquals(predicateEvaluator.applySV(value), (value.compareTo("10") >= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       String value = Integer.toString(i);
       Assert.assertEquals(predicateEvaluator.applySV(value), (value.compareTo("10") > 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.STRING);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.STRING);
     for (int i = -20; i < 20; i++) {
       Assert.assertTrue(predicateEvaluator.applySV(Integer.toString(i)));
     }
@@ -300,52 +300,52 @@ public class NoDictionaryRangePredicateEvaluatorTest {
 
   @Test
   public void testBytesPredicateEvaluator() {
-    PredicateEvaluator predicateEvaluator = buildRangePredicate("[10\t\t20]", FieldSpec.DataType.BYTES);
+    PredicateEvaluator predicateEvaluator = buildRangePredicate("[10\00020]", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value),
           (ByteArray.compare(value, new byte[]{0x10}) >= 0 && ByteArray.compare(value, new byte[]{0x20}) <= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t20]", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(10\00020]", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value),
           (ByteArray.compare(value, new byte[]{0x10}) > 0 && ByteArray.compare(value, new byte[]{0x20}) <= 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t20)", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(10\00020)", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value),
           (ByteArray.compare(value, new byte[]{0x10}) > 0 && ByteArray.compare(value, new byte[]{0x20}) < 0));
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10]", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(*\00010]", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value), ByteArray.compare(value, new byte[]{0x10}) <= 0);
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t10)", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(*\00010)", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value), ByteArray.compare(value, new byte[]{0x10}) < 0);
     }
 
-    predicateEvaluator = buildRangePredicate("[10\t\t*)", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("[10\000*)", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value), ByteArray.compare(value, new byte[]{0x10}) >= 0);
     }
 
-    predicateEvaluator = buildRangePredicate("(10\t\t*)", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(10\000*)", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertEquals(predicateEvaluator.applySV(value), ByteArray.compare(value, new byte[]{0x10}) > 0);
     }
 
-    predicateEvaluator = buildRangePredicate("(*\t\t*)", FieldSpec.DataType.BYTES);
+    predicateEvaluator = buildRangePredicate("(*\000*)", FieldSpec.DataType.BYTES);
     for (int i = 0x00; i < 0x30; i++) {
       byte[] value = Integer.toString(i).getBytes();
       Assert.assertTrue(predicateEvaluator.applySV(value));


### PR DESCRIPTION
- Stop using deprecated range delimiter `\t\t` and replace it with `\0`. This can prevent the unexpected behavior for string comparison with embedded `\t`.
- Replace the magic string for range string with constants
- Fix the typo for PQL `>` and `>=` with identifier on right-hand side
- `RangePredicate` still support deprecated range delimiter for backward-compatibility in case queries are compiled from the old version