### PR TITLE
Upgrade zookeeper version to 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <helix.version>0.9.8</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.10.0</jackson.version>
+    <zookeeper.version>3.5.8</zookeeper.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.28</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
@@ -465,6 +466,28 @@
         <classifier>linux-x86_64</classifier>
       </dependency>
 
+      <!-- this part is for resolving dependency convergence error for zookeeper -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
@@ -615,7 +638,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.4.11</version>
+        <version>${zookeeper.version}</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>


### PR DESCRIPTION
## Description

Per https://github.com/apache/incubator-pinot/issues/6554, upgrade zookeeper version from 3.4.11 to 3.5.8 to fix:
[ZOOKEEPER-2184](https://issues.apache.org/jira/browse/ZOOKEEPER-2184) : Zookeeper Client should re-resolve hosts when connection attempts fail.

Note:

- Found an issue on Zookeeper v3.4.13 running on JDK 14+ with an unresolvable hostname issue, so directly jump to 3.5.8.
- From zookeeper 3.5.x, `org.apache.zookeeper.server.ZooKeeperServerMain` added an AdminServer, so there is one more exception in the throw list. 
- From zookeeper 3.5.x, ZK client will fail the initialization immediately if ZK server is unreachable, so ZkStarter needs to catch the exception and retry.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
