### PR TITLE
Optimize group-key generator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.aggregation.groupby;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
@@ -46,9 +45,6 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
   private static final ThreadLocal<int[][]> THREAD_LOCAL_MV_GROUP_KEYS =
       ThreadLocal.withInitial(() -> new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][]);
 
-  // Thread local (reusable) hashMap as holder for group keys
-  private static final ThreadLocal<Map> THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS =
-      ThreadLocal.withInitial(() -> new HashMap());
   protected final AggregationFunction[] _aggregationFunctions;
   protected final GroupKeyGenerator _groupKeyGenerator;
   protected final GroupByResultHolder[] _groupByResultHolders;
@@ -89,7 +85,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
       }
     } else {
       _groupKeyGenerator = new DictionaryBasedGroupKeyGenerator(transformOperator, groupByExpressions, numGroupsLimit,
-          maxInitialResultHolderCapacity, THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+          maxInitialResultHolderCapacity);
     }
 
     // Initialize result holders

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -75,8 +75,6 @@ public class DictionaryBasedGroupKeyGeneratorTest {
   private static final String FILTER_COLUMN = "docId";
   private static final String[] SV_COLUMNS = {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10"};
   private static final String[] MV_COLUMNS = {"m1", "m2"};
-  private static final ThreadLocal<Map> THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS =
-      ThreadLocal.withInitial(() -> new HashMap());
 
   private final long _randomSeed = System.currentTimeMillis();
   private final Random _random = new Random(_randomSeed);
@@ -170,8 +168,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
 
@@ -191,8 +188,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -213,8 +209,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -235,8 +230,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -271,8 +265,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     int groupKeyUpperBound = dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound();
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound, _errorMessage);
 
@@ -293,8 +286,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -316,8 +308,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -339,8 +330,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns),
             InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(),
         InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
@@ -360,7 +350,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     // NOTE: arrayBasedThreshold must be smaller or equal to numGroupsLimit
     DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
         new DictionaryBasedGroupKeyGenerator(_transformOperator, getExpressions(groupByColumns), numGroupsLimit,
-            numGroupsLimit, THREAD_LOCAL_DICTIONARY_BASED_GROUP_KEY_HOLDERS.get());
+            numGroupsLimit);
     assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), numGroupsLimit, _errorMessage);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIntOpenHashMap.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIntOpenHashMap.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pinot.core.query.aggregation.groupby.DictionaryBasedGroupKeyGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 5, time = 10)
+@State(Scope.Benchmark)
+public class BenchmarkIntOpenHashMap {
+  private static final int NUM_VALUES = 10_000_000;
+  private static final int NUM_THREADS = 20;
+  private static final Random RANDOM = new Random();
+
+  private final int[] _values = new int[NUM_VALUES];
+  private ExecutorService _executorService;
+
+  @Param({"10000", "20000", "50000", "100000", "150000"})
+  public int _cardinality;
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    for (int i = 0; i < NUM_VALUES; i++) {
+      _values[i] = RANDOM.nextInt(_cardinality);
+    }
+    _executorService = Executors.newFixedThreadPool(NUM_THREADS);
+  }
+
+  @TearDown
+  public void tearDown() {
+    _executorService.shutdown();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int intOpenHashMap()
+      throws Exception {
+    AtomicInteger globalSum = new AtomicInteger();
+    CountDownLatch operatorLatch = new CountDownLatch(NUM_THREADS);
+    for (int i = 0; i < NUM_THREADS; i++) {
+      _executorService.submit(() -> {
+        int sum = 0;
+        Int2IntOpenHashMap map = new Int2IntOpenHashMap((int) ((1 << 10) * 0.75f));
+        map.defaultReturnValue(-1);
+        for (int value : _values) {
+          sum += getGroupId(map, value);
+        }
+        ObjectIterator<Int2IntMap.Entry> iterator = map.int2IntEntrySet().fastIterator();
+        while (iterator.hasNext()) {
+          Int2IntMap.Entry entry = iterator.next();
+          sum += entry.getIntKey();
+          sum += entry.getIntValue();
+        }
+        globalSum.addAndGet(sum);
+        operatorLatch.countDown();
+      });
+    }
+    operatorLatch.await();
+    return globalSum.get();
+  }
+
+  private int getGroupId(Int2IntOpenHashMap map, int value) {
+    int numGroups = map.size();
+    if (numGroups < 100_000) {
+      return map.computeIfAbsent(value, k -> numGroups);
+    } else {
+      return map.get(value);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int intGroupIdMap()
+      throws Exception {
+    AtomicInteger globalSum = new AtomicInteger();
+    CountDownLatch operatorLatch = new CountDownLatch(NUM_THREADS);
+    for (int i = 0; i < NUM_THREADS; i++) {
+      _executorService.submit(() -> {
+        int sum = 0;
+        DictionaryBasedGroupKeyGenerator.IntGroupIdMap map = new DictionaryBasedGroupKeyGenerator.IntGroupIdMap();
+        for (int value : _values) {
+          map.getGroupId(value, 100_000);
+        }
+        Iterator<DictionaryBasedGroupKeyGenerator.IntGroupIdMap.Entry> iterator = map.iterator();
+        while (iterator.hasNext()) {
+          DictionaryBasedGroupKeyGenerator.IntGroupIdMap.Entry entry = iterator.next();
+          sum += entry._rawKey;
+          sum += entry._groupId;
+        }
+        globalSum.addAndGet(sum);
+        operatorLatch.countDown();
+      });
+    }
+    operatorLatch.await();
+    return globalSum.get();
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkIntOpenHashMap.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -161,12 +161,14 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     File[] segments = new File(dataDir, tableName).listFiles();
     Preconditions.checkNotNull(segments);
     for (File segment : segments) {
-      SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segment);
-      if (!tableConfigured) {
-        driver.configureTable(tableName, invertedIndexColumns, bloomFilterColumns);
-        tableConfigured = true;
+      if (segment.isDirectory()) {
+        SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(segment);
+        if (!tableConfigured) {
+          driver.configureTable(tableName, invertedIndexColumns, bloomFilterColumns);
+          tableConfigured = true;
+        }
+        driver.addSegment(tableName, segmentMetadata);
       }
-      driver.addSegment(tableName, segmentMetadata);
     }
   }
 


### PR DESCRIPTION
## Description
Optimize the `IntMapBasedHolder` in the `DictionaryBasedGroupKeyGenerator` for better group-by performance on query with group-by columns cardinality product from 10K to 2B.
The improvement (up to ~40%) is mainly from replacing the `Int2IntOpenHashMap` with the new implemented `IntGroupIdMap`. The `IntGroupIdMap` stores both keys and values within a single array so that it is more friendly to CPU cache.
The benchmark result for these 2 map implementations are as followings (with 20 threads):
```
Benchmark                               (_cardinality)  Mode  Cnt     Score    Error  Units
BenchmarkIntOpenHashMap.intGroupIdMap            10000  avgt    5   177.478 ± 13.114  ms/op
BenchmarkIntOpenHashMap.intGroupIdMap            20000  avgt    5   192.885 ± 14.417  ms/op
BenchmarkIntOpenHashMap.intGroupIdMap            50000  avgt    5   274.969 ± 20.314  ms/op
BenchmarkIntOpenHashMap.intGroupIdMap           100000  avgt    5   568.092 ±  1.432  ms/op
BenchmarkIntOpenHashMap.intGroupIdMap           150000  avgt    5   720.392 ±  5.983  ms/op
BenchmarkIntOpenHashMap.intOpenHashMap           10000  avgt    5   170.883 ±  5.290  ms/op
BenchmarkIntOpenHashMap.intOpenHashMap           20000  avgt    5   229.085 ± 12.062  ms/op
BenchmarkIntOpenHashMap.intOpenHashMap           50000  avgt    5   377.269 ±  5.762  ms/op
BenchmarkIntOpenHashMap.intOpenHashMap          100000  avgt    5  1001.601 ± 34.179  ms/op
BenchmarkIntOpenHashMap.intOpenHashMap          150000  avgt    5   984.365 ± 17.488  ms/op
```

Also move the thread-local data structures into the `DictionaryBasedGroupKeyGenerator` and fixes the issue of not dropping the large map that should not be cached.