### PR TITLE
Adding pinot minion metrics to JMX Prometheus reporter

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -206,3 +206,10 @@ rules:
   name: "pinot_server_netty_tcp_$2_$3"
   labels:
     id: "$1"
+# Pinot Minions
+- pattern: "\"org.apache.pinot.minion.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(\\w+)\"><>(\\w+)"
+  name: "pinot_minion_$1_$2"
+- pattern: "\"org.apache.pinot.minion.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(\\w+).(\\w+)\"><>(\\w+)"
+  name: "pinot_minion_$2_$3"
+  labels:
+    id: "$1"


### PR DESCRIPTION
## Description
Adding pinot minion metrics to JMX Prometheus reporter.

Publishing metrics:
Meter:
```
pinot.minion.healthCheckBadCalls
pinot.minion.healthCheckGoodCalls
pinot.minion.<task_type>.numberTasksCompleted
pinot.minion.<task_type>.numberTasksExecuted
```
Timer:
```
pinot.minion.<task_type>.taskExecution
```

Sample Screenshot from jconsole
![image](https://user-images.githubusercontent.com/1202120/105782045-8df66d80-5f28-11eb-84d2-eed8a3187059.png)

![image](https://user-images.githubusercontent.com/1202120/105781810-11fc2580-5f28-11eb-87c5-dd86b9d3413f.png)

Sample output from jmx agent HTTP endpoint:
```
# HELP pinot_minion_healthCheckBadCalls_FifteenMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckBadCalls"><>FifteenMinuteRate)
# TYPE pinot_minion_healthCheckBadCalls_FifteenMinuteRate untyped
pinot_minion_healthCheckBadCalls_FifteenMinuteRate 0.0
# HELP pinot_minion_healthCheckBadCalls_FiveMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckBadCalls"><>FiveMinuteRate)
# TYPE pinot_minion_healthCheckBadCalls_FiveMinuteRate untyped
pinot_minion_healthCheckBadCalls_FiveMinuteRate 0.0
# HELP pinot_minion_taskExecution_50thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>50thPercentile)
# TYPE pinot_minion_taskExecution_50thPercentile untyped
pinot_minion_taskExecution_50thPercentile{id="SegmentGenerationAndPushTask",} 10880.8888685
# HELP pinot_minion_healthCheckGoodCalls_OneMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckGoodCalls"><>OneMinuteRate)
# TYPE pinot_minion_healthCheckGoodCalls_OneMinuteRate untyped
pinot_minion_healthCheckGoodCalls_OneMinuteRate 0.0
# HELP pinot_minion_numberTasksExecuted_MeanRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksExecuted"><>MeanRate)
# TYPE pinot_minion_numberTasksExecuted_MeanRate untyped
pinot_minion_numberTasksExecuted_MeanRate{id="SegmentGenerationAndPushTask",} 0.002321165098931667
# HELP pinot_minion_taskExecution_999thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>999thPercentile)
# TYPE pinot_minion_taskExecution_999thPercentile untyped
pinot_minion_taskExecution_999thPercentile{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_numberTasksExecuted_FifteenMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksExecuted"><>FifteenMinuteRate)
# TYPE pinot_minion_numberTasksExecuted_FifteenMinuteRate untyped
pinot_minion_numberTasksExecuted_FifteenMinuteRate{id="SegmentGenerationAndPushTask",} 0.0778037296061929
# HELP pinot_minion_taskExecution_95thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>95thPercentile)
# TYPE pinot_minion_taskExecution_95thPercentile untyped
pinot_minion_taskExecution_95thPercentile{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_taskExecution_FifteenMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>FifteenMinuteRate)
# TYPE pinot_minion_taskExecution_FifteenMinuteRate untyped
pinot_minion_taskExecution_FifteenMinuteRate{id="SegmentGenerationAndPushTask",} 0.07824746856425359
# HELP pinot_minion_taskExecution_99thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>99thPercentile)
# TYPE pinot_minion_taskExecution_99thPercentile untyped
pinot_minion_taskExecution_99thPercentile{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_numberTasksCompleted_FifteenMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksCompleted"><>FifteenMinuteRate)
# TYPE pinot_minion_numberTasksCompleted_FifteenMinuteRate untyped
pinot_minion_numberTasksCompleted_FifteenMinuteRate{id="SegmentGenerationAndPushTask",} 0.07824746856425359
# HELP pinot_minion_healthCheckGoodCalls_Count Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckGoodCalls"><>Count)
# TYPE pinot_minion_healthCheckGoodCalls_Count untyped
pinot_minion_healthCheckGoodCalls_Count 0.0
# HELP pinot_minion_healthCheckBadCalls_MeanRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckBadCalls"><>MeanRate)
# TYPE pinot_minion_healthCheckBadCalls_MeanRate untyped
pinot_minion_healthCheckBadCalls_MeanRate 0.0
# HELP pinot_minion_taskExecution_Count Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>Count)
# TYPE pinot_minion_taskExecution_Count untyped
pinot_minion_taskExecution_Count{id="SegmentGenerationAndPushTask",} 2.0
# HELP pinot_minion_numberTasksExecuted_OneMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksExecuted"><>OneMinuteRate)
# TYPE pinot_minion_numberTasksExecuted_OneMinuteRate untyped
pinot_minion_numberTasksExecuted_OneMinuteRate{id="SegmentGenerationAndPushTask",} 1.5541820543561043E-7
# HELP pinot_minion_taskExecution_75thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>75thPercentile)
# TYPE pinot_minion_taskExecution_75thPercentile untyped
pinot_minion_taskExecution_75thPercentile{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_taskExecution_StdDev Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>StdDev)
# TYPE pinot_minion_taskExecution_StdDev untyped
pinot_minion_taskExecution_StdDev{id="SegmentGenerationAndPushTask",} 12200.43870888015
# HELP pinot_minion_taskExecution_MeanRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>MeanRate)
# TYPE pinot_minion_taskExecution_MeanRate untyped
pinot_minion_taskExecution_MeanRate{id="SegmentGenerationAndPushTask",} 0.002328596939660439
# HELP pinot_minion_taskExecution_OneMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>OneMinuteRate)
# TYPE pinot_minion_taskExecution_OneMinuteRate untyped
pinot_minion_taskExecution_OneMinuteRate{id="SegmentGenerationAndPushTask",} 1.8006112863228987E-7
# HELP pinot_minion_numberTasksCompleted_MeanRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksCompleted"><>MeanRate)
# TYPE pinot_minion_numberTasksCompleted_MeanRate untyped
pinot_minion_numberTasksCompleted_MeanRate{id="SegmentGenerationAndPushTask",} 0.0023279578505843636
# HELP pinot_minion_taskExecution_Max Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>Max)
# TYPE pinot_minion_taskExecution_Max untyped
pinot_minion_taskExecution_Max{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_healthCheckGoodCalls_MeanRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckGoodCalls"><>MeanRate)
# TYPE pinot_minion_healthCheckGoodCalls_MeanRate untyped
pinot_minion_healthCheckGoodCalls_MeanRate 0.0
# HELP pinot_minion_numberTasksExecuted_Count Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksExecuted"><>Count)
# TYPE pinot_minion_numberTasksExecuted_Count untyped
pinot_minion_numberTasksExecuted_Count{id="SegmentGenerationAndPushTask",} 2.0
# HELP pinot_minion_numberTasksExecuted_FiveMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksExecuted"><>FiveMinuteRate)
# TYPE pinot_minion_numberTasksExecuted_FiveMinuteRate untyped
pinot_minion_numberTasksExecuted_FiveMinuteRate{id="SegmentGenerationAndPushTask",} 0.01179855626140159
# HELP pinot_minion_healthCheckGoodCalls_FifteenMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckGoodCalls"><>FifteenMinuteRate)
# TYPE pinot_minion_healthCheckGoodCalls_FifteenMinuteRate untyped
pinot_minion_healthCheckGoodCalls_FifteenMinuteRate 0.0
# HELP pinot_minion_numberTasksCompleted_Count Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksCompleted"><>Count)
# TYPE pinot_minion_numberTasksCompleted_Count untyped
pinot_minion_numberTasksCompleted_Count{id="SegmentGenerationAndPushTask",} 2.0
# HELP pinot_minion_taskExecution_98thPercentile Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>98thPercentile)
# TYPE pinot_minion_taskExecution_98thPercentile untyped
pinot_minion_taskExecution_98thPercentile{id="SegmentGenerationAndPushTask",} 19507.901813
# HELP pinot_minion_taskExecution_FiveMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>FiveMinuteRate)
# TYPE pinot_minion_taskExecution_FiveMinuteRate untyped
pinot_minion_taskExecution_FiveMinuteRate{id="SegmentGenerationAndPushTask",} 0.012012947587373967
# HELP pinot_minion_numberTasksCompleted_OneMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksCompleted"><>OneMinuteRate)
# TYPE pinot_minion_numberTasksCompleted_OneMinuteRate untyped
pinot_minion_numberTasksCompleted_OneMinuteRate{id="SegmentGenerationAndPushTask",} 1.8006112863228987E-7
# HELP pinot_minion_taskExecution_Min Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>Min)
# TYPE pinot_minion_taskExecution_Min untyped
pinot_minion_taskExecution_Min{id="SegmentGenerationAndPushTask",} 2253.875924
# HELP pinot_minion_numberTasksCompleted_FiveMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.numberTasksCompleted"><>FiveMinuteRate)
# TYPE pinot_minion_numberTasksCompleted_FiveMinuteRate untyped
pinot_minion_numberTasksCompleted_FiveMinuteRate{id="SegmentGenerationAndPushTask",} 0.012012947587373967
# HELP pinot_minion_taskExecution_Mean Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.SegmentGenerationAndPushTask.taskExecution"><>Mean)
# TYPE pinot_minion_taskExecution_Mean untyped
pinot_minion_taskExecution_Mean{id="SegmentGenerationAndPushTask",} 10880.8888685
# HELP pinot_minion_healthCheckBadCalls_Count Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckBadCalls"><>Count)
# TYPE pinot_minion_healthCheckBadCalls_Count untyped
pinot_minion_healthCheckBadCalls_Count 0.0
# HELP pinot_minion_healthCheckGoodCalls_FiveMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckGoodCalls"><>FiveMinuteRate)
# TYPE pinot_minion_healthCheckGoodCalls_FiveMinuteRate untyped
pinot_minion_healthCheckGoodCalls_FiveMinuteRate 0.0
# HELP pinot_minion_healthCheckBadCalls_OneMinuteRate Attribute exposed for management ("org.apache.pinot.minion.metrics"<type="MinionMetrics", name="pinot.minion.healthCheckBadCalls"><>OneMinuteRate)
# TYPE pinot_minion_healthCheckBadCalls_OneMinuteRate untyped
pinot_minion_healthCheckBadCalls_OneMinuteRate 0.0
```