### PR TITLE
[TE]frontend - Change the formatting of metric display in exploration page

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-alert-yaml-details/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-alert-yaml-details/component.js
@@ -30,12 +30,22 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     const mode = get(this, 'displayMode');
+
     if (mode === 'single') {
       setProperties(this, {
         valueClassSuffix: '-solo',
         modeSubClass: 'solo'
       });
     }
+  },
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    const { alertData: { metric: metrics = [] } = {} } = this;
+
+    this.set('firstMetric', metrics[0]);
+    this.set('remainingMetricCount', metrics.length - 1);
   },
 
   actions: {

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-alert-yaml-details/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-alert-yaml-details/template.hbs
@@ -5,15 +5,21 @@
         {{alertData.detectionName}}
       </h3>
       {{#if isLoadError}}
-        <div class="te-search-results__tag
-             {{if (eq displayMode " list") "te-search-results__tag--list"}}
-             {{if alertData.isActive "te-search-results__tag--active"}}">
+        <div
+          class="te-search-results__tag
+            {{if (eq displayMode " list") "te-search-results__tag--list"}}
+
+            {{if alertData.isActive "te-search-results__tag--active"}}"
+        >
           Error
         </div>
       {{else}}
-        <div class="te-search-results__tag
-             {{if (eq displayMode " list") "te-search-results__tag--list"}}
-             {{if alertData.isActive "te-search-results__tag--active"}}">
+        <div
+          class="te-search-results__tag
+            {{if (eq displayMode " list") "te-search-results__tag--list"}}
+
+            {{if alertData.isActive "te-search-results__tag--active"}}"
+        >
           {{if alertData.isActive "Active" "Inactive"}}
         </div>
         {{#x-toggle
@@ -46,7 +52,15 @@
         Metric
       </dt>
       <dd class="col-md-8 te-search-results__value{{valueClassSuffix}}" title={{alertData.metric}}>
-        {{if alertData.metric alertData.metric "N/A"}}
+        <span>
+          {{if firstMetric firstMetric "N/A"}}
+        </span>
+        {{#if (gt remainingMetricCount 0)}}
+          <span class="te-search-results__value te-search-results__value--remaining-metric-count">
+            +
+            {{remainingMetricCount}}
+          </span>
+        {{/if}}
       </dd>
       <dt class="col-md-4">
         Dataset

--- a/thirdeye/thirdeye-frontend/app/pods/manage/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/explore/route.js
@@ -55,6 +55,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
             updatedBy: detection_json.updatedBy,
             exploreDimensions: detection_json.dimensions,
             dataset: detection_json.datasetNames,
+            metric: detection_json.metric,
             filters: formatYamlFilter(detectionInfo.filters),
             dimensionExploration: formatYamlFilter(detectionInfo.dimensionExploration),
             lastDetectionTime:

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -853,6 +853,16 @@ body {
     flex-shrink: 9015;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &--remaining-metric-count {
+      font-family: Lato;
+      font-style: normal;
+      font-weight: normal;
+      font-size: 14px;
+      line-height: 20px;
+
+      color: #0073b1;
+    }
   }
 
   &__value-solo {


### PR DESCRIPTION
Composite alerts can have multiple metrics instead of just 1. The backend would be making the change to return a list of all metrics in yaml, instead of string. On the frontend we would be displaying the name of the first metric and the count of the remaining metrics for now.

If need be, we may show tooltips later to display the entire metric list, but at this point there is no decision made yet for that.