### PR TITLE
Adding a controller periodic task to clean up dead minion instances

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -70,7 +70,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   CRON_SCHEDULER_JOB_SCHEDULED("cronSchedulerJobScheduled", false),
 
   // Number of Tasks Status
-  TASK_STATUS("taskStatus", false);
+  TASK_STATUS("taskStatus", false),
+
+  // Number of dropped minion instances
+  DROPPED_MINION_INSTANCES("droppedMinionInstances", true);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -88,6 +88,10 @@ public class ControllerConf extends PinotConfiguration {
     public static final String STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS =
         "controller.statuschecker.waitForPushTimeInSeconds";
     public static final String TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
+    public static final String MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = "controller.minion.instances.cleanup.task.frequencyInSeconds";
+    public static final String MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS = "controller.minion.instances.cleanup.task.initialDelaySeconds";
+
+
     public static final String PINOT_TASK_MANAGER_SCHEDULER_ENABLED = "controller.task.scheduler.enabled";
     @Deprecated
     // RealtimeSegmentRelocator has been rebranded as SegmentRelocator
@@ -131,6 +135,8 @@ public class ControllerConf extends PinotConfiguration {
     private static final int DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
     private static final int DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS = 10 * 60; // 10 minutes
     private static final int DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS = -1; // Disabled
+    private static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
+
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
   }
@@ -537,6 +543,24 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setTaskManagerFrequencyInSeconds(int frequencyInSeconds) {
     setProperty(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_IN_SECONDS, Integer.toString(frequencyInSeconds));
+  }
+
+  public long getMinionInstancesCleanupTaskFrequencyInSeconds() {
+    return getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
+        ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS);
+  }
+
+  public void setMinionInstancesCleanupTaskFrequencyInSeconds(int frequencyInSeconds) {
+    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS, Integer.toString(frequencyInSeconds));
+  }
+
+  public long getMinionInstancesCleanupTaskInitialDelaySeconds() {
+    return getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
+  }
+
+  public void setMinionInstancesCleanupTaskInitialDelaySeconds(int initialDelaySeconds) {
+    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS, Integer.toString(initialDelaySeconds));
   }
 
   public int getDefaultTableMinReplicas() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -63,6 +63,7 @@ import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.events.MetadataEventNotifierFactory;
+import org.apache.pinot.controller.helix.core.minion.MinionInstancesCleanupTask;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.controller.api.resources.InvalidControllerConfigException;
@@ -140,6 +141,7 @@ public class ControllerStarter implements ServiceStartable {
   private SegmentCompletionManager _segmentCompletionManager;
   private LeadControllerManager _leadControllerManager;
   private List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbackList;
+  private MinionInstancesCleanupTask _minionInstancesCleanupTask;
 
   public ControllerStarter(ControllerConf conf) {
     _config = conf;
@@ -250,6 +252,10 @@ public class ControllerStarter implements ServiceStartable {
 
   public PinotTaskManager getTaskManager() {
     return _taskManager;
+  }
+
+  public MinionInstancesCleanupTask getMinionInstancesCleanupTask() {
+    return _minionInstancesCleanupTask;
   }
 
   @Override
@@ -580,6 +586,8 @@ public class ControllerStarter implements ServiceStartable {
     _segmentRelocator = new SegmentRelocator(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
         _executorService);
     periodicTasks.add(_segmentRelocator);
+    _minionInstancesCleanupTask = new MinionInstancesCleanupTask(_helixResourceManager, _config, _controllerMetrics);
+    periodicTasks.add(_minionInstancesCleanupTask);
 
     return periodicTasks;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTask.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
+import org.apache.pinot.core.periodictask.BasePeriodicTask;
+
+
+/**
+ * A periodic task to clean up offline Minion instances to not spam Helix.
+ */
+public class MinionInstancesCleanupTask extends BasePeriodicTask {
+  protected final PinotHelixResourceManager _pinotHelixResourceManager;
+  protected final ControllerMetrics _controllerMetrics;
+
+  public MinionInstancesCleanupTask(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf controllerConf,
+      ControllerMetrics controllerMetrics) {
+    super("MinionInstancesCleanupTask", controllerConf.getMinionInstancesCleanupTaskFrequencyInSeconds(),
+        controllerConf.getMinionInstancesCleanupTaskInitialDelaySeconds());
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _controllerMetrics = controllerMetrics;
+  }
+
+  @Override
+  protected void runTask() {
+    List<String> offlineInstances = new ArrayList<>(_pinotHelixResourceManager.getAllInstances());
+    offlineInstances.removeAll(_pinotHelixResourceManager.getOnlineInstanceList());
+    for (String offlineInstance : offlineInstances) {
+      if (offlineInstance.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
+        PinotResourceManagerResponse response = _pinotHelixResourceManager.dropInstance(offlineInstance);
+        if (response.isSuccessful()) {
+          _controllerMetrics.addValueToGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES, 1);
+        }
+      }
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
@@ -55,7 +55,7 @@ public class ControllerPeriodicTaskStarterStatelessTest extends ControllerTest {
   }
 
   private class MockControllerStarter extends ControllerStarter {
-    private static final int NUM_PERIODIC_TASKS = 7;
+    private static final int NUM_PERIODIC_TASKS = 8;
 
     public MockControllerStarter(ControllerConf conf) {
       super(conf);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class MinionInstancesCleanupTaskTest extends ControllerTest {
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    startZk();
+    startController();
+  }
+
+  @Test
+  public void testMinionInstancesCleanupTask()
+      throws Exception {
+    MinionInstancesCleanupTask minionInstancesCleanupTask = _controllerStarter.getMinionInstancesCleanupTask();
+    minionInstancesCleanupTask.runTask();
+    Assert.assertEquals(
+        _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 0);
+    addFakeMinionInstancesToAutoJoinHelixCluster(3);
+    Assert.assertEquals(
+        _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 0);
+    stopFakeInstance("Minion_localhost_0");
+    minionInstancesCleanupTask.runTask();
+    Assert.assertEquals(
+        _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 1);
+    stopFakeInstance("Minion_localhost_1");
+    minionInstancesCleanupTask.runTask();
+    Assert.assertEquals(
+        _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 2);
+    stopFakeInstance("Minion_localhost_2");
+    minionInstancesCleanupTask.runTask();
+    Assert.assertEquals(
+        _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 3);
+  }
+
+  @AfterClass
+  public void teardown() {
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/tenant/TenantRole.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/tenant/TenantRole.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.tenant;
 
 public enum TenantRole {
-  SERVER, BROKER
+  SERVER, BROKER, MINION
 }


### PR DESCRIPTION
## Description
Pinot Minion is designed as a stateless service. In the Kubernetes deployment model, there is no guarantee for the minion instance id which means there could be many offline minion instances in the helix when we operate Pinot for a certain amount of time.

This PR introduces a new controller periodical task to cleanup dead pinot minion instances.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
