### PR TITLE
Add support for getObject to Pinot JDBC driver

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotResultSet.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotResultSet.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -38,6 +39,7 @@ import java.util.Map;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.client.base.AbstractBaseResultSet;
 import org.apache.pinot.client.utils.DateTimeUtils;
+import org.apache.pinot.client.utils.DriverUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -295,6 +297,54 @@ public class PinotResultSet extends AbstractBaseResultSet {
     }
 
     return val;
+  }
+
+  @Override
+  public Object getObject(int columnIndex)
+      throws SQLException {
+
+    String dataType = _columnDataTypes.getOrDefault(columnIndex, "");
+
+    if (dataType.isEmpty()) {
+      throw new SQLDataException("Data type not supported for " + dataType);
+    }
+
+    switch (dataType) {
+      case "STRING":
+        return getString(columnIndex);
+      case "INT":
+        return getInt(columnIndex);
+      case "LONG":
+        return getLong(columnIndex);
+      case "FLOAT":
+        return getFloat(columnIndex);
+      case "DOUBLE":
+        return getDouble(columnIndex);
+      case "BOOLEAN":
+        return getBoolean(columnIndex);
+      case "BYTES":
+        return getBytes(columnIndex);
+      default:
+        throw new SQLDataException("Data type not supported for " + dataType);
+    }
+  }
+
+  @Override
+  public <T> T getObject(int columnIndex, Class<T> type)
+      throws SQLException {
+    Object value = getObject(columnIndex);
+
+    try {
+      return type.cast(value);
+    } catch (ClassCastException e) {
+      throw new SQLDataException("Data type conversion is not supported from :" + value.getClass() + " to: " + type);
+    }
+  }
+
+  @Override
+  public <T> T getObject(String columnLabel, Class<T> type)
+      throws SQLException {
+    return super.getObject(columnLabel, type);
   }
 
   private boolean checkIsNull(String val) {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseResultSet.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseResultSet.java
@@ -307,39 +307,27 @@ public abstract class AbstractBaseResultSet implements ResultSet {
   }
 
   @Override
-  public Object getObject(int columnIndex)
-      throws SQLException {
-    throw new SQLFeatureNotSupportedException();
-  }
-
-  @Override
   public Object getObject(String columnLabel)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return getObject(findColumn(columnLabel));
   }
 
   @Override
   public Object getObject(int columnIndex, Map<String, Class<?>> map)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return getObject(columnIndex);
   }
 
   @Override
   public Object getObject(String columnLabel, Map<String, Class<?>> map)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
-  }
-
-  @Override
-  public <T> T getObject(int columnIndex, Class<T> type)
-      throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return getObject(findColumn(columnLabel), map);
   }
 
   @Override
   public <T> T getObject(String columnLabel, Class<T> type)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return getObject(findColumn(columnLabel), type);
   }
 
   @Override


### PR DESCRIPTION
Currently, Pinot JDBC ResultSet doesn't support getObject. This PR addresses this issue. 
Do note that only datatype supported by Pinot can be called and there is still no support for custom datatypes as well datatype conversion.