### PR TITLE
use default broker and controller ports if not defined

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -133,9 +133,8 @@ public class HelixBrokerStarter implements ServiceStartable {
 
   private int inferPort() {
     return Optional.ofNullable(_brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT)).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).orElseThrow(() ->
-            new IllegalStateException(String.format("Requires at least one ingress config or '%s'",
-                Helix.KEY_OF_BROKER_QUERY_PORT))));
+        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort)
+            .orElse(Helix.DEFAULT_BROKER_QUERY_PORT));
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -133,8 +133,7 @@ public class HelixBrokerStarter implements ServiceStartable {
 
   private int inferPort() {
     return Optional.ofNullable(_brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT)).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort)
-            .orElse(Helix.DEFAULT_BROKER_QUERY_PORT));
+        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).get());
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -126,14 +126,9 @@ public class HelixBrokerStarter implements ServiceStartable {
     }
 
     _brokerId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY,
-        Helix.PREFIX_OF_BROKER_INSTANCE + brokerHost + "_" + inferPort());
+        Helix.PREFIX_OF_BROKER_INSTANCE + brokerHost + "_" + _listenerConfigs.get(0).getPort());
 
     _brokerConf.addProperty(Broker.CONFIG_OF_BROKER_ID, _brokerId);
-  }
-
-  private int inferPort() {
-    return Optional.ofNullable(_brokerConf.getProperty(Helix.KEY_OF_BROKER_QUERY_PORT)).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).get());
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -65,6 +65,8 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 
+  public static final int DEFAULT_CONTROLLER_PORT = 9000;
+
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -65,8 +65,6 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 
-  public static final int DEFAULT_CONTROLLER_PORT = 9000;
-
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -195,9 +195,8 @@ public class ControllerStarter implements ServiceStartable {
 
   private int inferPort() {
     return Optional.ofNullable(_config.getControllerPort()).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).orElseThrow(() ->
-            new IllegalStateException(String.format("Requires at least one ingress config or '%s'",
-                ControllerConf.CONTROLLER_PORT))));
+        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort)
+            .orElse(ControllerConf.DEFAULT_CONTROLLER_PORT));
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -195,9 +195,7 @@ public class ControllerStarter implements ServiceStartable {
 
   private int inferPort() {
     return Optional.ofNullable(_config.getControllerPort()).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).orElseThrow(() ->
-            new IllegalStateException(String.format("Requires at least one ingress config or '%s'",
-                CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT))));
+        .orElse(_listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).get());
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -195,8 +195,9 @@ public class ControllerStarter implements ServiceStartable {
 
   private int inferPort() {
     return Optional.ofNullable(_config.getControllerPort()).map(Integer::parseInt)
-        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort)
-            .orElse(ControllerConf.DEFAULT_CONTROLLER_PORT));
+        .orElseGet(() -> _listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).orElseThrow(() ->
+            new IllegalStateException(String.format("Requires at least one ingress config or '%s'",
+                CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT))));
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -153,7 +153,7 @@ public class ControllerStarter implements ServiceStartable {
     _listenerConfigs = ListenerConfigUtil.buildControllerConfigs(_config);
 
     String host = conf.getControllerHost();
-    int port = inferPort();
+    int port = _listenerConfigs.get(0).getPort();
     
     _helixControllerInstanceId = host + "_" + port;
     _helixParticipantInstanceId = LeadControllerUtils.generateParticipantInstanceId(host, port);
@@ -191,11 +191,6 @@ public class ControllerStarter implements ServiceStartable {
         }
       }
     }
-  }
-
-  private int inferPort() {
-    return Optional.ofNullable(_config.getControllerPort()).map(Integer::parseInt)
-        .orElse(_listenerConfigs.stream().findFirst().map(ListenerConfig::getPort).get());
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -112,6 +112,12 @@ public final class ListenerConfigUtil {
 
     listeners.addAll(buildListenerConfigs(brokerConf, "pinot.broker.client", tlsDefaults));
 
+    // support legacy behavior < 0.7.0
+    if (listeners.isEmpty()) {
+      listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST,
+          CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
+    }
+
     return listeners;
   }
 
@@ -127,6 +133,12 @@ public final class ListenerConfigUtil {
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(serverConf, CommonConstants.Server.SERVER_TLS_PREFIX);
 
     listeners.addAll(buildListenerConfigs(serverConf, "pinot.server.adminapi", tlsDefaults));
+
+    // support legacy behavior < 0.7.0
+    if (listeners.isEmpty()) {
+      listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST,
+          CommonConstants.Server.DEFAULT_ADMIN_API_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
+    }
 
     return listeners;
   }


### PR DESCRIPTION
## Description
Reverts to legacy behavior on port defaults for broker and controller if listener specs aren't provided. Expands on #6513 .

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**