### PR TITLE
Update DimTableSegmentAssignment to include both OFFLINE and REALTIME servers

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -481,7 +481,7 @@ public class HelixHelper {
         .addAll(HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getRealtimeTagForTenant(tenant)));
     return serverInstances;
   }
-  
+
   /**
    * Returns the broker instances in the cluster for the given tenant.
    *

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -463,6 +463,13 @@ public class HelixHelper {
 
   /**
    * Returns the server instances in the cluster for the given tenant.
+   */
+  public static Set<String> getServerInstancesForTenant(HelixManager helixManager, String tenant) {
+    return getServerInstancesForTenant(getInstanceConfigs(helixManager), tenant);
+  }
+
+  /**
+   * Returns the server instances in the cluster for the given tenant.
    *
    * TODO: refactor code to use this method if applicable to reuse instance configs in order to reduce ZK accesses
    */
@@ -474,6 +481,7 @@ public class HelixHelper {
         .addAll(HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getRealtimeTagForTenant(tenant)));
     return serverInstances;
   }
+
 
   /**
    * Returns the broker instances in the cluster for the given tenant.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -481,8 +481,7 @@ public class HelixHelper {
         .addAll(HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getRealtimeTagForTenant(tenant)));
     return serverInstances;
   }
-
-
+  
   /**
    * Returns the broker instances in the cluster for the given tenant.
    *

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignment.java
@@ -72,12 +72,10 @@ public class OfflineDimTableSegmentAssignment implements SegmentAssignment {
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
     String serverTag = _tenantConfig.getServer();
     Set<String> instances = HelixHelper.getServerInstancesForTenant(_helixManager, serverTag);
-
     int numInstances = instances.size();
     Preconditions.checkState(numInstances > 0, "No instance found with tag: %s or %s",
         TagNameUtils.getOfflineTagForTenant(serverTag),
         TagNameUtils.getRealtimeTagForTenant(serverTag));
-
     return new ArrayList<>(instances);
   }
 
@@ -85,7 +83,6 @@ public class OfflineDimTableSegmentAssignment implements SegmentAssignment {
   public Map<String, Map<String, String>> rebalanceTable(Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
       @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap, Configuration config) {
-
     String serverTag = _tenantConfig.getServer();
     Set<String> instances = HelixHelper.getServerInstancesForTenant(_helixManager, serverTag);
     Map<String, Map<String, String>> newAssignment = new TreeMap<>();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignmentTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.calcite.runtime.Resources;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixProperty;
@@ -104,5 +105,24 @@ public class OfflineDimTableSegmentAssignmentTest {
     Map<String, Map<String, String>> newAssignment =
         _segmentAssignment.rebalanceTable(currentAssignment, new TreeMap<>(), null, null, null);
     assertEquals(newAssignment.get(SEGMENT_NAME).size(), NUM_INSTANCES - 1);
+  }
+
+  @Test
+  public void testSegmentAssignmentToRealtimeHosts() {
+    List<HelixProperty> instanceConfigList = new ArrayList<>();
+    for (String instance: INSTANCES) {
+      ZNRecord znRecord = new ZNRecord(instance);
+      znRecord.setListField(TAG_LIST.name(), ImmutableList.of(REALTIME_SERVER_TAG));
+      instanceConfigList.add(new InstanceConfig(znRecord));
+    }
+    HelixDataAccessor dataAccessor = mock(HelixDataAccessor.class);
+    PropertyKey.Builder builder = new PropertyKey.Builder("cluster");
+    when(dataAccessor.keyBuilder()).thenReturn(builder);
+    when(dataAccessor.getChildValues(builder.instanceConfigs(), true)).thenReturn(instanceConfigList);
+    when(_helixManager.getHelixDataAccessor()).thenReturn(dataAccessor);
+
+    List<String> instances = _segmentAssignment.assignSegment(SEGMENT_NAME, new TreeMap(), new TreeMap());
+    assertEquals(instances.size(), NUM_INSTANCES);
+    assertEqualsNoOrder(instances.toArray(), INSTANCES.toArray());
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineDimTableSegmentAssignmentTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.calcite.runtime.Resources;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixProperty;


### PR DESCRIPTION
## Description
Fixes a bug with the DimTableSegmentAssignment logic where we skipped REALTIME servers when distributing segments.
We want dimension tables to be distributed to REALTIME servers as well as OFFLINE servers to enable "Realtime Fact Table to Dimension Table Joins".

## Testing
Unit tests are updated accordingly.