### PR TITLE
Adding new validation for Json, TEXT indexing

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -480,10 +480,13 @@ public final class TableConfigUtils {
     }
 
     // Range index semantic validation
+    // Range index can be defined on numeric columns and any column with a dictionary
     if (indexingConfig.getRangeIndexColumns() != null) {
       for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
-        Preconditions.checkState(schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric(),
-            "Cannot create a range index on non-numeric column " + rangeIndexCol);
+        Preconditions.checkState(
+            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet
+                .contains(rangeIndexCol),
+            "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -508,8 +508,10 @@ public final class TableConfigUtils {
 
     if (indexingConfig.getJsonIndexColumns() != null) {
       for (String jsonIndexCol : indexingConfig.getJsonIndexColumns()) {
-        Preconditions.checkState(schema.getFieldSpecFor(jsonIndexCol).isSingleValueField(),
-            "Cannot create json index on multi-value column: " + jsonIndexCol);
+        Preconditions.checkState(
+            schema.getFieldSpecFor(jsonIndexCol).isSingleValueField() && schema.getFieldSpecFor(jsonIndexCol)
+                .getDataType().equals(FieldSpec.DataType.STRING),
+            "Json index can only be created for single value String column. Invalid for column: " + jsonIndexCol);
       }
     }
   }
@@ -553,8 +555,6 @@ public final class TableConfigUtils {
               "FST Index is only supported for single value string columns");
           break;
         case TEXT:
-          Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW,
-              "TEXT Index is only enabled on non dictionary encoded columns");
           Preconditions.checkState(
               fieldConfigColSpec.isSingleValueField() && fieldConfigColSpec.getDataType() == FieldSpec.DataType.STRING,
               "TEXT Index is only supported for single value string columns");

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -49,6 +49,7 @@ import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -63,7 +64,6 @@ import org.apache.pinot.spi.utils.TimeUtils;
 public final class TableConfigUtils {
 
   private TableConfigUtils() {
-
   }
 
   /**
@@ -214,7 +214,7 @@ public final class TableConfigUtils {
               "Dimension tables must have segment ingestion type REFRESH");
         }
       }
-      if (tableConfig.isDimTable()){
+      if (tableConfig.isDimTable()) {
         Preconditions.checkState(ingestionConfig.getBatchIngestionConfig() != null,
             "Dimension tables must have batch ingestion configuration");
       }
@@ -256,8 +256,7 @@ public final class TableConfigUtils {
           String columnName = transformConfig.getColumnName();
           if (schema != null) {
             Preconditions.checkState(schema.getFieldSpecFor(columnName) != null,
-                "The destination column '" + columnName
-                    + "' of the transform function must be present in the schema");
+                "The destination column '" + columnName + "' of the transform function must be present in the schema");
           }
           String transformFunction = transformConfig.getTransformFunction();
           if (columnName == null || transformFunction == null) {
@@ -437,6 +436,11 @@ public final class TableConfigUtils {
         columnNameToConfigMap.put(columnName, "Segment Partition Config");
       }
     }
+    if (indexingConfig.getJsonIndexColumns() != null) {
+      for (String columnName : indexingConfig.getJsonIndexColumns()) {
+        columnNameToConfigMap.put(columnName, "Json Index Config");
+      }
+    }
 
     List<StarTreeIndexConfig> starTreeIndexConfigList = indexingConfig.getStarTreeIndexConfigs();
     if (starTreeIndexConfigList != null) {
@@ -474,11 +478,43 @@ public final class TableConfigUtils {
       Preconditions.checkState(schema.getFieldSpecFor(columnName) != null,
           "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
     }
+
+    // Range index semantic validation
+    if (indexingConfig.getRangeIndexColumns() != null) {
+      for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
+        Preconditions.checkState(schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric(),
+            "Cannot create a range index on non-numeric column " + rangeIndexCol);
+      }
+    }
+
+    // Var length dictionary semantic validation
+    if (indexingConfig.getVarLengthDictionaryColumns() != null) {
+      for (String varLenDictCol : indexingConfig.getVarLengthDictionaryColumns()) {
+        FieldSpec varLenDictFieldSpec = schema.getFieldSpecFor(varLenDictCol);
+        switch (varLenDictFieldSpec.getDataType()) {
+          case STRING:
+          case BYTES:
+            continue;
+          default:
+            throw new IllegalStateException(
+                "var length dictionary can only be created for columns of type STRING and BYTES. Invalid for column "
+                    + varLenDictCol);
+        }
+      }
+    }
+
+    if (indexingConfig.getJsonIndexColumns() != null) {
+      for (String jsonIndexCol : indexingConfig.getJsonIndexColumns()) {
+        Preconditions.checkState(schema.getFieldSpecFor(jsonIndexCol).isSingleValueField(),
+            "Cannot create json index on multi-value column: " + jsonIndexCol);
+      }
+    }
   }
 
   /**
    * Validates the Field Config List in the given TableConfig
    * Ensures that every referred column name exists in the corresponding schema
+   * Additional checks for TEXT and FST index types
    */
   private static void validateFieldConfigList(@Nullable List<FieldConfig> fieldConfigList,
       @Nullable IndexingConfig indexingConfigs, @Nullable Schema schema) {
@@ -488,18 +524,37 @@ public final class TableConfigUtils {
 
     for (FieldConfig fieldConfig : fieldConfigList) {
       String columnName = fieldConfig.getName();
-      Preconditions.checkState(schema.getFieldSpecFor(columnName) != null,
+      FieldSpec fieldConfigColSpec = schema.getFieldSpecFor(columnName);
+      Preconditions.checkState(fieldConfigColSpec != null,
           "Column Name " + columnName + " defined in field config list must be a valid column defined in the schema");
 
-      if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY &&
-          indexingConfigs.getNoDictionaryColumns() != null) {
-        Preconditions.checkArgument(!indexingConfigs.getNoDictionaryColumns().contains(columnName),
-            "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
+      List<String> noDictionaryColumns = indexingConfigs.getNoDictionaryColumns();
+      switch (fieldConfig.getEncodingType()) {
+        case RAW:
+          Preconditions.checkState(noDictionaryColumns != null && noDictionaryColumns.contains(columnName),
+              "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
+          break;
+        case DICTIONARY:
+          if (noDictionaryColumns != null) {
+            Preconditions.checkArgument(!noDictionaryColumns.contains(columnName),
+                "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
+          }
       }
-      // FST Index is only available on dictionary encoded columns.
-      if (fieldConfig.getIndexType() == FieldConfig.IndexType.FST) {
-        Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
-            "FST Index is only enabled on dictionary encoded columns");
+
+      switch (fieldConfig.getIndexType()) {
+        case FST:
+          Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
+              "FST Index is only enabled on dictionary encoded columns");
+          Preconditions.checkState(
+              fieldConfigColSpec.isSingleValueField() && fieldConfigColSpec.getDataType() == FieldSpec.DataType.STRING,
+              "FST Index is only supported for single value string columns");
+          break;
+        case TEXT:
+          Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW,
+              "TEXT Index is only enabled on non dictionary encoded columns");
+          Preconditions.checkState(
+              fieldConfigColSpec.isSingleValueField() && fieldConfigColSpec.getDataType() == FieldSpec.DataType.STRING,
+              "TEXT Index is only supported for single value string columns");
       }
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -695,17 +695,6 @@ public class TableConfigUtilsTest {
       Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
     }
 
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
-    try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.TEXT, null);
-      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
-      TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail since TEXT index is enabled on dictionary encoded column");
-    } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "TEXT Index is only enabled on non dictionary encoded columns");
-    }
-
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
     try {
@@ -933,6 +922,24 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for non existent column in Json index config");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setJsonIndexColumns(Arrays.asList("intCol")).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for Json index defined on non string column");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for Json index defined on multi-value column");
     } catch (Exception e) {
       // expected
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -941,9 +941,18 @@ public class TableConfigUtilsTest {
         build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail for range index defined on non numeric column");
     } catch (Exception e) {
-      // expected
+      Assert.fail("Should work for range index defined on dictionary encoded string column");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList)
+        .setNoDictionaryColumns(columnList).
+            build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for range index defined on non numeric/no-dictionary column");
+    } catch (Exception e) {
+      // Expected
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setVarLengthDictionaryColumns(Arrays.asList("intCol")).

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -178,8 +178,8 @@ public class TableConfigUtilsTest {
     // dimension table with REALTIME type (should be OFFLINE)
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
-        .setTableName(TABLE_NAME).setIsDimTable(true).setTimeColumnName(TIME_COLUMN).build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setIsDimTable(true)
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension table of type REALTIME");
@@ -188,8 +188,8 @@ public class TableConfigUtilsTest {
     }
 
     // dimension table without a schema
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME).setIsDimTable(true).setTimeColumnName(TIME_COLUMN).build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, null);
       Assert.fail("Should fail with a Dimension table without a schema");
@@ -200,8 +200,8 @@ public class TableConfigUtilsTest {
     // dimension table without a Primary Key
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME).setIsDimTable(true).setTimeColumnName(TIME_COLUMN).build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension without a primary key");
@@ -210,10 +210,10 @@ public class TableConfigUtilsTest {
     }
 
     // valid dimension table
-    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-        .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME).setIsDimTable(true).build();
+    schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true).build();
     TableConfigUtils.validate(tableConfig, schema);
   }
 
@@ -456,17 +456,14 @@ public class TableConfigUtilsTest {
 
     // valid dimension table ingestion config
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setIngestionConfig(
-            new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), "REFRESH",
-                null), null, null, null)
-        ).build();
+        .setIngestionConfig(new IngestionConfig(
+            new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), "REFRESH", null), null, null,
+            null)).build();
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     // dimension tables should have batch ingestion config
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setIngestionConfig(
-            new IngestionConfig(null, null, null, null)
-        ).build();
+        .setIngestionConfig(new IngestionConfig(null, null, null, null)).build();
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for Dimension table without batch ingestion config");
@@ -476,10 +473,9 @@ public class TableConfigUtilsTest {
 
     // dimension tables should have batch ingestion config of type REFRESH
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setIngestionConfig(
-            new IngestionConfig(new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), "APPEND",
-                null), null, null, null)
-        ).build();
+        .setIngestionConfig(new IngestionConfig(
+            new BatchIngestionConfig(Lists.newArrayList(batchConfigMap, batchConfigMap), "APPEND", null), null, null,
+            null)).build();
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for Dimension table with ingestion type APPEND (should be REFRESH)");
@@ -648,7 +644,9 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateFieldConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING).build();
+        .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("myCol2", FieldSpec.DataType.INT)
+        .addSingleValueDimension("intCol", FieldSpec.DataType.INT).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
 
@@ -675,6 +673,63 @@ public class TableConfigUtilsTest {
       Assert.assertEquals(e.getMessage(), "FST Index is only enabled on dictionary encoded columns");
     }
 
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since FST index is enabled on multi value column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since FST index is enabled on non String column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.TEXT, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since TEXT index is enabled on dictionary encoded column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "TEXT Index is only enabled on non dictionary encoded columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since TEXT index is enabled on multi value column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "TEXT Index is only supported for single value string columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since TEXT index is enabled on non String column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "TEXT Index is only supported for single value string columns");
+    }
+
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
@@ -682,7 +737,7 @@ public class TableConfigUtilsTest {
           new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail since field name is not persent in schema");
+      Assert.fail("Should fail since field name is not present in schema");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
           "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
@@ -693,7 +748,9 @@ public class TableConfigUtilsTest {
   public void testValidateIndexingConfig() {
     Schema schema =
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .build();
+            .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
+            .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
+            .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setBloomFilterColumns(Arrays.asList("myCol2")).build();
     try {
@@ -867,6 +924,42 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for valid column name in both no dictionary and bloom filter column config");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setJsonIndexColumns(Arrays.asList("non-existent-column")).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for non existent column in Json index config");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList).
+        build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for range index defined on non numeric column");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setVarLengthDictionaryColumns(Arrays.asList("intCol")).
+        build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for Var length dictionary defined for non string/bytes column");
+    } catch (Exception e) {
+      // expected
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setJsonIndexColumns(Arrays.asList("multiValCol")).
+        build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for Json Index defined on a multi value column");
     } catch (Exception e) {
       // expected
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -94,6 +94,7 @@ public class TableConfigBuilder {
   private boolean _nullHandlingEnabled;
   private List<String> _varLengthDictionaryColumns;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
+  private List<String> _jsonIndexColumns;
 
   private TableCustomConfig _customConfig;
   private QuotaConfig _quotaConfig;
@@ -268,6 +269,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setJsonIndexColumns(List<String> jsonIndexColumns) {
+    _jsonIndexColumns = jsonIndexColumns;
+    return this;
+  }
+
   public TableConfigBuilder setStreamConfigs(Map<String, String> streamConfigs) {
     Preconditions.checkState(_tableType == TableType.REALTIME);
     _streamConfigs = streamConfigs;
@@ -386,6 +392,7 @@ public class TableConfigBuilder {
     indexingConfig.setNullHandlingEnabled(_nullHandlingEnabled);
     indexingConfig.setVarLengthDictionaryColumns(_varLengthDictionaryColumns);
     indexingConfig.setStarTreeIndexConfigs(_starTreeIndexConfigs);
+    indexingConfig.setJsonIndexColumns(_jsonIndexColumns);
 
     if (_customConfig == null) {
       _customConfig = new TableCustomConfig(null);


### PR DESCRIPTION
 - Adding semantic validation for indexing and field config

## Description
Related to #5942 . This PR adds some missing config validation for range, varLength, Json, TEXT, FST indexing config

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No
Does this PR fix a zero-downtime upgrade introduced earlier?
No
Does this PR otherwise need attention when creating release notes?
No