### PR TITLE
Fixing schema and table config for githubEvents demo

### DIFF
--- a/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "REALTIME",
   "segmentsConfig": {
     "timeColumnName": "mergedTimeMillis",
-    "timeType": "MILLISECONDS",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "60",
     "schemaName": "pullRequestMergedEvents",

--- a/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_schema.json
+++ b/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_schema.json
@@ -140,12 +140,12 @@
       "dataType": "LONG"
     }
   ],
-  "timeFieldSpec": {
-    "incomingGranularitySpec": {
-      "timeType": "MILLISECONDS",
-      "timeFormat": "EPOCH",
+  "dateTimeFieldSpecs": [
+    {
+      "name": "mergedTimeMillis",
       "dataType": "LONG",
-      "name": "mergedTimeMillis"
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS"
     }
-  }
+  ]
 }


### PR DESCRIPTION

## Description
The current schema and table config creates some issues when using the Cluster Manager UI. This PR fixes that issue.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* No

Does this PR fix a zero-downtime upgrade introduced earlier?
* No

Does this PR otherwise need attention when creating release notes? 
* No