### PR TITLE
Update the default kafka consumer factory class name to use Kafka 2.0

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -50,7 +50,7 @@ public class StreamConfig {
   public static final int DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS = 100_000;
 
   public static final String DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING =
-      "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory";
+      "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory";
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;


### PR DESCRIPTION
## Description
The default Kafka client version changed from 0.9 to 2.0 in this [PR ](https://github.com/apache/incubator-pinot/pull/4970/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R140)

Changed the default kafka consumer factory class name to be consistent


## Upgrade Notes
Does this PR otherwise need attention when creating release notes? Things to consider:
* [*] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
The default value of kafka consumer factory class name `stream.kafka.consumer.factory.class.name` is changed to `"org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory"`


