### PR TITLE
Update ADLSGen2PinotFS auth; Introduce unit tests

### DIFF
--- a/pinot-connectors/pinot-spark-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-connector/pom.xml
@@ -36,7 +36,7 @@
         <spark.version>2.4.5</spark.version>
         <circe.version>0.13.0</circe.version>
         <paranameter.version>2.8</paranameter.version>
-        <jackson.module.scala.version>2.9.8</jackson.module.scala.version>
+        <jackson.module.scala.version>2.10.0</jackson.module.scala.version>
         <scalaxml.version>1.3.0</scalaxml.version>
         <scalatest.version>3.1.1</scalatest.version>
     </properties>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
@@ -258,7 +258,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-      <version>2.9.8</version>
+      <version>2.10.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -39,12 +39,46 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-data-lake-store-sdk</artifactId>
-      <version>2.1.5</version>
+      <version>2.3.9</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-file-datalake</artifactId>
-      <version>12.0.0-beta.12</version>
+      <version>12.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.2.2</version>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.woodstox</groupId>
+        <artifactId>stax2-api</artifactId>
+        <version>4.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>5.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>5.6.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>msal4j</artifactId>
+        <version>1.8.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>oauth2-oidc-sdk</artifactId>
+        <version>7.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -1,0 +1,398 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.filesystem.test;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.http.rest.SimpleResponse;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.specialized.BlobInputStream;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import org.apache.pinot.plugin.filesystem.ADLSGen2PinotFS;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests the Azure implementation of ADLSGen2PinotFS
+ */
+public class ADLSGen2PinotFSTest {
+
+  @Mock
+  private DataLakeFileSystemClient _mockFileSystemClient;
+  @Mock
+  private DataLakeDirectoryClient _mockDirectoryClient;
+  @Mock
+  private BlobServiceClient _mockBlobServiceClient;
+  @Mock
+  private BlobContainerClient _mockBlobContainerClient;
+  @Mock
+  private BlobClient _mockBlobClient;
+  @Mock
+  private BlobInputStream _mockBlobInputStream;
+  @Mock
+  private DataLakeServiceClient _mockServiceClient;
+  @Mock
+  private DataLakeFileClient _mockFileClient;
+  @Mock
+  private DataLakeStorageException _mockDataLakeStorageException;
+  @Mock
+  private SimpleResponse _mockSimpleResponse;
+  @Mock
+  private PathProperties _mockPathProperties;
+  @Mock
+  private PagedIterable _mockPagedIterable;
+  @Mock
+  private PathItem _mockPathItem;
+
+  private URI _mockURI;
+  private ADLSGen2PinotFS _underTest;
+
+  private final static String MOCK_FILE_SYSTEM_NAME = "fileSystemName";
+
+  @BeforeMethod
+  public void setup() throws URISyntaxException {
+    MockitoAnnotations.initMocks(this);
+    _underTest = new ADLSGen2PinotFS(_mockFileSystemClient, _mockBlobServiceClient);
+    _mockURI = new URI("mock://mock");
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    verifyNoMoreInteractions(_mockDataLakeStorageException, _mockServiceClient, _mockFileSystemClient,
+        _mockSimpleResponse, _mockDirectoryClient, _mockPathItem, _mockPagedIterable, _mockPathProperties,
+        _mockFileClient, _mockBlobContainerClient, _mockBlobClient, _mockBlobServiceClient, _mockBlobInputStream);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testInitNoAuth() {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    _underTest.init(pinotConfiguration);
+  }
+
+  @Test
+  public void testGetOrCreateClientWithFileSystemGet() {
+    when(_mockServiceClient.getFileSystemClient(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockFileSystemClient);
+    when(_mockFileSystemClient.getProperties()).thenReturn(null);
+
+    final DataLakeFileSystemClient actual =
+        _underTest.getOrCreateClientWithFileSystem(_mockServiceClient, MOCK_FILE_SYSTEM_NAME);
+    Assert.assertEquals(actual, _mockFileSystemClient);
+
+    verify(_mockFileSystemClient).getProperties();
+    verify(_mockServiceClient).getFileSystemClient(MOCK_FILE_SYSTEM_NAME);
+  }
+
+  @Test
+  public void testGetOrCreateClientWithFileSystemCreate() {
+    when(_mockServiceClient.getFileSystemClient(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockFileSystemClient);
+    when(_mockServiceClient.createFileSystem(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockFileSystemClient);
+    when(_mockFileSystemClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
+    when(_mockDataLakeStorageException.getErrorCode()).thenReturn("FilesystemNotFound");
+
+    final DataLakeFileSystemClient actual =
+        _underTest.getOrCreateClientWithFileSystem(_mockServiceClient, MOCK_FILE_SYSTEM_NAME);
+    Assert.assertEquals(actual, _mockFileSystemClient);
+
+    verify(_mockFileSystemClient).getProperties();
+    verify(_mockServiceClient).getFileSystemClient(MOCK_FILE_SYSTEM_NAME);
+    verify(_mockServiceClient).createFileSystem(MOCK_FILE_SYSTEM_NAME);
+    verify(_mockDataLakeStorageException).getStatusCode();
+    verify(_mockDataLakeStorageException).getErrorCode();
+  }
+
+  @Test
+  public void testMkDirHappy() throws IOException {
+    when(_mockFileSystemClient.createDirectoryWithResponse(any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(_mockSimpleResponse);
+
+    boolean actual = _underTest.mkdir(_mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).createDirectoryWithResponse(any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testMkDirPathExists() throws IOException {
+    when(_mockFileSystemClient.createDirectoryWithResponse(any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(409);
+    when(_mockDataLakeStorageException.getErrorCode()).thenReturn("PathAlreadyExists");
+
+    boolean actual = _underTest.mkdir(_mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).createDirectoryWithResponse(any(), any(), any(), any(), any(), any(), any(), any());
+    verify(_mockDataLakeStorageException).getStatusCode();
+    verify(_mockDataLakeStorageException).getErrorCode();
+  }
+
+  @Test
+  public void testIsDirectory() throws IOException {
+    final HashMap<String, String> metadata = new HashMap<>();
+    metadata.put("hdi_isfolder", "true");
+
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getMetadata()).thenReturn(metadata);
+
+    boolean actual = _underTest.isDirectory(_mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getMetadata();
+  }
+
+  @Test
+  public void testListFiles() throws IOException {
+    when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
+    when(_mockPagedIterable.stream()).thenReturn(Collections.singletonList(_mockPathItem).stream());
+    when(_mockPathItem.getName()).thenReturn("foo");
+
+    String[] actual = _underTest.listFiles(_mockURI, true);
+    Assert.assertEquals(actual[0], "/foo");
+
+    verify(_mockFileSystemClient).listPaths(any(), any());
+    verify(_mockPagedIterable).stream();
+    verify(_mockPathItem).getName();
+  }
+
+  @Test
+  public void testListFilesException() {
+    when(_mockFileSystemClient.listPaths(any(), any())).thenThrow(_mockDataLakeStorageException);
+
+    Assert.expectThrows(IOException.class, () -> _underTest.listFiles(_mockURI, true));
+
+    verify(_mockFileSystemClient).listPaths(any(), any());
+  }
+
+  @Test
+  public void testDeleteDirectory() throws IOException {
+    final HashMap<String, String> metadata = new HashMap<>();
+    metadata.put("hdi_isfolder", "true");
+
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getMetadata()).thenReturn(metadata);
+    when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
+    when(_mockPagedIterable.stream()).thenReturn(Collections.singletonList(_mockPathItem).stream());
+    when(_mockPathItem.getName()).thenReturn("foo");
+    when(_mockFileSystemClient.deleteDirectoryWithResponse(eq(""), eq(true), eq(null), eq(null), eq(Context.NONE)))
+        .thenReturn(_mockSimpleResponse);
+    when(_mockSimpleResponse.getValue()).thenReturn(null);
+
+    boolean actual = _underTest.delete(_mockURI, true);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getMetadata();
+    verify(_mockFileSystemClient).listPaths(any(), any());
+    verify(_mockPagedIterable).stream();
+    verify(_mockPathItem).getName();
+    verify(_mockFileSystemClient).deleteDirectoryWithResponse(eq(""), eq(true), eq(null), eq(null), eq(Context.NONE));
+    verify(_mockSimpleResponse).getValue();
+  }
+
+  @Test
+  public void testDeleteFile() throws IOException {
+    final HashMap<String, String> metadata = new HashMap<>();
+    metadata.put("hdi_isfolder", "false");
+
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getMetadata()).thenReturn(metadata);
+    doNothing().when(_mockFileSystemClient).deleteFile(any());
+
+    boolean actual = _underTest.delete(_mockURI, true);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getMetadata();
+    verify(_mockFileSystemClient).deleteFile(any());
+  }
+
+  @Test
+  public void testDoMove() throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.rename(eq(null), any())).thenReturn(_mockDirectoryClient);
+
+    boolean actual = _underTest.doMove(_mockURI, _mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).rename(eq(null), any());
+  }
+
+  @Test
+  public void testDoMoveException() {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenThrow(_mockDataLakeStorageException);
+
+    Assert.expectThrows(IOException.class, () -> _underTest.doMove(_mockURI, _mockURI));
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+  }
+
+  @Test
+  public void testExistsTrue() throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+
+    boolean actual = _underTest.exists(_mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+  }
+
+  @Test
+  public void testExistsFalse() throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
+
+    boolean actual = _underTest.exists(_mockURI);
+    Assert.assertFalse(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockDataLakeStorageException).getStatusCode();
+  }
+
+  @Test
+  public void testExistsException() throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(123);
+
+    Assert.expectThrows(IOException.class, () -> _underTest.exists(_mockURI));
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockDataLakeStorageException).getStatusCode();
+  }
+
+  @Test
+  public void testLength() throws IOException {
+    final long testLength = 42;
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getFileSize()).thenReturn(testLength);
+
+    long actual = _underTest.length(_mockURI);
+    Assert.assertEquals(actual, testLength);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getFileSize();
+  }
+
+  @Test
+  public void testLengthException() {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+
+    Assert.expectThrows(IOException.class, () -> _underTest.length(_mockURI));
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+  }
+
+  @Test
+  public void testTouch() throws IOException {
+    when(_mockFileSystemClient.getFileClient(any())).thenReturn(_mockFileClient);
+    when(_mockFileClient.getProperties()).thenReturn(_mockPathProperties);
+    doNothing().when(_mockFileClient).setHttpHeaders(any());
+
+    boolean actual = _underTest.touch(_mockURI);
+    Assert.assertTrue(actual);
+
+    verify(_mockFileSystemClient).getFileClient(any());
+    verify(_mockFileClient).getProperties();
+    verify(_mockFileClient).setHttpHeaders(any());
+    verify(_mockPathProperties).getCacheControl();
+    verify(_mockPathProperties).getContentDisposition();
+    verify(_mockPathProperties).getContentEncoding();
+    verify(_mockPathProperties).getContentMd5();
+    verify(_mockPathProperties).getContentLanguage();
+    verify(_mockPathProperties).getContentType();
+  }
+
+  @Test
+  public void testTouchException() {
+    when(_mockFileSystemClient.getFileClient(any())).thenReturn(_mockFileClient);
+    when(_mockFileClient.getProperties()).thenReturn(_mockPathProperties);
+    doThrow(_mockDataLakeStorageException).when(_mockFileClient).setHttpHeaders(any());
+
+    Assert.expectThrows(IOException.class, () -> _underTest.touch(_mockURI));
+
+    verify(_mockFileSystemClient).getFileClient(any());
+    verify(_mockFileClient).getProperties();
+    verify(_mockFileClient).setHttpHeaders(any());
+    verify(_mockPathProperties).getCacheControl();
+    verify(_mockPathProperties).getContentDisposition();
+    verify(_mockPathProperties).getContentEncoding();
+    verify(_mockPathProperties).getContentMd5();
+    verify(_mockPathProperties).getContentLanguage();
+    verify(_mockPathProperties).getContentType();
+  }
+
+  @Test
+  public void open() throws IOException {
+    when(_mockFileSystemClient.getFileSystemName()).thenReturn(MOCK_FILE_SYSTEM_NAME);
+    when(_mockBlobServiceClient.getBlobContainerClient(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockBlobContainerClient);
+    when(_mockBlobContainerClient.getBlobClient(any())).thenReturn(_mockBlobClient);
+    when(_mockBlobClient.openInputStream()).thenReturn(_mockBlobInputStream);
+
+    InputStream actual = _underTest.open(_mockURI);
+    Assert.assertEquals(actual, _mockBlobInputStream);
+
+    verify(_mockFileSystemClient).getFileSystemName();
+    verify(_mockBlobServiceClient).getBlobContainerClient(MOCK_FILE_SYSTEM_NAME);
+    verify(_mockBlobContainerClient).getBlobClient(any());
+    verify(_mockBlobClient).openInputStream();
+  }
+}

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/AzurePinotFSTest.java
@@ -18,14 +18,11 @@
  */
 package org.apache.pinot.plugin.filesystem.test;
 
+import com.microsoft.azure.datalake.store.ADLFileInputStream;
 import com.microsoft.azure.datalake.store.ADLStoreClient;
-import com.microsoft.azure.datalake.store.MockADLFileInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.plugin.filesystem.AzurePinotFS;
 import org.mockito.ArgumentMatchers;
@@ -65,6 +62,7 @@ public class AzurePinotFSTest {
   public void testFS()
       throws Exception {
     ADLStoreClient adlStoreClient = Mockito.mock(ADLStoreClient.class);
+    ADLFileInputStream adlFileInputStream = Mockito.mock(ADLFileInputStream.class);
     Mockito.when(adlStoreClient.checkExists(_adlLocation)).thenReturn(true);
     Mockito.when(adlStoreClient.checkExists(_testFile.getPath())).thenReturn(true);
 
@@ -74,8 +72,6 @@ public class AzurePinotFSTest {
     Assert.assertTrue(azurePinotFS.exists(new URI(_adlLocation)));
 
     File file = new File(_adlLocation, "testfile2");
-    MockADLFileInputStream adlFileInputStream =
-        new MockADLFileInputStream(new ByteArrayInputStream(Files.readAllBytes(Paths.get(testFileURI))));
     Mockito.when(adlStoreClient.getReadStream(ArgumentMatchers.anyString())).thenReturn(adlFileInputStream);
     azurePinotFS.copyToLocalFile(testFileURI, file);
     Assert.assertTrue(file.exists());

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,4 @@
+# This class defines Mockito plugins to be used during testing
+
+# mock-maker inline enables mocking of 'final' classes in Mockito v2
+mock-maker-inline

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <aws.sdk.version>2.13.46</aws.sdk.version>
-    <netty.version>4.1.42.Final</netty.version>
+    <netty.version>4.1.54.Final</netty.version>
     <http.client.version>4.5.9</http.client.version>
     <http.core.version>4.4.9</http.core.version>
     <reactivestream.version>1.0.3</reactivestream.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <parquet.version>1.8.0</parquet.version>
     <helix.version>0.9.8</helix.version>
     <zkclient.version>0.7</zkclient.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.28</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
@@ -142,7 +142,7 @@
     <dropwizard-metrics.version>4.1.2</dropwizard-metrics.version>
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <log4j.version>2.11.2</log4j.version>
-    <netty.version>4.1.42.Final</netty.version>
+    <netty.version>4.1.54.Final</netty.version>
     <jts.version>1.16.1</jts.version>
     <h3.version>3.0.3</h3.version>
     <jmh.version>1.26</jmh.version>


### PR DESCRIPTION
## Description
Linkedin plans to use ADLSGen2PinotFS but requires
1) Service principal based authentication to do that for better ACL control. The current accesskey based auth would be harder to maintain with multiple applications.   https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-directory-file-acl-java#connect-by-using-azure-active-directory-azure-ad
2) The current implementation fails in case the blob container(file system) is not created beforehand. This adds additional friction when on-boarding new use cases or standing up pinot on a new environment.
3) Introduces unit tests to ADLSGen2PinotFS to improve craftsmanship. 

## Upgrade Notes
Improves ADLSGen2PinotFS with service principal based auth, auto create container on initial run.
Is backwards compatible with key based auth. But also optionally understands clientId, tenantId, clientSecret configs.
