### PR TITLE
Bump up quartz version to 2.3.2 to prevent XXE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <scala.version>2.11.11</scala.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.4.0</jsonpath.version>
-    <quartz.version>2.3.0</quartz.version>
+    <quartz.version>2.3.2</quartz.version>
     <calcite.version>1.19.0</calcite.version>
     <lucene.version>8.2.0</lucene.version>
     <reflections.version>0.9.11</reflections.version>


### PR DESCRIPTION
`initDocumentParser` in xml/XMLSchedulingDataProcessor.java in Terracotta Quartz Scheduler through 2.3.0 allows XXE attacks via a job description. Upgrade quartz from 2.3.0 to [2.3.2](https://github.com/quartz-scheduler/quartz/releases) to fix the vulnerability.