### PR TITLE
[TE] migrate PQL queries to standard SQL

### DIFF
--- a/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
+++ b/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
@@ -173,7 +173,7 @@ public class PqlUtilsTest {
   public void testLimit() throws Exception {
     MetricFunction metricFunction = new MetricFunction(MetricAggFunction.AVG, METRIC.getMetricName(), this.metricId, COLLECTION, null, null);
 
-    TimeSpec timeSpec = new TimeSpec(METRIC.getMetricName(), TimeGranularity.fromString("1_SECONDS"), TimeSpec.SINCE_EPOCH_FORMAT);
+    TimeSpec timeSpec = new TimeSpec("Date", TimeGranularity.fromString("1_SECONDS"), TimeSpec.SINCE_EPOCH_FORMAT);
 
     ThirdEyeRequest request = ThirdEyeRequest.newBuilder()
         .setMetricFunctions(Collections.singletonList(metricFunction))
@@ -185,14 +185,14 @@ public class PqlUtilsTest {
 
     String pql = SqlUtils.getSql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
 
-    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension LIMIT 12345");
+    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  Date >= 1 AND Date < 2 GROUP BY dimension LIMIT 12345");
   }
 
   @Test
   public void testLimitDefault() throws Exception {
     MetricFunction metricFunction = new MetricFunction(MetricAggFunction.AVG, METRIC.getMetricName(), this.metricId, COLLECTION, null, null);
 
-    TimeSpec timeSpec = new TimeSpec(METRIC.getMetricName(), TimeGranularity.fromString("1_SECONDS"), TimeSpec.SINCE_EPOCH_FORMAT);
+    TimeSpec timeSpec = new TimeSpec("Date", TimeGranularity.fromString("1_SECONDS"), TimeSpec.SINCE_EPOCH_FORMAT);
 
     ThirdEyeRequest request = ThirdEyeRequest.newBuilder()
         .setMetricFunctions(Collections.singletonList(metricFunction))
@@ -203,6 +203,6 @@ public class PqlUtilsTest {
 
     String pql = SqlUtils.getSql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
 
-    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension LIMIT 100000");
+    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  Date >= 1 AND Date < 2 GROUP BY dimension LIMIT 100000");
   }
 }

--- a/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
+++ b/thirdeye/thirdeye-dashboard/src/test/java/org/apache/pinot/thirdeye/datasource/pinot/PqlUtilsTest.java
@@ -77,7 +77,7 @@ public class PqlUtilsTest {
 
   @Test(dataProvider = "betweenClauseArgs")
   public void getBetweenClause(DateTime start, DateTime end, TimeSpec timeSpec, String expected) throws ExecutionException {
-    String betweenClause = PqlUtils.getBetweenClause(start, end, timeSpec, "collection");
+    String betweenClause = SqlUtils.getBetweenClause(start, end, timeSpec, "collection");
     Assert.assertEquals(betweenClause, expected);
   }
 
@@ -138,7 +138,7 @@ public class PqlUtilsTest {
     dimensions.put("key7", "value71\'");
     dimensions.put("key7", "value72\"");
 
-    String output = PqlUtils.getDimensionWhereClause(dimensions);
+    String output = SqlUtils.getDimensionWhereClause(dimensions);
 
     Assert.assertEquals(output, ""
         + "key < \"value\" AND "
@@ -158,15 +158,15 @@ public class PqlUtilsTest {
 
   @Test
   public  void testQuote() {
-    Assert.assertEquals(PqlUtils.quote("123"), "123");
-    Assert.assertEquals(PqlUtils.quote("abc"), "\"abc\"");
-    Assert.assertEquals(PqlUtils.quote("123\'"), "\"123\'\"");
-    Assert.assertEquals(PqlUtils.quote("abc\""), "\'abc\"\'");
+    Assert.assertEquals(SqlUtils.quote("123"), "123");
+    Assert.assertEquals(SqlUtils.quote("abc"), "\"abc\"");
+    Assert.assertEquals(SqlUtils.quote("123\'"), "\"123\'\"");
+    Assert.assertEquals(SqlUtils.quote("abc\""), "\'abc\"\'");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public  void testQuoteFail() {
-    PqlUtils.quote("123\"\'");
+    SqlUtils.quote("123\"\'");
   }
 
   @Test
@@ -183,9 +183,9 @@ public class PqlUtilsTest {
         .setLimit(12345)
         .build("ref");
 
-    String pql = PqlUtils.getPql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
+    String pql = SqlUtils.getSql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
 
-    Assert.assertEquals(pql, "SELECT AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension TOP 12345");
+    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension LIMIT 12345");
   }
 
   @Test
@@ -201,8 +201,8 @@ public class PqlUtilsTest {
         .setGroupBy("dimension")
         .build("ref");
 
-    String pql = PqlUtils.getPql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
+    String pql = SqlUtils.getSql(request, metricFunction, ArrayListMultimap.<String, String>create(), timeSpec);
 
-    Assert.assertEquals(pql, "SELECT AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension TOP 100000");
+    Assert.assertEquals(pql, "SELECT dimension, AVG(metric) FROM collection WHERE  metric >= 1 AND metric < 2 GROUP BY dimension LIMIT 100000");
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotDataSourceTimeQuery.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotDataSourceTimeQuery.java
@@ -82,17 +82,17 @@ public class PinotDataSourceTimeQuery {
       TimeSpec timeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
 
       long cutoffTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
-      String timeClause = PqlUtils
+      String timeClause = SqlUtils
           .getBetweenClause(new DateTime(0, DateTimeZone.UTC), new DateTime(cutoffTime, DateTimeZone.UTC), timeSpec, dataset);
 
-      String maxTimePql = String.format(TIME_QUERY_TEMPLATE, functionName, timeSpec.getColumnName(), dataset, timeClause);
-      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, dataset);
+      String maxTimeSql = String.format(TIME_QUERY_TEMPLATE, functionName, timeSpec.getColumnName(), dataset, timeClause);
+      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimeSql, dataset);
 
       ThirdEyeResultSetGroup resultSetGroup;
       final long tStart = System.nanoTime();
       try {
-        pinotThirdEyeDataSource.refreshPQL(maxTimePinotQuery);
-        resultSetGroup = pinotThirdEyeDataSource.executePQL(maxTimePinotQuery);
+        pinotThirdEyeDataSource.refreshSQL(maxTimePinotQuery);
+        resultSetGroup = pinotThirdEyeDataSource.executeSQL(maxTimePinotQuery);
         ThirdeyeMetricsUtil
             .getRequestLog().success(this.pinotThirdEyeDataSource.getName(), dataset, timeSpec.getColumnName(), tStart, System.nanoTime());
       } catch (ExecutionException e) {
@@ -101,7 +101,7 @@ public class PinotDataSourceTimeQuery {
       }
 
       if (resultSetGroup.size() == 0 || resultSetGroup.get(0).getRowCount() == 0) {
-        LOGGER.error("Failed to get latest max time for dataset {} with PQL: {}", dataset, maxTimePinotQuery.getQuery());
+        LOGGER.error("Failed to get latest max time for dataset {} with SQL: {}", dataset, maxTimePinotQuery.getQuery());
       } else {
         DateTimeZone timeZone = Utils.getDataTimeZone(dataset);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -168,19 +168,19 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
                   datasetConfig.getPreAggregatedKeyword());
         }
 
-        String pql;
+        String sql;
         MetricConfigDTO metricConfig = metricFunction.getMetricConfig();
         if (metricConfig != null && metricConfig.isDimensionAsMetric()) {
-          pql = PqlUtils.getDimensionAsMetricPql(request, metricFunction, decoratedFilterSet, dataTimeSpec,
+          sql = SqlUtils.getDimensionAsMetricSql(request, metricFunction, decoratedFilterSet, dataTimeSpec,
               datasetConfig);
         } else {
-          pql = PqlUtils.getPql(request, metricFunction, decoratedFilterSet, dataTimeSpec);
+          sql = SqlUtils.getSql(request, metricFunction, decoratedFilterSet, dataTimeSpec);
         }
 
         ThirdEyeResultSetGroup resultSetGroup;
         final long tStartFunction = System.nanoTime();
         try {
-          resultSetGroup = this.executePQL(new PinotQuery(pql, dataset));
+          resultSetGroup = this.executeSQL(new PinotQuery(sql, dataset));
           if (metricConfig != null) {
             ThirdeyeMetricsUtil.getRequestLog()
                 .success(this.getName(), metricConfig.getDataset(), metricConfig.getName(), tStartFunction, System.nanoTime());
@@ -275,7 +275,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
    *
    * @throws ExecutionException is thrown if failed to connect to Pinot or gets results from Pinot.
    */
-  public ThirdEyeResultSetGroup executePQL(PinotQuery pinotQuery) throws ExecutionException {
+  public ThirdEyeResultSetGroup executeSQL(PinotQuery pinotQuery) throws ExecutionException {
     Preconditions
         .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
 
@@ -295,7 +295,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
    *
    * @throws ExecutionException is thrown if failed to connect to Pinot or gets results from Pinot.
    */
-  public ThirdEyeResultSetGroup refreshPQL(PinotQuery pinotQuery) throws ExecutionException {
+  public ThirdEyeResultSetGroup refreshSQL(PinotQuery pinotQuery) throws ExecutionException {
     Preconditions
         .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
 

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/SqlUtils.java
@@ -398,7 +398,7 @@ public class SqlUtils {
     String quoteChar = "";
     if (!StringUtils.isNumeric(value)) {
       quoteChar = "\"";
-      if (value.contains(quoteChar) || StringUtils.isEmpty(value)) {
+      if (StringUtils.isEmpty(value) || value.contains(quoteChar)) {
         quoteChar = "\'";
       }
       if (value.contains(quoteChar)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/SqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/SqlUtils.java
@@ -134,7 +134,9 @@ public class SqlUtils {
         builder.append(groupByDimension).append(", ");
       }
     }
-    builder.append(getTimeColumnQueryName(aggregationGranularity, timeSpec)).append(", ");
+    if (aggregationGranularity != null) {
+      builder.append(getTimeColumnQueryName(aggregationGranularity, timeSpec)).append(", ");
+    }
     String metricName = null;
     if (metricFunction.getMetricName().equals("*")) {
       metricName = "*";
@@ -363,7 +365,9 @@ public class SqlUtils {
   private static String getDimensionGroupByClause(List<String> groupBy,
       TimeGranularity aggregationGranularity, TimeSpec timeSpec) {
     List<String> groups = new LinkedList<>();
-    groups.add(getTimeColumnQueryName(aggregationGranularity, timeSpec));
+    if (aggregationGranularity != null) {
+      groups.add(getTimeColumnQueryName(aggregationGranularity, timeSpec));
+    }
     if (groupBy != null) {
       groups.addAll(groupBy);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
@@ -70,7 +70,7 @@ public class PinotDataSourceResource {
     String resultString;
     PinotQuery pinotQuery = new PinotQuery(pql, tableName);
     try {
-      ThirdEyeResultSetGroup thirdEyeResultSetGroup = pinotDataSource.executePQL(pinotQuery);
+      ThirdEyeResultSetGroup thirdEyeResultSetGroup = pinotDataSource.executeSQL(pinotQuery);
       resultString = OBJECT_MAPPER.writeValueAsString(thirdEyeResultSetGroup);
     } catch (ExecutionException | JsonProcessingException e) {
       LOG.error("Failed to execute PQL ({}) due to the exception:", pinotQuery);


### PR DESCRIPTION
This PR changes the query to Pinot to standard SQL because Pinot is adopting standard SQL syntax and semantics for querying Pinot.