### PR TITLE
Adding Pinot server metric: `queriesDisabled`

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
@@ -272,14 +272,14 @@ public class RoutingManager implements ClusterChangeHandler {
 
   private static boolean isInstanceEnabled(ZNRecord instanceConfigZNRecord) {
     if ("false"
-        .equals(instanceConfigZNRecord.getSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name()))) {
+        .equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name()))) {
       return false;
     }
-    if ("true".equals(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS))) {
+    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS))) {
       return false;
     }
     //noinspection RedundantIfStatement
-    if ("true".equals(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED))) {
+    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED))) {
       return false;
     }
     return true;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/InstanceUtils.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.config.instance.Instance;
 
@@ -31,7 +32,6 @@ public class InstanceUtils {
   }
 
   public static final String POOL_KEY = "pool";
-  public static final String GRPC_PORT_KEY = "grpcPort";
 
   /**
    * Returns the Helix instance id (e.g. {@code Server_localhost_1234}) for the given instance.
@@ -76,7 +76,11 @@ public class InstanceUtils {
       }
       instanceConfig.getRecord().setMapField(POOL_KEY, mapValue);
     }
-    instanceConfig.getRecord().setSimpleField(GRPC_PORT_KEY, Integer.toString(instance.getGrpcPort()));
+    instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY, Integer.toString(instance.getGrpcPort()));
+    instanceConfig.getRecord().setSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, Integer.toString(instance.getAdminPort()));
+    if (instance.isQueriesDisabled()) {
+      instanceConfig.getRecord().setBooleanField(Helix.QUERIES_DISABLED, true);
+    }
     return instanceConfig;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
@@ -104,17 +105,34 @@ public class PinotInstanceRestletResource {
     response.set("tags", JsonUtils.objectToJsonNode(instanceConfig.getTags()));
     response.set("pools", JsonUtils.objectToJsonNode(instanceConfig.getRecord().getMapField(InstanceUtils.POOL_KEY)));
     response.put("grpcPort", getGrpcPort(instanceConfig));
+    response.put("adminPort", getAdminPort(instanceConfig));
+    String queriesDisabled = instanceConfig.getRecord().getSimpleField(CommonConstants.Helix.QUERIES_DISABLED);
+    if ("true".equalsIgnoreCase(queriesDisabled)) {
+      response.put(CommonConstants.Helix.QUERIES_DISABLED, "true");
+    }
     return response.toString();
   }
 
   private int getGrpcPort(InstanceConfig instanceConfig) {
     int grpcPort;
     try {
-      grpcPort = Integer.parseInt(instanceConfig.getRecord().getSimpleField(InstanceUtils.GRPC_PORT_KEY));
+      grpcPort = Integer.parseInt(instanceConfig.getRecord().getSimpleField(CommonConstants.Helix.Instance.GRPC_PORT_KEY));
     } catch (Exception e) {
+      LOGGER.warn("Grpc port is not set for instance: {}", instanceConfig.getInstanceName(), e);
       grpcPort = Instance.NOT_SET_GRPC_PORT_VALUE;
     }
     return grpcPort;
+  }
+
+  private int getAdminPort(InstanceConfig instanceConfig) {
+    int adminPort;
+    try {
+      adminPort = Integer.parseInt(instanceConfig.getRecord().getSimpleField(CommonConstants.Helix.Instance.ADMIN_PORT_KEY));
+    } catch (Exception e) {
+      LOGGER.warn("Admin port is not set for instance: {}", instanceConfig.getInstanceName(), e);
+      adminPort = Instance.NOT_SET_ADMIN_PORT_VALUE;
+    }
+    return adminPort;
   }
 
   @POST

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -82,10 +82,10 @@ public class PinotInstanceRestletResourceTest {
 
     // Create untagged broker and server instances
     String createInstanceUrl = ControllerTestUtils.getControllerRequestURLBuilder().forInstanceCreate();
-    Instance brokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null, 0);
+    Instance brokerInstance = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null, 0, 0, false);
     ControllerTestUtils.sendPostRequest(createInstanceUrl, brokerInstance.toJsonString());
 
-    Instance serverInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, null, null, 8090);
+    Instance serverInstance = new Instance("1.2.3.4", 2345, InstanceType.SERVER, null, null, 8090, 8091,false);
     ControllerTestUtils.sendPostRequest(createInstanceUrl, serverInstance.toJsonString());
 
     // Check that we have added two more instances
@@ -93,7 +93,7 @@ public class PinotInstanceRestletResourceTest {
 
     // Create broker and server instances with tags and pools
     brokerInstance =
-        new Instance("2.3.4.5", 1234, InstanceType.BROKER, Collections.singletonList("tag_BROKER"), null, 0);
+        new Instance("2.3.4.5", 1234, InstanceType.BROKER, Collections.singletonList("tag_BROKER"), null, 0, 0, false);
     ControllerTestUtils.sendPostRequest(createInstanceUrl, brokerInstance.toJsonString());
 
     Map<String, Integer> serverPools = new TreeMap<>();
@@ -101,7 +101,7 @@ public class PinotInstanceRestletResourceTest {
     serverPools.put("tag_REALTIME", 1);
     serverInstance =
         new Instance("2.3.4.5", 2345, InstanceType.SERVER, Arrays.asList("tag_OFFLINE", "tag_REALTIME"), serverPools,
-            18090);
+            18090, 18091, false);
     ControllerTestUtils.sendPostRequest(createInstanceUrl, serverInstance.toJsonString());
 
     // Check that we have added four instances so far
@@ -126,29 +126,29 @@ public class PinotInstanceRestletResourceTest {
     checkNumInstances(listInstancesUrl, counts[0] + 4);
 
     // Check that the instances are properly created
-    checkInstanceInfo("Broker_1.2.3.4_1234", "Broker_1.2.3.4", 1234, new String[0], null, null);
-    checkInstanceInfo("Server_1.2.3.4_2345", "Server_1.2.3.4", 2345, new String[0], null, null, 8090);
-    checkInstanceInfo("Broker_2.3.4.5_1234", "Broker_2.3.4.5", 1234, new String[]{"tag_BROKER"}, null, null);
+    checkInstanceInfo("Broker_1.2.3.4_1234", "Broker_1.2.3.4", 1234, new String[0], null, null, false);
+    checkInstanceInfo("Server_1.2.3.4_2345", "Server_1.2.3.4", 2345, new String[0], null, null, 8090, 8091, false);
+    checkInstanceInfo("Broker_2.3.4.5_1234", "Broker_2.3.4.5", 1234, new String[]{"tag_BROKER"}, null, null, false);
     checkInstanceInfo("Server_2.3.4.5_2345", "Server_2.3.4.5", 2345, new String[]{"tag_OFFLINE", "tag_REALTIME"},
-        new String[]{"tag_OFFLINE", "tag_REALTIME"}, new int[]{0, 1}, 18090);
+        new String[]{"tag_OFFLINE", "tag_REALTIME"}, new int[]{0, 1}, 18090, 18091, false);
 
     // Test PUT Instance API
     String newBrokerTag = "new-broker-tag";
     Instance newBrokerInstance =
-        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null, 0);
+        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null, 0, 0, false);
     String brokerInstanceId = "Broker_1.2.3.4_1234";
     String brokerInstanceUrl = ControllerTestUtils.getControllerRequestURLBuilder().forInstance(brokerInstanceId);
     ControllerTestUtils.sendPutRequest(brokerInstanceUrl, newBrokerInstance.toJsonString());
 
     String newServerTag = "new-server-tag";
     Instance newServerInstance =
-        new Instance("1.2.3.4", 2345, InstanceType.SERVER, Collections.singletonList(newServerTag), null, 28090);
+        new Instance("1.2.3.4", 2345, InstanceType.SERVER, Collections.singletonList(newServerTag), null, 28090, 28091, true);
     String serverInstanceId = "Server_1.2.3.4_2345";
     String serverInstanceUrl = ControllerTestUtils.getControllerRequestURLBuilder().forInstance(serverInstanceId);
     ControllerTestUtils.sendPutRequest(serverInstanceUrl, newServerInstance.toJsonString());
 
-    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{newBrokerTag}, null, null);
-    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null, 28090);
+    checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{newBrokerTag}, null, null, false);
+    checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345, new String[]{newServerTag}, null, null, 28090, 28091, true);
 
     // Test Instance updateTags API
     String brokerInstanceUpdateTagsUrl = ControllerTestUtils.getControllerRequestURLBuilder().forInstanceUpdateTags(brokerInstanceId,
@@ -158,18 +158,18 @@ public class PinotInstanceRestletResourceTest {
         Lists.newArrayList("tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"));
     ControllerTestUtils.sendPutRequest(serverInstanceUpdateTagsUrl);
     checkInstanceInfo(brokerInstanceId, "Broker_1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null,
-        null);
+        null, false);
     checkInstanceInfo(serverInstanceId, "Server_1.2.3.4", 2345,
-        new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null, 28090);
+        new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, null, 28090, 28091, true);
   }
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,
-      int[] poolValues) {
-    checkInstanceInfo(instanceName, hostName, port, tags, pools, poolValues, Instance.NOT_SET_GRPC_PORT_VALUE);
+      int[] poolValues, boolean queriesDisabled) {
+    checkInstanceInfo(instanceName, hostName, port, tags, pools, poolValues, Instance.NOT_SET_GRPC_PORT_VALUE, Instance.NOT_SET_ADMIN_PORT_VALUE, queriesDisabled);
   }
 
   private void checkInstanceInfo(String instanceName, String hostName, int port, String[] tags, String[] pools,
-      int[] poolValues, int grpcPort) {
+      int[] poolValues, int grpcPort, int adminPort, boolean queriesDisabled) {
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Nullable
       @Override
@@ -182,9 +182,9 @@ public class PinotInstanceRestletResourceTest {
                   && (instance.get("hostName") != null) && (instance.get("hostName").asText().equals(hostName)) && (
                   instance.get("port") != null) && (instance.get("port").asText().equals(String.valueOf(port)))
                   && (instance.get("enabled").asBoolean()) && (instance.get("tags") != null) && (
-                  instance.get("tags").size() == tags.length) && (instance.get("grpcPort")
-                  .asText()
-                  .equals(String.valueOf(grpcPort)));
+                  instance.get("tags").size() == tags.length) && (instance.get("grpcPort").asText().equals(String.valueOf(grpcPort))
+                  && (instance.get("queriesDisabled") == null && !queriesDisabled ||
+                  instance.get("queriesDisabled") != null && instance.get("queriesDisabled").asBoolean() == queriesDisabled));
 
           for (int i = 0; i < tags.length; i++) {
             result = result && instance.get("tags").get(i).asText().equals(tags[i]);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -177,7 +177,7 @@ public class PinotHelixResourceManagerTest {
 
     // Add new instance.
     Instance instance = new Instance("localhost", biggerRandomNumber, InstanceType.SERVER,
-        Collections.singletonList(UNTAGGED_SERVER_INSTANCE), null, 0);
+        Collections.singletonList(UNTAGGED_SERVER_INSTANCE), null, 0, 0, false);
     ControllerTestUtils.getHelixResourceManager().addInstance(instance);
 
     List<String> allInstances = ControllerTestUtils.getHelixResourceManager().getAllInstances();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerQueriesDisabledTracker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerQueriesDisabledTracker.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A class to track if the server is queries disabled.
+ */
+public class ServerQueriesDisabledTracker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueriesDisabledTracker.class);
+  private static final long FETCH_INTERVAL_MINS = 10L;
+
+  private final ScheduledExecutorService _executorService = Executors.newSingleThreadScheduledExecutor();
+  private final HelixManager _helixManager;
+  private final ServerMetrics _serverMetrics;
+  private final String _clusterName;
+  private final String _instanceId;
+  private AtomicBoolean _queriesDisabled = new AtomicBoolean();
+
+  public ServerQueriesDisabledTracker(
+      String helixClusterName, String instanceId, HelixManager helixManager, ServerMetrics serverMetrics) {
+    _helixManager = helixManager;
+    _serverMetrics = serverMetrics;
+    _clusterName = helixClusterName;
+    _instanceId = instanceId;
+  }
+
+  public void start() {
+    _serverMetrics.addCallbackGauge(CommonConstants.Helix.QUERIES_DISABLED, () -> _queriesDisabled.get() ? 1L : 0L);
+    LOGGER.info("Tracking server queries disabled.");
+    _executorService.scheduleWithFixedDelay(() -> {
+      ZNRecord instanceConfigZNRecord = _helixManager.getConfigAccessor().getInstanceConfig(_clusterName, _instanceId).getRecord();
+      if (instanceConfigZNRecord == null) {
+        LOGGER.error("Failed to get instance config: {} in {} from zookeeper" , _instanceId, _clusterName);
+      } else {
+        _queriesDisabled.set(instanceConfigZNRecord.getBooleanField(CommonConstants.Helix.QUERIES_DISABLED, false));
+      }
+    }, 0L, FETCH_INTERVAL_MINS, TimeUnit.MINUTES);
+  }
+
+  public void stop() {
+    LOGGER.info("Stopped tracking server queries disabled.");
+    _executorService.shutdown();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  */
 public class Instance extends BaseJsonConfig {
   public static int NOT_SET_GRPC_PORT_VALUE = -1;
+  public static int NOT_SET_ADMIN_PORT_VALUE = -1;
 
   private final String _host;
   private final int _port;
@@ -52,13 +53,17 @@ public class Instance extends BaseJsonConfig {
   private final List<String> _tags;
   private final Map<String, Integer> _pools;
   private final int _grpcPort;
+  private final int _adminPort;
+  private final boolean _queriesDisabled;
 
   @JsonCreator
   public Instance(@JsonProperty(value = "host", required = true) String host,
       @JsonProperty(value = "port", required = true) int port,
       @JsonProperty(value = "type", required = true) InstanceType type,
       @JsonProperty("tags") @Nullable List<String> tags, @JsonProperty("pools") @Nullable Map<String, Integer> pools,
-      @JsonProperty("grpcPort") int grpcPort) {
+      @JsonProperty("grpcPort") int grpcPort,
+      @JsonProperty("adminPort") int adminPort,
+      @JsonProperty("queriesDisabled") boolean queriesDisabled) {
     Preconditions.checkArgument(host != null, "'host' must be configured");
     Preconditions.checkArgument(type != null, "'type' must be configured");
     _host = host;
@@ -71,6 +76,12 @@ public class Instance extends BaseJsonConfig {
     } else {
       _grpcPort = grpcPort;
     }
+    if (adminPort == 0) {
+      _adminPort = NOT_SET_ADMIN_PORT_VALUE;
+    } else {
+      _adminPort = adminPort;
+    }
+    _queriesDisabled = queriesDisabled;
   }
 
   public String getHost() {
@@ -97,5 +108,13 @@ public class Instance extends BaseJsonConfig {
 
   public int getGrpcPort() {
     return _grpcPort;
+  }
+
+  public int getAdminPort() {
+    return _adminPort;
+  }
+
+  public boolean isQueriesDisabled() {
+    return _queriesDisabled;
   }
 }


### PR DESCRIPTION
  1. Periodically check instance config, and send metric whether the server is queries disabled or not.
  2. Update instance api to set `queriesDsiabled` field.

Manual tested by setting up local cluster, updating server instance config through rest api and checking jmx mbean values.