### PR TITLE
Add Access Control for REST endpoints of Controller - Declarative Approach

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -18,19 +18,35 @@
  */
 package org.apache.pinot.controller.api;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessControlUtils;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -56,6 +72,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
     register(new CorsFilter());
+    register(AuthFilter.class);
     // property("jersey.config.server.tracing.type", "ALL");
     // property("jersey.config.server.tracing.threshold", "VERBOSE");
   }
@@ -122,6 +139,66 @@ public class ControllerAdminApiApplication extends ResourceConfig {
         ContainerResponseContext containerResponseContext)
         throws IOException {
       containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+    }
+  }
+
+  @javax.ws.rs.ext.Provider
+  public static class AuthFilter implements ContainerRequestFilter {
+
+    @Inject
+    Provider<Request> _requestProvider;
+
+    @Inject
+    AccessControlFactory _accessControlFactory;
+
+    @Context
+    ResourceInfo _resourceInfo;
+
+    @Context
+    HttpHeaders _httpHeaders;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+        throws IOException {
+      // check if authentication is required
+      Method endpointMethod = _resourceInfo.getResourceMethod();
+      if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
+        // Perform authentication:
+        // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
+        // followings:
+        //     - "tableName",
+        //     - "tableNameWithType", or
+        //     - "schemaName"
+        // If table name is not available, it means the endpoint is not a table-level endpoint.
+        AccessControlUtils accessControlUtils = new AccessControlUtils();
+        AccessType accessType = endpointMethod.getAnnotation(Authenticate.class).value();
+        String endpointUrl = _requestProvider.get().getRequestURL().toString();
+        UriInfo uriInfo = requestContext.getUriInfo();
+        Optional<String> tableName = extractTableName(uriInfo.getPathParameters(), uriInfo.getQueryParameters());
+        accessControlUtils
+            .validatePermission(tableName, accessType, _httpHeaders, endpointUrl, _accessControlFactory.create());
+      }
+    }
+
+    @VisibleForTesting
+    Optional<String> extractTableName(MultivaluedMap<String, String> pathParameters,
+        MultivaluedMap<String, String> queryParameters) {
+      Optional<String> tableName = extractTableName(pathParameters);
+      if (tableName.isPresent()) {
+        return tableName;
+      }
+      return extractTableName(queryParameters);
+    }
+
+    private Optional<String> extractTableName(MultivaluedMap<String, String> mmap) {
+      String tableName = mmap.getFirst("tableName");
+      if (tableName == null) {
+        tableName = mmap.getFirst("tableNameWithType");
+        if (tableName == null) {
+          tableName = mmap.getFirst("schemaName");
+        }
+      }
+      return Optional.ofNullable(tableName);
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -30,9 +30,38 @@ public interface AccessControl {
   /**
    * Return whether the client has data access to the given table.
    *
-   * @param httpHeaders Http headers
+   * Note: This method is only used fore read access. It's being deprecated and its usage will be replaced by
+   * `hasAccess` method with AccessType.READ.
+   *
+   * @param httpHeaders HTTP headers containing requester identity
    * @param tableName Name of the table to be accessed
    * @return Whether the client has data access to the table
    */
+  @Deprecated
   boolean hasDataAccess(HttpHeaders httpHeaders, String tableName);
+
+  /**
+   * Return whether the client has permission to the given table
+   *
+   * @param tableName name of the table to be accessed
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity
+   * @param endpointUrl the request url for which this access control is called
+   * @return whether the client has permission
+   */
+  default boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    return true;
+  }
+
+  /**
+   * Return whether the client has permission to access the epdpoints with are not table level
+   *
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers
+   * @param endpointUrl the request url for which this access control is called
+   * @return whether the client has permission
+   */
+  default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+    return true;
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.access;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.resources.ControllerApplicationException;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utility class to simplify access control validation. This class is simple wrapper around AccessControl class.
+ */
+public class AccessControlUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AccessControlUtils.class);
+
+  /**
+   * Validate permission for the given access type against the given table
+   *
+   * @param tableName name of the table to be accessed
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity required by access control object
+   * @param endpointUrl the request url for which this access control is called
+   * @param accessControl AccessControl object which does the actual validation
+   */
+  public void validatePermission(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl,
+      AccessControl accessControl) {
+    validatePermission(Optional.of(tableName), accessType, httpHeaders, endpointUrl, accessControl);
+  }
+
+  /**
+   * Validate permission for the given access type for a non-table level endpoint
+   *
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity required by access control object
+   * @param endpointUrl the request url for which this access control is called
+   * @param accessControl AccessControl object which does the actual validation
+   */
+  public void validatePermission(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl,
+      AccessControl accessControl) {
+    validatePermission(Optional.empty(), accessType, httpHeaders, endpointUrl, accessControl);
+  }
+
+  /**
+   * Validate permission for the given access type against the given table
+   *
+   * @param tableNameOpt name of the table to be accessed; if `none`, it's a non-table level endpoint.
+   * @param accessType type of the access
+   * @param httpHeaders HTTP headers containing requester identity required by access control object
+   * @param endpointUrl the request url for which this access control is called
+   * @param accessControl AccessControl object which does the actual validation
+   */
+  public void validatePermission(Optional<String> tableNameOpt, AccessType accessType, HttpHeaders httpHeaders,
+      String endpointUrl, AccessControl accessControl) {
+      boolean hasPermission;
+      String accessTypeToEndpointMsg =
+          String.format("access type '%s' to the endpoint '%s'", accessType, endpointUrl) + tableNameOpt
+              .map(name -> String.format(" for table '%s'", name)).orElse("");
+      try {
+        if (tableNameOpt.isPresent()) {
+          String rawTableName = TableNameBuilder.extractRawTableName(tableNameOpt.get());
+          hasPermission = accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl);
+        } else {
+          hasPermission = accessControl.hasAccess(accessType, httpHeaders, endpointUrl);
+        }
+      } catch (Exception e) {
+        throw new ControllerApplicationException(LOGGER,
+            "Caught exception while validating permission for " + accessTypeToEndpointMsg,
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
+      if (!hasPermission) {
+        throw new ControllerApplicationException(LOGGER, "Permission is denied for " + accessTypeToEndpointMsg,
+            Response.Status.FORBIDDEN);
+      }
+    }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessType.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessType.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.access;
+
+/**
+ * Different access types used in access control of the rest endpoints
+ */
+public enum AccessType {
+  CREATE, READ, UPDATE, DELETE
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/Authenticate.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/Authenticate.java
@@ -28,8 +28,7 @@ import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 
 /**
  * Annotation to be used on top of REST endpoints. Methods annotated with this annotation automatically get
- * authenticated in {@link ControllerAdminApiApplication.AuthFilter} and if validation passes, then the methods get
- * executed.
+ * authenticated in {@link AuthenticationFilter} and if validation passes, then the methods get executed.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/Authenticate.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/Authenticate.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.access;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.pinot.controller.api.ControllerAdminApiApplication;
+
+
+/**
+ * Annotation to be used on top of REST endpoints. Methods annotated with this annotation automatically get
+ * authenticated in {@link ControllerAdminApiApplication.AuthFilter} and if validation passes, then the methods get
+ * executed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Authenticate {
+  public AccessType value();
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.access;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import org.glassfish.grizzly.http.server.Request;
+
+
+/**
+ * A container filter class responsible for automatic authentication of REST endpoints. Any rest endpoints annotated
+ * with {@link Authenticate} annotation, will go through authentication.
+ */
+@javax.ws.rs.ext.Provider
+public class AuthenticationFilter implements ContainerRequestFilter {
+
+  @Inject
+  Provider<Request> _requestProvider;
+
+  @Inject
+  AccessControlFactory _accessControlFactory;
+
+  @Context
+  ResourceInfo _resourceInfo;
+
+  @Context
+  HttpHeaders _httpHeaders;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext)
+      throws IOException {
+    // check if authentication is required
+    Method endpointMethod = _resourceInfo.getResourceMethod();
+    if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
+      // Perform authentication:
+      // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
+      // followings:
+      //     - "tableName",
+      //     - "tableNameWithType", or
+      //     - "schemaName"
+      // If table name is not available, it means the endpoint is not a table-level endpoint.
+      AccessControlUtils accessControlUtils = new AccessControlUtils();
+      AccessType accessType = endpointMethod.getAnnotation(Authenticate.class).value();
+      String endpointUrl = _requestProvider.get().getRequestURL().toString();
+      UriInfo uriInfo = requestContext.getUriInfo();
+      Optional<String> tableName = extractTableName(uriInfo.getPathParameters(), uriInfo.getQueryParameters());
+      accessControlUtils
+          .validatePermission(tableName, accessType, _httpHeaders, endpointUrl, _accessControlFactory.create());
+    }
+  }
+
+  @VisibleForTesting
+  Optional<String> extractTableName(MultivaluedMap<String, String> pathParameters,
+      MultivaluedMap<String, String> queryParameters) {
+    Optional<String> tableName = extractTableName(pathParameters);
+    if (tableName.isPresent()) {
+      return tableName;
+    }
+    return extractTableName(queryParameters);
+  }
+
+  private Optional<String> extractTableName(MultivaluedMap<String, String> mmap) {
+    String tableName = mmap.getFirst("tableName");
+    if (tableName == null) {
+      tableName = mmap.getFirst("tableNameWithType");
+      if (tableName == null) {
+        tableName = mmap.getFirst("schemaName");
+      }
+    }
+    return Optional.ofNullable(tableName);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -42,6 +42,8 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import org.apache.pinot.controller.util.SegmentCompletionUtils;
@@ -257,6 +259,7 @@ public class LLCSegmentCompletionHandlers {
 
   @POST
   @Path(SegmentCompletionProtocol.MSG_TYPE_COMMIT)
+  @Authenticate(AccessType.CREATE)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Produces(MediaType.APPLICATION_JSON)
   public String segmentCommit(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,
@@ -340,6 +343,7 @@ public class LLCSegmentCompletionHandlers {
   // TODO: remove this API. Should not upload segment via controller
   @POST
   @Path(SegmentCompletionProtocol.MSG_TYPE_SEGMENT_UPLOAD)
+  @Authenticate(AccessType.CREATE)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   public String segmentUpload(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,
@@ -380,6 +384,7 @@ public class LLCSegmentCompletionHandlers {
 
   @POST
   @Path(SegmentCompletionProtocol.MSG_TYPE_COMMIT_END_METADATA)
+  @Authenticate(AccessType.CREATE)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   public String segmentCommitEndWithMetadata(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
@@ -43,6 +43,8 @@ import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -206,6 +208,7 @@ public class PinotBrokerRestletResource {
 
   @POST
   @Path("/brokers/instances/{instanceName}/qps")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Enable/disable the query rate limiting for a broker instance", notes = "Enable/disable the query rate limiting for a broker instance")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotClusterConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotClusterConfigs.java
@@ -43,6 +43,8 @@ import javax.ws.rs.core.Response;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
@@ -88,6 +90,7 @@ public class PinotClusterConfigs {
 
   @POST
   @Path("/cluster/configs")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update cluster configuration")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Server error updating configuration")})
@@ -115,6 +118,7 @@ public class PinotClusterConfigs {
 
   @DELETE
   @Path("/cluster/configs/{configName}")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete cluster configuration")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Server error deleting configuration")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -37,6 +37,8 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.FileIngestionHelper;
 import org.apache.pinot.controller.util.FileIngestionHelper.DataPayload;
@@ -108,6 +110,7 @@ public class PinotIngestionRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromFile")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Ingest a file", notes = "Creates a segment using given file and pushes it to Pinot. "
       + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "
       + "\n Example usage (query params need encoding):" + "\n```"
@@ -147,6 +150,7 @@ public class PinotIngestionRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/ingestFromURI")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Ingest from the given URI", notes =
       "Creates a segment using file at the given URI and pushes it to Pinot. "
           + "\n All steps happen on the controller. This API is NOT meant for production environments/large input files. "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceAssignmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceAssignmentRestletResource.java
@@ -44,6 +44,8 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.assignment.instance.InstanceAssignmentDriver;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -114,6 +116,7 @@ public class PinotInstanceAssignmentRestletResource {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/assignInstances")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Assign server instances to a table")
   public Map<InstancePartitionsType, InstancePartitions> assignInstances(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName,
@@ -198,6 +201,7 @@ public class PinotInstanceAssignmentRestletResource {
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/instancePartitions")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Create/update the instance partitions")
   public Map<InstancePartitionsType, InstancePartitions> setInstancePartitions(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName, String instancePartitionsStr) {
@@ -236,6 +240,7 @@ public class PinotInstanceAssignmentRestletResource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/instancePartitions")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Remove the instance partitions")
   public SuccessResponse removeInstancePartitions(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName,
@@ -270,6 +275,7 @@ public class PinotInstanceAssignmentRestletResource {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/replaceInstance")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Replace an instance in the instance partitions")
   public Map<InstancePartitionsType, InstancePartitions> replaceInstance(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -40,6 +40,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.spi.config.instance.Instance;
@@ -117,6 +119,7 @@ public class PinotInstanceRestletResource {
 
   @POST
   @Path("/instances")
+  @Authenticate(AccessType.CREATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Create a new instance", consumes = MediaType.APPLICATION_JSON, notes = "Creates a new instance with given instance config")
@@ -131,6 +134,7 @@ public class PinotInstanceRestletResource {
 
   @POST
   @Path("/instances/{instanceName}/state")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.TEXT_PLAIN)
   @ApiOperation(value = "Enable/disable/drop an instance", notes = "Enable/disable/drop an instance")
@@ -172,6 +176,7 @@ public class PinotInstanceRestletResource {
 
   @DELETE
   @Path("/instances/{instanceName}")
+  @Authenticate(AccessType.DELETE)
   @Consumes(MediaType.TEXT_PLAIN)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Drop an instance", notes = "Drop an instance")
@@ -193,6 +198,7 @@ public class PinotInstanceRestletResource {
 
   @PUT
   @Path("/instances/{instanceName}")
+  @Authenticate(AccessType.UPDATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update the specified instance", consumes = MediaType.APPLICATION_JSON, notes = "Update specified instance with given instance config")
@@ -211,6 +217,7 @@ public class PinotInstanceRestletResource {
 
   @PUT
   @Path("/instances/{instanceName}/updateTags")
+  @Authenticate(AccessType.UPDATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update the tags of the specified instance", consumes = MediaType.APPLICATION_JSON, notes = "Update the tags of the specified instance")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -60,6 +60,8 @@ import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
@@ -338,6 +340,7 @@ public class PinotSegmentRestletResource {
 
   @POST
   @Path("segments/{tableName}/{segmentName}/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload a segment", notes = "Reload a segment")
   public SuccessResponse reloadSegment(
@@ -362,6 +365,7 @@ public class PinotSegmentRestletResource {
    */
   @POST
   @Path("segments/{tableNameWithType}/{segmentName}/reset")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Resets a segment by first disabling it, waiting for external view to stabilize, and finally enabling it again", notes = "Resets a segment by disabling and then enabling the segment")
   public SuccessResponse resetSegment(
@@ -395,6 +399,7 @@ public class PinotSegmentRestletResource {
   @POST
   @Path("segments/{tableNameWithType}/reset")
   @Produces(MediaType.APPLICATION_JSON)
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Resets all segments of the table, by first disabling them, waiting for external view to stabilize, and finally enabling the segments", notes = "Resets a segment by disabling and then enabling a segment")
   public SuccessResponse resetAllSegments(
       @ApiParam(value = "Name of the table with type", required = true) @PathParam("tableNameWithType") String tableNameWithType,
@@ -419,6 +424,7 @@ public class PinotSegmentRestletResource {
   @Deprecated
   @POST
   @Path("tables/{tableName}/segments/{segmentName}/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload a segment (deprecated, use 'POST /segments/{tableName}/{segmentName}/reload' instead)", notes = "Reload a segment (deprecated, use 'POST /segments/{tableName}/{segmentName}/reload' instead)")
   public SuccessResponse reloadSegmentDeprecated1(
@@ -438,6 +444,7 @@ public class PinotSegmentRestletResource {
   @Deprecated
   @GET
   @Path("tables/{tableName}/segments/{segmentName}/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload a segment (deprecated, use 'POST /segments/{tableName}/{segmentName}/reload' instead)", notes = "Reload a segment (deprecated, use 'POST /segments/{tableName}/{segmentName}/reload' instead)")
   public SuccessResponse reloadSegmentDeprecated2(
@@ -449,6 +456,7 @@ public class PinotSegmentRestletResource {
 
   @POST
   @Path("segments/{tableName}/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload all segments", notes = "Reload all segments")
   public SuccessResponse reloadAllSegments(
@@ -466,6 +474,7 @@ public class PinotSegmentRestletResource {
   @Deprecated
   @POST
   @Path("tables/{tableName}/segments/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload all segments (deprecated, use 'POST /segments/{tableName}/reload' instead)", notes = "Reload all segments (deprecated, use 'POST /segments/{tableName}/reload' instead)")
   public SuccessResponse reloadAllSegmentsDeprecated1(
@@ -483,6 +492,7 @@ public class PinotSegmentRestletResource {
   @Deprecated
   @GET
   @Path("tables/{tableName}/segments/reload")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Reload all segments (deprecated, use 'POST /segments/{tableName}/reload' instead)", notes = "Reload all segments (deprecated, use 'POST /segments/{tableName}/reload' instead)")
   public SuccessResponse reloadAllSegmentsDeprecated2(
@@ -494,6 +504,7 @@ public class PinotSegmentRestletResource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/segments/{tableName}/{segmentName}")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete a segment", notes = "Delete a segment")
   public SuccessResponse deleteSegment(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
@@ -508,6 +519,7 @@ public class PinotSegmentRestletResource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/segments/{tableName}")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete all segments", notes = "Delete all segments")
   public SuccessResponse deleteAllSegments(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
@@ -525,6 +537,7 @@ public class PinotSegmentRestletResource {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/segments/{tableName}/delete")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete the segments in the JSON array payload", notes = "Delete the segments in the JSON array payload")
   public SuccessResponse deleteSegments(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -71,6 +71,8 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.upload.SegmentValidator;
 import org.apache.pinot.controller.api.upload.ZKOperator;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -394,6 +396,7 @@ public class PinotSegmentUploadDownloadRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("/segments")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as json")
   // We use this endpoint with URI upload because a request sent with the multipart content type will reject the POST
   // request if a multipart object is not sent. This endpoint does not move the segment to its final location;
@@ -414,6 +417,7 @@ public class PinotSegmentUploadDownloadRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/segments")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as binary")
   // For the multipart endpoint, we will always move segment to final location regardless of the segment endpoint.
   public void uploadSegmentAsMultiPart(FormDataMultiPart multiPart,
@@ -432,6 +436,7 @@ public class PinotSegmentUploadDownloadRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
   @Path("/v2/segments")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as json")
   // We use this endpoint with URI upload because a request sent with the multipart content type will reject the POST
   // request if a multipart object is not sent. This endpoint is recommended for use. It differs from the first
@@ -452,6 +457,7 @@ public class PinotSegmentUploadDownloadRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @Path("/v2/segments")
+  @Authenticate(AccessType.CREATE)
   @ApiOperation(value = "Upload a segment", notes = "Upload a segment as binary")
   // This behavior does not differ from v1 of the same endpoint.
   public void uploadSegmentAsMultiPartV2(FormDataMultiPart multiPart,
@@ -467,6 +473,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   @POST
   @Path("segments/{tableName}/startReplaceSegments")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Start to replace segments", notes = "Start to replace segments")
   public Response startReplaceSegments(
@@ -487,6 +494,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   @POST
   @Path("segments/{tableName}/endReplaceSegments")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "End to replace segments", notes = "End to replace segments")
   public Response endReplaceSegments(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableIndexingConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableIndexingConfigs.java
@@ -30,6 +30,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.util.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -50,6 +52,7 @@ public class PinotTableIndexingConfigs {
   @Deprecated
   @PUT
   @Path("/tables/{tableName}/indexingConfigs")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update table indexing configuration")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 404, message = "Table not found"), @ApiResponse(code = 500, message = "Server error updating configuration")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableMetadataConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableMetadataConfigs.java
@@ -29,6 +29,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.util.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -49,6 +51,7 @@ public class PinotTableMetadataConfigs {
   @Deprecated
   @PUT
   @Path("/tables/{tableName}/metadataConfigs")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update table metadata", notes = "Updates table configuration")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"), @ApiResponse(code = 404, message = "Table not found")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableSegmentConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableSegmentConfigs.java
@@ -31,6 +31,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.util.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -53,6 +55,7 @@ public class PinotTableSegmentConfigs {
   @Deprecated
   @PUT
   @Path("/tables/{tableName}/segmentConfigs")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update segments configuration", notes = "Updates segmentsConfig section (validation and retention) of a table")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 404, message = "Table not found"), @ApiResponse(code = 500, message = "Internal server error")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableTenantConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableTenantConfigs.java
@@ -31,6 +31,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.slf4j.Logger;
@@ -48,6 +50,7 @@ public class PinotTableTenantConfigs {
 
   @POST
   @Produces(MediaType.APPLICATION_JSON)
+  @Authenticate(AccessType.UPDATE)
   @Path("/tables/{tableName}/rebuildBrokerResourceFromHelixTags")
   @ApiOperation(value = "Rebuild broker resource for table", notes = "when new brokers are added")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 400, message = "Bad request: table name has to be with table type"), @ApiResponse(code = 500, message = "Internal error rebuilding broker resource or serializing response")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -38,6 +38,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import org.apache.helix.task.TaskState;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -289,6 +291,7 @@ public class PinotTaskRestletResource {
 
   @POST
   @Path("/tasks/schedule")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Schedule tasks and return a map from task type to task name scheduled")
   public Map<String, String> scheduleTasks(@ApiParam(value = "Task type") @QueryParam("taskType") String taskType,
       @ApiParam(value = "Table name (with type suffix)") @QueryParam("tableName") String tableName) {
@@ -306,6 +309,7 @@ public class PinotTaskRestletResource {
   @Deprecated
   @PUT
   @Path("/tasks/scheduletasks")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Schedule tasks (deprecated)")
   public Map<String, String> scheduleTasksDeprecated() {
     return _pinotTaskManager.scheduleTasks();
@@ -313,6 +317,7 @@ public class PinotTaskRestletResource {
 
   @PUT
   @Path("/tasks/{taskType}/cleanup")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Clean up finished tasks (COMPLETED, FAILED) for the given task type")
   public SuccessResponse cleanUpTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
@@ -323,6 +328,7 @@ public class PinotTaskRestletResource {
   @Deprecated
   @PUT
   @Path("/tasks/cleanuptasks/{taskType}")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Clean up finished tasks (COMPLETED, FAILED) for the given task type (deprecated)")
   public SuccessResponse cleanUpTasksDeprecated(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
@@ -332,6 +338,7 @@ public class PinotTaskRestletResource {
 
   @PUT
   @Path("/tasks/{taskType}/stop")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Stop all running/pending tasks (as well as the task queue) for the given task type")
   public SuccessResponse stopTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
@@ -341,6 +348,7 @@ public class PinotTaskRestletResource {
 
   @PUT
   @Path("/tasks/{taskType}/resume")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Resume all stopped tasks (as well as the task queue) for the given task type")
   public SuccessResponse resumeTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType) {
@@ -351,6 +359,7 @@ public class PinotTaskRestletResource {
   @Deprecated
   @PUT
   @Path("/tasks/taskqueue/{taskType}")
+  @Authenticate(AccessType.UPDATE)
   @ApiOperation("Stop/resume a task queue (deprecated)")
   public SuccessResponse toggleTaskQueueState(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
@@ -369,6 +378,7 @@ public class PinotTaskRestletResource {
 
   @DELETE
   @Path("/tasks/{taskType}")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation("Delete all tasks (as well as the task queue) for the given task type")
   public SuccessResponse deleteTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
@@ -380,6 +390,7 @@ public class PinotTaskRestletResource {
   @Deprecated
   @DELETE
   @Path("/tasks/taskqueue/{taskType}")
+  @Authenticate(AccessType.DELETE)
   @ApiOperation("Delete a task queue (deprecated)")
   public SuccessResponse deleteTaskQueue(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -46,6 +46,8 @@ import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -92,6 +94,7 @@ public class PinotTenantRestletResource {
 
   @POST
   @Path("/tenants")
+  @Authenticate(AccessType.CREATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = " Create a tenant")
@@ -121,6 +124,7 @@ public class PinotTenantRestletResource {
   // TODO: should be /tenant/{tenantName}
   @PUT
   @Path("/tenants")
+  @Authenticate(AccessType.UPDATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update a tenant")
@@ -339,6 +343,7 @@ public class PinotTenantRestletResource {
   //   2. with GET, we need to write our own routing logic to avoid conflict since this is same as the API above
   @POST
   @Path("/tenants/{tenantName}/metadata")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Change tenant state")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = String.class), @ApiResponse(code = 404, message = "Tenant not found"), @ApiResponse(code = 500, message = "Server error reading tenant information")})
@@ -394,6 +399,7 @@ public class PinotTenantRestletResource {
 
   @DELETE
   @Path("/tenants/{tenantName}")
+  @Authenticate(AccessType.DELETE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Delete a tenant")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 400, message = "Tenant can not be deleted"), @ApiResponse(code = 404, message = "Tenant not found"), @ApiResponse(code = 500, message = "Error deleting tenant")})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ZookeeperResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ZookeeperResource.java
@@ -42,6 +42,8 @@ import javax.ws.rs.core.Response;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.zookeeper.data.Stat;
@@ -82,6 +84,7 @@ public class ZookeeperResource {
 
   @DELETE
   @Path("/zk/delete")
+  @Authenticate(AccessType.DELETE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Delete the znode at this path")
   @ApiResponses(value = { //
@@ -105,6 +108,7 @@ public class ZookeeperResource {
 
   @PUT
   @Path("/zk/put")
+  @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update the content of the node")
   @ApiResponses(value = { //

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ControllerAdminApiApplicationTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ControllerAdminApiApplicationTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api;
+
+import java.util.Optional;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class ControllerAdminApiApplicationTest {
+
+  private final ControllerAdminApiApplication.AuthFilter _authFilter = new ControllerAdminApiApplication.AuthFilter();
+
+  @Test
+  public void testAuthFilter_extractTableName_withTableNameInPathParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    pathParams.putSingle("tableName", "A");
+    pathParams.putSingle("tableNameWithType", "B");
+    pathParams.putSingle("schemaName", "C");
+    queryParams.putSingle("tableName", "D");
+    queryParams.putSingle("tableNameWithType", "E");
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("A"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withTableNameWithTypeInPathParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    pathParams.putSingle("tableNameWithType", "B");
+    pathParams.putSingle("schemaName", "C");
+    queryParams.putSingle("tableName", "D");
+    queryParams.putSingle("tableNameWithType", "E");
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("B"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withSchemaNameInPathParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    pathParams.putSingle("schemaName", "C");
+    queryParams.putSingle("tableName", "D");
+    queryParams.putSingle("tableNameWithType", "E");
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("C"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withTableNameInQueryParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.putSingle("tableName", "D");
+    queryParams.putSingle("tableNameWithType", "E");
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("D"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withTableNameWithTypeInQueryParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.putSingle("tableNameWithType", "E");
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("E"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withSchemaNameInQueryParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.putSingle("schemaName", "F");
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.of("F"));
+  }
+
+  @Test
+  public void testAuthFilter_extractTableName_withEmptyParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
+    assertEquals(actual, Optional.empty());
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.pinot.controller.api;
+package org.apache.pinot.controller.api.access;
 
 import java.util.Optional;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -27,9 +27,8 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 
-public class ControllerAdminApiApplicationTest {
-
-  private final ControllerAdminApiApplication.AuthFilter _authFilter = new ControllerAdminApiApplication.AuthFilter();
+public class AuthenticationFilterTest {
+  private final AuthenticationFilter _authFilter = new AuthenticationFilter();
 
   @Test
   public void testAuthFilter_extractTableName_withTableNameInPathParams() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -31,7 +31,7 @@ public class AuthenticationFilterTest {
   private final AuthenticationFilter _authFilter = new AuthenticationFilter();
 
   @Test
-  public void testAuthFilter_extractTableName_withTableNameInPathParams() {
+  public void testExtractTableName_withTableNameInPathParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     pathParams.putSingle("tableName", "A");
@@ -45,7 +45,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withTableNameWithTypeInPathParams() {
+  public void testExtractTableName_withTableNameWithTypeInPathParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     pathParams.putSingle("tableNameWithType", "B");
@@ -58,7 +58,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withSchemaNameInPathParams() {
+  public void testExtractTableName_withSchemaNameInPathParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     pathParams.putSingle("schemaName", "C");
@@ -70,7 +70,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withTableNameInQueryParams() {
+  public void testExtractTableName_withTableNameInQueryParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     queryParams.putSingle("tableName", "D");
@@ -81,7 +81,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withTableNameWithTypeInQueryParams() {
+  public void testExtractTableName_withTableNameWithTypeInQueryParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     queryParams.putSingle("tableNameWithType", "E");
@@ -91,7 +91,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withSchemaNameInQueryParams() {
+  public void testExtractTableName_withSchemaNameInQueryParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     queryParams.putSingle("schemaName", "F");
@@ -100,7 +100,7 @@ public class AuthenticationFilterTest {
   }
 
   @Test
-  public void testAuthFilter_extractTableName_withEmptyParams() {
+  public void testExtractTableName_withEmptyParams() {
     MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);


### PR DESCRIPTION
## Description
- This PR adds access control capability for REST endpoints of Controller. 
- If an endpoint requires authentication, it can be simply annotated with `@Authenticate` annotation with `AccessType` parameter. This will trigger automatic authentication.
- Authentication happens in a container filter - `AuthFilter` - which automatically gets called before execution of each endpoint.
- `AuthFilter` checks if `@Authenticate` annotation is available on the requested endpoint. If available, then it calls `AccessControl` object to perform actual authentication.
- The described approach works just fine for the endpoints that are not table level. In other words, they don't require table name for authentication.
- For table level endpoints which require table name as an input to authentication, there are two ways:
 
1. _Table name can be provided as a path (or query) parameter on the endpoint._ In this case, `AuthFilter` can extract it and pass it to AccessControl object. For backward compatibility, `AuthFilter` looks for `tableName`, `tableNameWithType`, or `schemaName` in path (or query) parameters.
2. _Table name cannot be provided as a path (or query) param._ For example in case of uploading a table or schema, tableName is deep inside the json body of the post request and extracting table name needs to happen within the endpoint. In this case, automatic authentication via AuthFilter is not possible. Therefore, `@Authenticate` annotation will not be placed on these endpoints and authentication needs to be explicitly invoked within the endpoint.


## Testing Done
Deployed locally and verified that the authentication gets called automatically for annotated endpoints.
Also verified the expected behavior on the endpoints with no annotation and the explicit (manual) authentication, for example POST method of `/schemas` and `/tables`.