### PR TITLE
Support chained transform functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
@@ -18,8 +18,13 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -36,24 +41,48 @@ import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
  */
 public class ExpressionTransformer implements RecordTransformer {
 
-  private final Map<String, FunctionEvaluator> _expressionEvaluators = new HashMap<>();
+  private final LinkedHashMap<String, FunctionEvaluator> _expressionEvaluators = new LinkedHashMap<>();
 
   public ExpressionTransformer(TableConfig tableConfig, Schema schema) {
+    Map<String, FunctionEvaluator> expressionEvaluators = new HashMap<>();
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getTransformConfigs() != null) {
       for (TransformConfig transformConfig : tableConfig.getIngestionConfig().getTransformConfigs()) {
-        _expressionEvaluators.put(transformConfig.getColumnName(),
+        expressionEvaluators.put(transformConfig.getColumnName(),
             FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction()));
       }
     }
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       String fieldName = fieldSpec.getName();
-      if (!fieldSpec.isVirtualColumn() && !_expressionEvaluators.containsKey(fieldName)) {
+      if (!fieldSpec.isVirtualColumn() && !expressionEvaluators.containsKey(fieldName)) {
         FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
         if (functionEvaluator != null) {
-          _expressionEvaluators.put(fieldName, functionEvaluator);
+          expressionEvaluators.put(fieldName, functionEvaluator);
         }
       }
     }
+
+    // Sort the transform functions based on dependencies
+    Set<String> visited = new HashSet<>();
+    for (Map.Entry<String, FunctionEvaluator> entry : expressionEvaluators.entrySet()) {
+      topologicalSort(entry.getKey(), expressionEvaluators, visited);
+    }
+  }
+
+  private void topologicalSort(String column, Map<String, FunctionEvaluator> expressionEvaluators, Set<String> visited) {
+    if (visited.contains(column)) {
+      return;
+    }
+    FunctionEvaluator functionEvaluator = expressionEvaluators.get(column);
+    if (functionEvaluator == null) {
+      visited.add(column);
+      return;
+    }
+    List<String> arguments = functionEvaluator.getArguments();
+    for (String arg : arguments) {
+      topologicalSort(arg, expressionEvaluators, visited);
+    }
+    visited.add(column);
+    _expressionEvaluators.put(column, functionEvaluator);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
@@ -18,20 +18,19 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.core.data.function.FunctionEvaluator;
+import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.core.data.function.FunctionEvaluator;
-import org.apache.pinot.core.data.function.FunctionEvaluatorFactory;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.util;
 
 import com.google.common.base.Preconditions;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -251,7 +250,6 @@ public final class TableConfigUtils {
       List<TransformConfig> transformConfigs = ingestionConfig.getTransformConfigs();
       if (transformConfigs != null) {
         Set<String> transformColumns = new HashSet<>();
-        Set<String> argumentColumns = new HashSet<>();
         for (TransformConfig transformConfig : transformConfigs) {
           String columnName = transformConfig.getColumnName();
           if (schema != null) {
@@ -280,12 +278,6 @@ public final class TableConfigUtils {
                 "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
                     + columnName + "'");
           }
-          argumentColumns.addAll(arguments);
-        }
-        // TODO: remove this once we add support for derived columns/chained transform functions
-        if (!Collections.disjoint(transformColumns, argumentColumns)) {
-          throw new IllegalStateException(
-              "Derived columns not supported yet. Cannot use a transform column as argument to another transform functions");
         }
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -375,16 +375,11 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    // chained transform functions
+    // derived columns - should pass
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
-        new IngestionConfig(null, null, null,
-            Lists.newArrayList(new TransformConfig("a", "reverse(x)"), new TransformConfig("b", "lower(a)")))).build();
-    try {
-      TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail due to using transformed column 'a' as argument for transform function of column 'b'");
-    } catch (IllegalStateException e) {
-      // expected
-    }
+        new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("transformedCol", "reverse(x)"),
+            new TransformConfig("myCol", "lower(transformedCol)")))).build();
+    TableConfigUtils.validate(tableConfig, schema);
   }
 
   @Test


### PR DESCRIPTION
## Description
Allow chained transform functions. This will be needed when supporting derived columns https://github.com/apache/incubator-pinot/pull/6494. 
For example, millisSinceEpoch = f(isoDateTime) and hoursSinceEpoch = f(millisSinceEpoch) i.e. User created millisSinceEpoch column while ingesting, using a transform function on a isoDateTime column, and did not keep the isoDateTime column. If we don't allow chained transform functions, user won't be able to use millisSinceEpoch column in derived function for hoursSinceEpoch.


## Release Notes
You can now add chained transform functions. 