### PR TITLE
[TE]frontend - Add filtering support for Entity Monitoring tables

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/entity-metrics-anomalies/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/entity-metrics-anomalies/component.js
@@ -16,42 +16,11 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { A as EmberArray } from '@ember/array';
 
-import moment from 'moment';
-import config from 'thirdeye-frontend/config/environment';
-import { getAnomaliesStartDuration, getFeedback } from 'thirdeye-frontend/utils/composite-anomalies';
-
-const TABLE_COLUMNS = [
-  {
-    component: 'custom/composite-anomalies-table/start-duration',
-    propertyName: 'startDuration',
-    title: `Start / Duration (${moment.tz([2012, 5], config.timeZone).format('z')})`
-  },
-  {
-    component: 'custom/composite-anomalies-table/metric',
-    propertyName: 'metric',
-    title: 'Metric'
-  },
-  {
-    component: 'custom/composite-anomalies-table/dimensions',
-    propertyName: 'dimensions',
-    title: 'Dimension'
-  },
-  {
-    component: 'custom/composite-anomalies-table/current-predicted',
-    propertyName: 'currentPredicted',
-    title: 'Current / Predicted'
-  },
-  {
-    component: 'custom/composite-anomalies-table/resolution',
-    propertyName: 'feedback',
-    title: 'Feedback'
-  },
-  {
-    component: 'custom/anomalies-table/investigation-link',
-    propertyName: 'id',
-    title: 'Investigate'
-  }
-];
+import {
+  getAnomaliesStartDuration,
+  getFeedback,
+  ENTITY_METRICS_COLUMNS
+} from 'thirdeye-frontend/utils/composite-anomalies';
 
 const CUSTOM_TABLE_CLASSES = {
   table: 'composite-anomalies-table'
@@ -67,14 +36,14 @@ export default Component.extend({
     const computedTableData = [];
 
     if (this.data && this.data.length > 0) {
-      this.data.map((d) => {
+      this.data.map(({ id, startTime, endTime, metric, dimensions, currentPredicted, feedback }) => {
         const row = {
-          id: d.id,
-          startDuration: getAnomaliesStartDuration(d.startTime, d.endTime, false),
-          metric: d.metric,
-          dimensions: d.dimensions,
-          currentPredicted: d.currentPredicted,
-          feedback: getFeedback(d.feedback),
+          id: id,
+          startDuration: getAnomaliesStartDuration(startTime, endTime, false),
+          metric: metric,
+          dimensions: dimensions,
+          currentPredicted: currentPredicted,
+          feedback: getFeedback(feedback),
           isLeaf: true
         };
         computedTableData.push(row);
@@ -83,5 +52,5 @@ export default Component.extend({
 
     return computedTableData;
   }),
-  tableColumns: TABLE_COLUMNS
+  tableColumns: ENTITY_METRICS_COLUMNS
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/group-constituents-anomalies/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/group-constituents-anomalies/component.js
@@ -16,37 +16,11 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { A as EmberArray } from '@ember/array';
 
-import moment from 'moment';
-import config from 'thirdeye-frontend/config/environment';
-import { getAnomaliesStartDuration, getFeedback } from 'thirdeye-frontend/utils/composite-anomalies';
-
-const TABLE_COLUMNS = [
-  {
-    component: 'custom/composite-anomalies-table/start-duration',
-    propertyName: 'startDuration',
-    title: `Start / Duration (${moment.tz([2012, 5], config.timeZone).format('z')})`
-  },
-  {
-    component: 'custom/composite-anomalies-table/group-name',
-    propertyName: 'groupName',
-    title: 'Group Name'
-  },
-  {
-    component: 'custom/composite-anomalies-table/criticality',
-    propertyName: 'criticalityScore',
-    title: 'Criticality Score'
-  },
-  {
-    component: 'custom/composite-anomalies-table/current-predicted',
-    propertyName: 'currentPredicted',
-    title: 'Current / Predicted'
-  },
-  {
-    component: 'custom/composite-anomalies-table/resolution',
-    propertyName: 'feedback',
-    title: 'Feedback'
-  }
-];
+import {
+  getAnomaliesStartDuration,
+  getFeedback,
+  GROUP_CONSTITUENTS_COLUMNS
+} from 'thirdeye-frontend/utils/composite-anomalies';
 
 const CUSTOM_TABLE_CLASSES = {
   table: 'composite-anomalies-table'
@@ -62,14 +36,14 @@ export default Component.extend({
     const computedTableData = [];
 
     if (this.data && this.data.length > 0) {
-      this.data.map((d) => {
+      this.data.map(({ id, startTime, endTime, groupName, criticality, currentPredicted, feedback }) => {
         const row = {
-          anomalyId: d.id,
-          startDuration: getAnomaliesStartDuration(d.startTime, d.endTime, false),
-          groupName: d.groupName,
-          criticalityScore: d.criticality,
-          currentPredicted: d.currentPredicted,
-          feedback: getFeedback(d.feedback),
+          anomalyId: id,
+          startDuration: getAnomaliesStartDuration(startTime, endTime, false),
+          groupName: groupName,
+          criticalityScore: criticality,
+          currentPredicted: currentPredicted,
+          feedback: getFeedback(feedback),
           isLeaf: false
         };
         computedTableData.push(row);
@@ -78,5 +52,5 @@ export default Component.extend({
 
     return computedTableData;
   }),
-  tableColumns: TABLE_COLUMNS
+  tableColumns: GROUP_CONSTITUENTS_COLUMNS
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/parent-anomalies/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/composite-anomalies/parent-anomalies/component.js
@@ -16,27 +16,11 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { A as EmberArray } from '@ember/array';
 
-import moment from 'moment';
-import config from 'thirdeye-frontend/config/environment';
-import { getAnomaliesStartDuration, getFeedback } from 'thirdeye-frontend/utils/composite-anomalies';
-
-const TABLE_COLUMNS = [
-  {
-    component: 'custom/composite-anomalies-table/start-duration',
-    propertyName: 'startDuration',
-    title: `Start / Duration (${moment.tz([2012, 5], config.timeZone).format('z')})`
-  },
-  {
-    template: 'custom/composite-anomalies-table/anomalies-list',
-    propertyName: 'anomaliesDetails',
-    title: 'Anomalies details'
-  },
-  {
-    component: 'custom/composite-anomalies-table/resolution',
-    propertyName: 'feedback',
-    title: 'Feedback'
-  }
-];
+import {
+  getAnomaliesStartDuration,
+  getFeedback,
+  PARENT_TABLE_COLUMNS
+} from 'thirdeye-frontend/utils/composite-anomalies';
 
 const CUSTOM_TABLE_CLASSES = {
   table: 'composite-anomalies-table'
@@ -52,12 +36,12 @@ export default Component.extend({
     const computedTableData = [];
 
     if (this.data && this.data.length > 0) {
-      this.data.map((d) => {
+      this.data.map(({ id, startTime, endTime, details, feedback }) => {
         const row = {
-          anomalyId: d.id,
-          startDuration: getAnomaliesStartDuration(d.startTime, d.endTime, true),
-          anomaliesDetails: this.getAnomaliesDetails(d.details),
-          feedback: getFeedback(d.feedback),
+          anomalyId: id,
+          startDuration: getAnomaliesStartDuration(startTime, endTime, true),
+          anomaliesDetails: details,
+          feedback: getFeedback(feedback),
           isLeaf: false
         };
         computedTableData.push(row);
@@ -65,20 +49,5 @@ export default Component.extend({
     }
     return computedTableData;
   }),
-  tableColumns: TABLE_COLUMNS,
-  /*
-   * Convert list of anonalies object in to an array of objects to be used by template: 'custom/composite-animalies-table/anomalies-list'
-   *
-   * @param {Object} details
-   *   The object containing the list of anomalies and their count.
-   *
-   * @returns {Array}
-   *   Description of the object.
-   */
-  getAnomaliesDetails: (anomalies) => {
-    return Object.entries(anomalies).reduce((anomalyList, anomalyDetails) => {
-      anomalyList.push({ name: anomalyDetails[0], count: anomalyDetails[1] });
-      return anomalyList;
-    }, []);
-  }
+  tableColumns: PARENT_TABLE_COLUMNS
 });

--- a/thirdeye/thirdeye-frontend/app/pods/custom/composite-anomalies-table/anomalies-list/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/composite-anomalies-table/anomalies-list/template.hbs
@@ -1,3 +1,3 @@
-{{#each record.anomaliesDetails as |anomalyDetails| }}
-    <p class="te-anomaly-table__details te-label te-label--small">{{anomalyDetails.name}} ({{anomalyDetails.count}})</p>
-{{/each}}
+{{#each-in record.anomaliesDetails as |name count| }}
+    <p class="te-anomaly-table__details te-label te-label--small">{{name}} ({{count}})</p>
+{{/each-in}}

--- a/thirdeye/thirdeye-frontend/app/pods/custom/composite-anomalies-table/start-duration/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/composite-anomalies-table/start-duration/template.hbs
@@ -1,8 +1,8 @@
 <label class="te-label te-label--small {{if record.startDuration.showLink "te-anomaly-table__link" "te-label--disable-click"}}">
-    <span class="start-time" onclick={{action "drilldownAnomaly" record.anomalyId}}>{{moment-format record.startDuration.startTime "MMM Do, h:mm z"}}</span>
+    <span class="start-time" onclick={{action "drilldownAnomaly" record.anomalyId}}>{{record.startDuration.startTime}}</span>
     {{#tooltip-on-element}}
-      Start: {{moment-format record.startDuration.startTime "MMM Do, h:mm z"}}<br />
-      End: {{moment-format record.startDuration.endTime "MMM Do, h:mm z"}}
+      Start: {{record.startDuration.startTime}}<br />
+      End: {{record.startDuration.endTime}}
     {{/tooltip-on-element}}
 </label>
 <p class="te-anomaly-table__duration">{{record.startDuration.duration}}</p>

--- a/thirdeye/thirdeye-frontend/app/utils/composite-anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/utils/composite-anomalies.js
@@ -4,6 +4,97 @@
 
 import moment from 'moment';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
+import { ANOMALIES_START_DISPLAY_FORMAT } from 'thirdeye-frontend/utils/constants';
+import { checkForMatch } from 'thirdeye-frontend/utils/utils';
+import config from 'thirdeye-frontend/config/environment';
+
+const COMMON_COLUMNS = {
+  START_DURATION: {
+    component: 'custom/composite-anomalies-table/start-duration',
+    propertyName: 'startDuration',
+    title: `Start / Duration (${moment.tz([2012, 5], config.timeZone).format('z')})`,
+    filterFunction(cell, filterStr, record) {
+      const { startTime, duration } = record[this.propertyName];
+
+      return checkForMatch({ startTime, duration }, filterStr);
+    }
+  },
+  FEEDBACK: {
+    component: 'custom/composite-anomalies-table/resolution',
+    propertyName: 'feedback',
+    title: 'Feedback'
+  },
+  CURRENT_PREDICTED: {
+    component: 'custom/composite-anomalies-table/current-predicted',
+    propertyName: 'currentPredicted',
+    title: 'Current / Predicted',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  }
+};
+
+export const PARENT_TABLE_COLUMNS = [
+  COMMON_COLUMNS.START_DURATION,
+  {
+    template: 'custom/composite-anomalies-table/anomalies-list',
+    propertyName: 'anomaliesDetails',
+    title: 'Anomalies details',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  },
+  COMMON_COLUMNS.FEEDBACK
+];
+
+export const GROUP_CONSTITUENTS_COLUMNS = [
+  COMMON_COLUMNS.START_DURATION,
+  {
+    component: 'custom/composite-anomalies-table/group-name',
+    propertyName: 'groupName',
+    title: 'Group Name',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  },
+  {
+    component: 'custom/composite-anomalies-table/criticality',
+    propertyName: 'criticalityScore',
+    title: 'Criticality Score',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  },
+  COMMON_COLUMNS.CURRENT_PREDICTED,
+  COMMON_COLUMNS.FEEDBACK
+];
+
+export const ENTITY_METRICS_COLUMNS = [
+  COMMON_COLUMNS.START_DURATION,
+  {
+    component: 'custom/composite-anomalies-table/metric',
+    propertyName: 'metric',
+    title: 'Metric',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  },
+  {
+    component: 'custom/composite-anomalies-table/dimensions',
+    propertyName: 'dimensions',
+    title: 'Dimension',
+    filterFunction(cell, filterStr, record) {
+      return checkForMatch(record[this.propertyName], filterStr);
+    }
+  },
+  COMMON_COLUMNS.CURRENT_PREDICTED,
+  COMMON_COLUMNS.FEEDBACK,
+  {
+    component: 'custom/anomalies-table/investigation-link',
+    propertyName: 'id',
+    title: 'Investigate'
+  }
+];
 
 /*
  * Convert anomaly 'start' and 'end' into an object
@@ -19,9 +110,11 @@ import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
  *   Description of the object.
  */
 export const getAnomaliesStartDuration = (start, end, showLink = false) => {
+  const timezone = moment().tz(moment.tz.guess()).format('z');
+
   return {
-    startTime: start,
-    endTime: end,
+    startTime: `${moment(start).format(ANOMALIES_START_DISPLAY_FORMAT)} ${timezone}`,
+    endTime: `${moment(end).format(ANOMALIES_START_DISPLAY_FORMAT)} ${timezone}`,
     duration: moment.duration(end - start).asHours() + ' hours',
     showLink
   };

--- a/thirdeye/thirdeye-frontend/app/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/app/utils/constants.js
@@ -10,9 +10,11 @@ export const toastOptions = {
 };
 
 export const BREADCRUMB_TIME_DISPLAY_FORMAT = 'MMM D HH:mm';
+export const ANOMALIES_START_DISPLAY_FORMAT = 'MMM Do, h:mm';
 
 export default {
   deleteProps,
   toastOptions,
-  BREADCRUMB_TIME_DISPLAY_FORMAT
+  BREADCRUMB_TIME_DISPLAY_FORMAT,
+  ANOMALIES_START_DISPLAY_FORMAT
 };

--- a/thirdeye/thirdeye-frontend/app/utils/utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/utils.js
@@ -22,16 +22,15 @@ export function checkStatus(response, mode = 'get', recoverBlank = false, isYaml
     if (mode === 'delete' || response.status === 204) {
       return '';
     } else {
-      return (mode === 'get' || isYamlPreview) ? response.json() : JSON.parse(JSON.stringify(response));
+      return mode === 'get' || isYamlPreview ? response.json() : JSON.parse(JSON.stringify(response));
     }
   } else {
     if (isYamlPreview) {
-      return response.json()
-        .then(data => {
-          const error = new Error(data);
-          error.body= data;
-          throw error;
-        });
+      return response.json().then((data) => {
+        const error = new Error(data);
+        error.body = data;
+        throw error;
+      });
     }
     const error = new Error(response.statusText);
     error.response = response;
@@ -62,10 +61,12 @@ function isValidForDisplay(f) {
  * 1.234e-4 =>   0.12m
  */
 export function humanizeFloat(f) {
-  if (!isValidForDisplay(f)) { return '-'; }
+  if (!isValidForDisplay(f)) {
+    return '-';
+  }
   const formattedNum = d3.format('.3s')(f);
   // Catch/replace meaningless micro value
-  const isMicroNum = (new RegExp(/0\.0+y$/)).test(formattedNum);
+  const isMicroNum = new RegExp(/0\.0+y$/).test(formattedNum);
   return isMicroNum ? 0 : formattedNum;
 }
 
@@ -81,7 +82,9 @@ export function humanizeFloat(f) {
  * -10.01  => -1000%+
  */
 export function humanizeChange(f) {
-  if (!isValidForDisplay(f)) { return '-'; }
+  if (!isValidForDisplay(f)) {
+    return '-';
+  }
   if (f > 10) {
     return '+1000%+';
   } else if (f < -10) {
@@ -96,7 +99,9 @@ export function humanizeChange(f) {
  * @return {string} human-readable score string
  */
 export function humanizeScore(f) {
-  if (!isValidForDisplay(f)) { return '-'; }
+  if (!isValidForDisplay(f)) {
+    return '-';
+  }
   return f.toFixed(2);
 }
 
@@ -115,11 +120,12 @@ export function buildDateEod(unit, type) {
 export function parseProps(filters) {
   filters = filters || '';
 
-  return filters.split(';')
-    .filter(prop => prop)
-    .map(prop => prop.split('='))
+  return filters
+    .split(';')
+    .filter((prop) => prop)
+    .map((prop) => prop.split('='))
     .reduce(function (aggr, prop) {
-      const [ propName, value ] = prop;
+      const [propName, value] = prop;
       aggr[propName] = value;
       return aggr;
     }, {});
@@ -205,7 +211,7 @@ export function replaceNonFiniteWithCurrent(series1, series2) {
     return stripNonFiniteValues(series1);
   }
   for (let i = 0; i < series1.length; i++) {
-    if (!isFinite(series1[i]) || (!series1[i] && (series1[i] !== 0))) {
+    if (!isFinite(series1[i]) || (!series1[i] && series1[i] !== 0)) {
       let newValue = null;
       if (i < series2.length) {
         newValue = isFinite(series2[i]) ? series2[i] : null;
@@ -221,7 +227,7 @@ export function replaceNonFiniteWithCurrent(series1, series2) {
  * @param {Array} toCheck - array to check for all nulls
  */
 export function isAllNull(toCheck) {
-  return _.isEmpty(toCheck.filter(value => value !== null));
+  return _.isEmpty(toCheck.filter((value) => value !== null));
 }
 
 /**
@@ -233,36 +239,32 @@ export function isAllNull(toCheck) {
  */
 export function buildBounds(series, baseline, timeseries, useCurrent) {
   if (baseline) {
-    const upperExists = (!_.isEmpty(baseline.upper_bound) && !isAllNull(baseline.upper_bound));
-    const lowerExists = (!_.isEmpty(baseline.lower_bound) && !isAllNull(baseline.lower_bound));
+    const upperExists = !_.isEmpty(baseline.upper_bound) && !isAllNull(baseline.upper_bound);
+    const lowerExists = !_.isEmpty(baseline.lower_bound) && !isAllNull(baseline.lower_bound);
     if (upperExists && lowerExists) {
       series['Upper and lower bound'] = {
         timestamps: baseline.timestamp,
-        values: replaceNonFiniteWithCurrent(baseline.upper_bound,
-          useCurrent ? timeseries.current : timeseries.value),
+        values: replaceNonFiniteWithCurrent(baseline.upper_bound, useCurrent ? timeseries.current : timeseries.value),
         type: 'line',
         color: 'screenshot-bounds'
       };
       series['lowerBound'] = {
         timestamps: baseline.timestamp,
-        values: replaceNonFiniteWithCurrent(baseline.lower_bound,
-          useCurrent ? timeseries.current : timeseries.value),
+        values: replaceNonFiniteWithCurrent(baseline.lower_bound, useCurrent ? timeseries.current : timeseries.value),
         type: 'line',
         color: 'screenshot-bounds'
       };
     } else if (upperExists) {
       series['Upper Bound'] = {
         timestamps: baseline.timestamp,
-        values: replaceNonFiniteWithCurrent(baseline.upper_bound,
-          useCurrent ? timeseries.current : timeseries.value),
+        values: replaceNonFiniteWithCurrent(baseline.upper_bound, useCurrent ? timeseries.current : timeseries.value),
         type: 'line',
         color: 'screenshot-bounds'
       };
     } else if (lowerExists) {
       series['Lower Bound'] = {
         timestamps: baseline.timestamp,
-        values: replaceNonFiniteWithCurrent(baseline.lower_bound,
-          useCurrent ? timeseries.current : timeseries.value),
+        values: replaceNonFiniteWithCurrent(baseline.lower_bound, useCurrent ? timeseries.current : timeseries.value),
         type: 'line',
         color: 'screenshot-bounds'
       };
@@ -275,9 +277,67 @@ export function buildBounds(series, baseline, timeseries, useCurrent) {
  * @param {Array} timeSeries - time series to modify
  */
 export function stripNonFiniteValues(timeSeries) {
-  return timeSeries.map(value => {
-    return (isFinite(value) ? value : null);
+  return timeSeries.map((value) => {
+    return isFinite(value) ? value : null;
   });
+}
+
+/*
+ * Detect if the input is in Object form
+ *
+ * @param {Any} input
+ *   The input to test.
+ *
+ * @returns {Boolean}
+ *   True if input is an object, false otherwise.
+ */
+export function isObject(input) {
+  return input instanceof Object && input.constructor === Object;
+}
+
+/*
+ * Search the input for the existence of the search term
+ *   -Supports searching on following input types - string, integer, float, boolean, object, array
+ *
+ * @param {Any} input
+ *   The input to test.
+ * @param {String} filterStr
+ *   The search term
+ *
+ * @returns {Boolean}
+ *   True if the match is found, false otherwise.
+ */
+export function checkForMatch(input, filterStr) {
+  if (filterStr === '') {
+    return true;
+  }
+
+  if (typeof input === 'string') {
+    return input.includes(filterStr);
+  } else if (typeof input === 'number' || typeof input === 'boolean') {
+    return input.toString().includes(filterStr);
+  } else if (isObject(input)) {
+    for (const prop in input) {
+      if (
+        {}.propertyIsEnumerable.call(input, prop) &&
+        (checkForMatch(prop, filterStr) || checkForMatch(input[prop], filterStr))
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  } else if (Array.isArray(input)) {
+    for (const entry of input) {
+      if (checkForMatch(entry, filterStr)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return false;
 }
 
 export default {
@@ -295,5 +355,7 @@ export default {
   stripNonFiniteValues,
   getProps,
   isAllNull,
-  buildBounds
+  buildBounds,
+  isObject,
+  checkForMatch
 };

--- a/thirdeye/thirdeye-frontend/tests/unit/utils/utils-test.js
+++ b/thirdeye/thirdeye-frontend/tests/unit/utils/utils-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { isObject, checkForMatch } from 'thirdeye-frontend/utils/utils';
+
+module('Unit | Utility | Basic utils tests', function () {
+  test('it determines correctly if the data type is of the type object', function (assert) {
+    assert.notOk(isObject('hello'));
+    assert.notOk(isObject(4));
+    assert.notOk(isObject(true));
+    assert.notOk(isObject(null));
+    assert.notOk(isObject(['hi', 1]));
+    assert.notOk(isObject(() => {}));
+
+    assert.ok(isObject({ prop1: 1, prop2: 'hi' }));
+  });
+
+  test('it detects the substring match in the input correctly', function (assert) {
+    //String input
+    let input = 'hello';
+    assert.ok(checkForMatch(input, 'hel'));
+    assert.notOk(checkForMatch(input, 'hef'));
+
+    //Boolean input
+    input = true;
+    assert.ok(checkForMatch(input, 'tru'));
+    assert.notOk(checkForMatch(input, 's'));
+
+    //Numeric input
+    input = 12;
+    assert.ok(checkForMatch(12, '1'));
+    assert.ok(checkForMatch(12, '12'));
+    assert.notOk(checkForMatch(12, '13'));
+
+    //Array input - Substring match in any one of the entries should return true
+    input = ['hi', 'hello'];
+    assert.ok(checkForMatch(input, 'hel'));
+    assert.notOk(checkForMatch(input, 'test'));
+
+    //Object input - Substring match in any one of the properties or any one of the property values should return true
+    input = { propOne: 124, propTwo: 3 };
+    assert.ok(checkForMatch(input, 'One'));
+    assert.ok(checkForMatch(input, '12'));
+    assert.notOk(checkForMatch(input, 'three'));
+  });
+});


### PR DESCRIPTION
Filtering is supposed to work on column level with all possible data types in the table. It will do a substring match of the string passed in with each of the column entries; a return value of true would make table display the corresponding row.

Miscellaneous
1. Refactored `anomaliesDetails` to avoid doing the O(N) computation along with O(N) memory involved in converting object to array to be used in the template. Instead the template is modified to directly work with the object.
2. Refactored the columns in each of the table for entity monitoring to ensure reuse columns which can be shared.

Note to reviewers:
Lot of changes in `utils.js` are style related auto changed by the prettifier. Please focus on just 2 functions in that file -`isObject` and `checkForMatch`. Both are towards the end of the file.