### PR TITLE
Fix the SIGSEGV for large index

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -354,9 +354,8 @@ org.roaringbitmap:shims:0.9.0
 org.scala-lang:scala-library:2.11.11
 org.webjars:swagger-ui:3.18.2
 org.xerial.java:xerial-core:2.1
-org.xerial.larray:larray:0.2.1
-org.xerial.larray:larray-buffer:0.2.1
-org.xerial.larray:larray-mmap:0.2.1
+org.xerial.larray:larray-buffer:0.4.1
+org.xerial.larray:larray-mmap:0.4.1
 org.xerial.snappy:snappy-java:1.1.1.7
 org.xerial:xerial-core:3.2.2
 org.yaml:snakeyaml:1.16

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -147,13 +147,7 @@
     </dependency>
     <dependency>
       <groupId>org.xerial.larray</groupId>
-      <artifactId>larray</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>larray-mmap</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/BasePinotLBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/BasePinotLBuffer.java
@@ -27,7 +27,6 @@ import java.nio.channels.FileChannel;
 import javax.annotation.concurrent.ThreadSafe;
 import xerial.larray.buffer.LBuffer;
 import xerial.larray.buffer.LBufferAPI;
-import xerial.larray.buffer.WrappedLBuffer;
 import xerial.larray.mmap.MMapBuffer;
 
 
@@ -132,13 +131,9 @@ public abstract class BasePinotLBuffer extends PinotDataBuffer {
   @Override
   public PinotDataBuffer view(long start, long end, ByteOrder byteOrder) {
     if (byteOrder == NATIVE_ORDER) {
-      // Workaround to handle cases where offset is not page-aligned or view of view
-      return new PinotNativeOrderLBuffer(
-          new WrappedLBuffer(_buffer.m, start + _buffer.address() - _buffer.m.address(), end - start), false, false);
+      return new PinotNativeOrderLBuffer(_buffer.view(start, end), false, false);
     } else {
-      // Workaround to handle cases where offset is not page-aligned or view of view
-      return new PinotNonNativeOrderLBuffer(
-          new WrappedLBuffer(_buffer.m, start + _buffer.address() - _buffer.m.address(), end - start), false, false);
+      return new PinotNonNativeOrderLBuffer(_buffer.view(start, end), false, false);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -631,8 +631,8 @@
       </dependency>
       <dependency>
         <groupId>org.xerial.larray</groupId>
-        <artifactId>larray</artifactId>
-        <version>0.2.1</version>
+        <artifactId>larray-mmap</artifactId>
+        <version>0.4.1</version>
       </dependency>
       <!-- Transitive dependencies with inconsistent version numbers -->
       <dependency>


### PR DESCRIPTION
## Description
Upgrade the larray version to include the fix: https://github.com/xerial/larray/pull/52
Also fix the issue of not able to load large index if it shows up first in `SingleFileIndexDirectory`