### PR TITLE
Adding cron scheduler metrics reporting

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -52,6 +52,21 @@ rules:
   name: "pinot_controller_validateion_$2_$3"
   labels:
     table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.cronSchedulerJobScheduled.(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobScheduled_$3"
+  labels:
+    table: "$1"
+    taskType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(\\w+)\\.(\\w+).cronSchedulerTriggered\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerTriggered_$3"
+  labels:
+    table: "$1"
+    taskType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(\\w+)\\.(\\w+).cronSchedulerJobExecutionTimeMs\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobExecutionTimeMs_$3"
+  labels:
+    table: "$1"
+    taskType: "$2"
 # Pinot Broker
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+).authorization\"><>(\\w+)"
   name: "pinot_broker_authorization_$2"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -64,7 +64,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   TABLE_STORAGE_QUOTA_UTILIZATION("TableStorageQuotaUtilization", false),
 
   // Percentage of segments we failed to get size for
-  TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false);
+  TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false),
+
+  // Number of scheduled Cron jobs
+  CRON_SCHEDULER_JOB_SCHEDULED("cronSchedulerJobScheduled", false);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -48,7 +48,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
-  NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true);
+  NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
+  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false);
 
   private final String brokerMeterName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerTimer.java
@@ -26,7 +26,7 @@ import org.apache.pinot.common.Utils;
  *
  */
 public enum ControllerTimer implements AbstractMetrics.Timer {
-  ;
+  CRON_SCHEDULER_JOB_EXECUTION_TIME_MS("cronSchedulerJobExecutionTimeMs", false);
 
   private final String timerName;
   private final boolean global;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -72,6 +72,10 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
     }
   }
 
+  public final ControllerMetrics getControllerMetrics() {
+    return _controllerMetrics;
+  }
+
   /**
    * Processes the given list of tables, and returns the number of tables processed.
    * <p>


### PR DESCRIPTION
## Description
Adding metrics for cron scheduler execution:
![image](https://user-images.githubusercontent.com/1202120/106202956-8674d580-616f-11eb-8624-1c248d41c59d.png)


JMX report generates sample records below:
```
# HELP pinot_controller_cronSchedulerJobExecutionTimeMs_Count Attribute exposed for management ("org.apache.pinot.common.metrics"<type="ControllerMetrics", name="pinot.controller.githubEvents_OFFLINE.SegmentGenerationAndPushTask.cronSchedulerJobExecutionTimeMs"><>Count)
# TYPE pinot_controller_cronSchedulerJobExecutionTimeMs_Count untyped
pinot_controller_cronSchedulerJobExecutionTimeMs_Count{table="githubEvents_OFFLINE",taskType="SegmentGenerationAndPushTask",} 1.0
# HELP pinot_controller_cronSchedulerJobScheduled_Value Attribute exposed for management ("org.apache.pinot.common.metrics"<type="ControllerMetrics", name="pinot.controller.cronSchedulerJobScheduled.githubEvents_OFFLINE.SegmentGenerationAndPushTask"><>Value)
# TYPE pinot_controller_cronSchedulerJobScheduled_Value untyped
pinot_controller_cronSchedulerJobScheduled_Value{table="githubEvents_OFFLINE",taskType="SegmentGenerationAndPushTask",} 1.0

```
