### PR TITLE
Fix missing default admin port for pinot-server

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -44,7 +44,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 
 /**
- * Utility class that generates Http {@link ListenerConfig} instances 
+ * Utility class that generates Http {@link ListenerConfig} instances
  * based on the properties provided by a property namespace in {@link PinotConfiguration}.
  */
 public final class ListenerConfigUtil {
@@ -61,11 +61,11 @@ public final class ListenerConfigUtil {
   /**
    * Generates {@link ListenerConfig} instances based on the combination
    * of properties such as *.port and *.access.protocols.
-   * 
+   *
    * @param config property holders for controller configuration
    * @param namespace property namespace to extract from
    *
-   * @return List of {@link ListenerConfig} for which http listeners 
+   * @return List of {@link ListenerConfig} for which http listeners
    * should be created.
    */
   public static List<ListenerConfig> buildListenerConfigs(PinotConfiguration config, String namespace,
@@ -124,11 +124,10 @@ public final class ListenerConfigUtil {
   public static List<ListenerConfig> buildServerAdminConfigs(PinotConfiguration serverConf) {
     List<ListenerConfig> listeners = new ArrayList<>();
 
-    String adminApiPortString = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT);
-    if (adminApiPortString != null) {
-      listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(adminApiPortString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
-    }
+    int adminApiPort = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT,
+        CommonConstants.Server.DEFAULT_ADMIN_API_PORT);
+    listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, adminApiPort,
+        CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(serverConf, CommonConstants.Server.SERVER_TLS_PREFIX);
 


### PR DESCRIPTION
## Description
The PR (https://github.com/apache/incubator-pinot/pull/6418) removed the default value of admin port for pinot-server. This makes pinot-servers  which don't have specified admin port in their instance configs fail to start the admin endpoints.

Before this fix:
```
$  lsof -i -P -n | grep LISTEN
java    140  ...  ...  IPv6 ...      0t0  TCP *:15507 (LISTEN)
java    140  ... ...  IPv6 ...      0t0  TCP *:8001 (LISTEN)
```

After this fix:
```
java    1231  ...  ...  IPv6 ...      0t0  TCP *:15507 (LISTEN)
java    1231  ...  ...  IPv6 ...      0t0  TCP *:8097 (LISTEN)
java    1231  ... ...  IPv6 ...      0t0  TCP *:8001 (LISTEN)
```
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
