### PR TITLE
Directly store values in GroupKey and avoid ser/de

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -152,9 +152,10 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
             AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
             if (aggregationGroupByResult != null) {
               // Iterate over the group-by keys, for each key, update the group-by result in the resultsMap.
-              Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+              Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator =
+                  aggregationGroupByResult.getStringGroupKeyIterator();
               while (groupKeyIterator.hasNext()) {
-                GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+                GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
                 resultsMap.compute(groupKey._stringKey, (key, value) -> {
                   if (value == null) {
                     if (numGroups.getAndIncrement() < _interSegmentNumGroupsLimit) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByResult.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByResult.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
  * It provides an iterator over group-by keys, and provides a method
  * to get the aggregation result for the given group-by key.
  */
+@SuppressWarnings("rawtypes")
 public class AggregationGroupByResult {
   private final GroupKeyGenerator _groupKeyGenerator;
   private final AggregationFunction[] _aggregationFunctions;
@@ -40,11 +41,17 @@ public class AggregationGroupByResult {
   }
 
   /**
-   * Returns an iterator for group-by keys.
-   * @return
+   * Returns an iterator of {@link GroupKeyGenerator.GroupKey}.
    */
   public Iterator<GroupKeyGenerator.GroupKey> getGroupKeyIterator() {
-    return _groupKeyGenerator.getUniqueGroupKeys();
+    return _groupKeyGenerator.getGroupKeys();
+  }
+
+  /**
+   * Returns an iterator of {@link GroupKeyGenerator.StringGroupKey}.
+   */
+  public Iterator<GroupKeyGenerator.StringGroupKey> getStringGroupKeyIterator() {
+    return _groupKeyGenerator.getStringGroupKeys();
   }
 
   /**
@@ -64,7 +71,11 @@ public class AggregationGroupByResult {
    * @param index
    * @return
    */
-  public Object getResultForKey(GroupKeyGenerator.GroupKey groupKey, int index) {
-    return _aggregationFunctions[index].extractGroupByResult(_resultHolders[index], groupKey._groupId);
+  public Object getResultForKey(GroupKeyGenerator.StringGroupKey groupKey, int index) {
+    return getResultForGroupId(index, groupKey._groupId);
+  }
+
+  public Object getResultForGroupId(int index, int groupId) {
+    return _aggregationFunctions[index].extractGroupByResult(_resultHolders[index], groupId);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -67,16 +67,28 @@ public interface GroupKeyGenerator {
   int getCurrentGroupKeyUpperBound();
 
   /**
-   * Returns an iterator of group keys. Use this interface to iterate through all the group keys.
-   *
-   * @return iterator of group keys.
+   * Returns an iterator of {@link GroupKey}. Use this interface to iterate through all the group keys.
    */
-  Iterator<GroupKey> getUniqueGroupKeys();
+  Iterator<GroupKey> getGroupKeys();
+
+  /**
+   * Returns an iterator of {@link StringGroupKey}. Use this interface to iterate through all the group keys.
+   * TODO: Remove this interface after deprecating PQL.
+   */
+  Iterator<StringGroupKey> getStringGroupKeys();
+
+  /**
+   * This class encapsulates the integer group id and the group keys.
+   */
+  class GroupKey {
+    public int _groupId;
+    public Object[] _keys;
+  }
 
   /**
    * This class encapsulates the integer group id and the string group key.
    */
-  class GroupKey {
+  class StringGroupKey {
     public int _groupId;
     public String _stringKey;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -163,7 +163,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   }
 
   @Override
-  public Iterator<GroupKey> getUniqueGroupKeys() {
+  public Iterator<GroupKey> getGroupKeys() {
     switch (_dataType) {
       case INT:
         return new IntGroupKeyIterator((Int2IntOpenHashMap) _groupKeyMap);
@@ -176,6 +176,25 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
       case STRING:
       case BYTES:
         return new ObjectGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap);
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  @Override
+  public Iterator<StringGroupKey> getStringGroupKeys() {
+    switch (_dataType) {
+      case INT:
+        return new IntStringGroupKeyIterator((Int2IntOpenHashMap) _groupKeyMap);
+      case LONG:
+        return new LongStringGroupKeyIterator((Long2IntOpenHashMap) _groupKeyMap);
+      case FLOAT:
+        return new FloatStringGroupKeyIterator((Float2IntOpenHashMap) _groupKeyMap);
+      case DOUBLE:
+        return new DoubleStringGroupKeyIterator((Double2IntOpenHashMap) _groupKeyMap);
+      case STRING:
+      case BYTES:
+        return new ObjectStringGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap);
       default:
         throw new IllegalStateException();
     }
@@ -259,7 +278,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Int2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._stringKey = Integer.toString(entry.getIntKey());
+      _groupKey._keys = new Object[]{entry.getIntKey()};
       return _groupKey;
     }
 
@@ -287,7 +306,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Long2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._stringKey = Long.toString(entry.getLongKey());
+      _groupKey._keys = new Object[]{entry.getLongKey()};
       return _groupKey;
     }
 
@@ -315,7 +334,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Float2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._stringKey = Float.toString(entry.getFloatKey());
+      _groupKey._keys = new Object[]{entry.getFloatKey()};
       return _groupKey;
     }
 
@@ -343,7 +362,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Double2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._stringKey = Double.toString(entry.getDoubleKey());
+      _groupKey._keys = new Object[]{entry.getDoubleKey()};
       return _groupKey;
     }
 
@@ -369,6 +388,146 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
     @Override
     public GroupKey next() {
+      Object2IntMap.Entry entry = _iterator.next();
+      _groupKey._groupId = entry.getIntValue();
+      _groupKey._keys = new Object[]{entry.getKey()};
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class IntStringGroupKeyIterator implements Iterator<StringGroupKey> {
+    final Iterator<Int2IntMap.Entry> _iterator;
+    final StringGroupKey _groupKey;
+
+    IntStringGroupKeyIterator(Int2IntOpenHashMap intMap) {
+      _iterator = intMap.int2IntEntrySet().fastIterator();
+      _groupKey = new StringGroupKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public StringGroupKey next() {
+      Int2IntMap.Entry entry = _iterator.next();
+      _groupKey._groupId = entry.getIntValue();
+      _groupKey._stringKey = Integer.toString(entry.getIntKey());
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class LongStringGroupKeyIterator implements Iterator<StringGroupKey> {
+    final Iterator<Long2IntMap.Entry> _iterator;
+    final StringGroupKey _groupKey;
+
+    LongStringGroupKeyIterator(Long2IntOpenHashMap longMap) {
+      _iterator = longMap.long2IntEntrySet().fastIterator();
+      _groupKey = new StringGroupKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public StringGroupKey next() {
+      Long2IntMap.Entry entry = _iterator.next();
+      _groupKey._groupId = entry.getIntValue();
+      _groupKey._stringKey = Long.toString(entry.getLongKey());
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class FloatStringGroupKeyIterator implements Iterator<StringGroupKey> {
+    final Iterator<Float2IntMap.Entry> _iterator;
+    final StringGroupKey _groupKey;
+
+    FloatStringGroupKeyIterator(Float2IntOpenHashMap floatMap) {
+      _iterator = floatMap.float2IntEntrySet().fastIterator();
+      _groupKey = new StringGroupKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public StringGroupKey next() {
+      Float2IntMap.Entry entry = _iterator.next();
+      _groupKey._groupId = entry.getIntValue();
+      _groupKey._stringKey = Float.toString(entry.getFloatKey());
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class DoubleStringGroupKeyIterator implements Iterator<StringGroupKey> {
+    final Iterator<Double2IntMap.Entry> _iterator;
+    final StringGroupKey _groupKey;
+
+    DoubleStringGroupKeyIterator(Double2IntOpenHashMap doubleMap) {
+      _iterator = doubleMap.double2IntEntrySet().fastIterator();
+      _groupKey = new StringGroupKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public StringGroupKey next() {
+      Double2IntMap.Entry entry = _iterator.next();
+      _groupKey._groupId = entry.getIntValue();
+      _groupKey._stringKey = Double.toString(entry.getDoubleKey());
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class ObjectStringGroupKeyIterator implements Iterator<StringGroupKey> {
+    final ObjectIterator<Object2IntMap.Entry> _iterator;
+    final StringGroupKey _groupKey;
+
+    ObjectStringGroupKeyIterator(Object2IntOpenHashMap objectMap) {
+      _iterator = objectMap.object2IntEntrySet().fastIterator();
+      _groupKey = new StringGroupKey();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public StringGroupKey next() {
       Object2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
       _groupKey._stringKey = entry.getKey().toString();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/BytesToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/BytesToIdMap.java
@@ -59,4 +59,9 @@ public class BytesToIdMap extends BaseValueToIdMap {
     assert id < _idToValueMap.size();
     return _idToValueMap.get(id);
   }
+
+  @Override
+  public Object get(int id) {
+    return getBytes(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/DoubleToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/DoubleToIdMap.java
@@ -58,4 +58,9 @@ public class DoubleToIdMap extends BaseValueToIdMap {
   public String getString(int id) {
     return Double.toString(getDouble(id));
   }
+
+  @Override
+  public Object get(int id) {
+    return getDouble(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/FloatToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/FloatToIdMap.java
@@ -58,4 +58,9 @@ public class FloatToIdMap extends BaseValueToIdMap {
   public String getString(int id) {
     return Float.toString(getFloat(id));
   }
+
+  @Override
+  public Object get(int id) {
+    return getFloat(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/IntToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/IntToIdMap.java
@@ -58,4 +58,9 @@ public class IntToIdMap extends BaseValueToIdMap {
   public String getString(int id) {
     return Integer.toString(getInt(id));
   }
+
+  @Override
+  public Object get(int id) {
+    return getInt(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/LongToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/LongToIdMap.java
@@ -58,4 +58,9 @@ public class LongToIdMap extends BaseValueToIdMap {
   public String getString(int id) {
     return Long.toString(getLong(id));
   }
+
+  @Override
+  public Object get(int id) {
+    return getLong(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/StringToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/StringToIdMap.java
@@ -53,4 +53,9 @@ public class StringToIdMap extends BaseValueToIdMap {
     assert id < _idToValueMap.size();
     return _idToValueMap.get(id);
   }
+
+  @Override
+  public Object get(int id) {
+    return getString(id);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMap.java
@@ -50,4 +50,18 @@ public interface ValueToIdMap {
   String getString(int id);
 
   ByteArray getBytes(int id);
+
+  /**
+   * Returns the value for the given id.
+   * <p>The Object type returned for each value type:
+   * <ul>
+   *   <li>INT -> Integer</li>
+   *   <li>LONG -> Long</li>
+   *   <li>FLOAT -> Float</li>
+   *   <li>DOUBLE -> Double</li>
+   *   <li>STRING -> String</li>
+   *   <li>BYTES -> ByteArray</li>
+   * </ul>
+   */
+  Object get(int id);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -150,6 +150,11 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
+  public Object getInternal(int dictId) {
+    return getByteArrayValue(dictId);
+  }
+
+  @Override
   public int getIntValue(int dictId) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -129,6 +129,11 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
+  public Object getInternal(int dictId) {
+    return getByteArrayValue(dictId);
+  }
+
+  @Override
   public int getIntValue(int dictId) {
     throw new UnsupportedOperationException();
   }
@@ -158,6 +163,11 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
     return getByteArrayValue(dictId).getBytes();
   }
 
+  @Override
+  public ByteArray getByteArrayValue(int dictId) {
+    return (ByteArray) super.get(dictId);
+  }
+
   private void updateMinMax(byte[] value) {
     if (_min == null) {
       _min = value;
@@ -170,9 +180,5 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
         _max = value;
       }
     }
-  }
-
-  private ByteArray getByteArrayValue(int dictId) {
-    return (ByteArray) super.get(dictId);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BytesDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/BytesDictionary.java
@@ -59,6 +59,11 @@ public class BytesDictionary extends BaseImmutableDictionary {
   }
 
   @Override
+  public Object getInternal(int dictId) {
+    return new ByteArray(getBytes(dictId));
+  }
+
+  @Override
   public int getIntValue(int dictId) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueBytesDictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/ConstantValueBytesDictionary.java
@@ -72,6 +72,11 @@ public class ConstantValueBytesDictionary extends BaseImmutableDictionary {
   }
 
   @Override
+  public Object getInternal(int dictId) {
+    return new ByteArray(_value);
+  }
+
+  @Override
   public int getIntValue(int dictId) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/readers/Dictionary.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.Closeable;
 import java.util.Arrays;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -107,6 +108,22 @@ public interface Dictionary extends Closeable {
    */
   Object get(int dictId);
 
+  /**
+   * Returns the value at the given dictId in the dictionary.
+   * <p>The Object type returned for each value type:
+   * <ul>
+   *   <li>INT -> Integer</li>
+   *   <li>LONG -> Long</li>
+   *   <li>FLOAT -> Float</li>
+   *   <li>DOUBLE -> Double</li>
+   *   <li>STRING -> String</li>
+   *   <li>BYTES -> ByteArray</li>
+   * </ul>
+   */
+  default Object getInternal(int dictId) {
+    return get(dictId);
+  }
+
   int getIntValue(int dictId);
 
   long getLongValue(int dictId);
@@ -122,6 +139,10 @@ public interface Dictionary extends Closeable {
    */
   default byte[] getBytesValue(int dictId) {
     throw new UnsupportedOperationException();
+  }
+
+  default ByteArray getByteArrayValue(int dictId) {
+    return new ByteArray(getBytesValue(dictId));
   }
 
   // Batch read APIs

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountBitmapQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountBitmapQueriesTest.java
@@ -207,9 +207,10 @@ public class DistinctCountBitmapQueriesTest extends BaseQueriesTest {
     while (groupKeyIterator.hasNext()) {
       numGroups++;
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      assertTrue(_values.contains(Integer.parseInt(groupKey._stringKey)));
+      Integer key = (Integer) groupKey._keys[0];
+      assertTrue(_values.contains(key));
       for (int i = 0; i < 6; i++) {
-        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForKey(groupKey, i)).size(), 1);
+        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId)).size(), 1);
       }
     }
     assertEquals(numGroups, _values.size());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
@@ -244,9 +244,10 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
     while (groupKeyIterator.hasNext()) {
       numGroups++;
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      assertTrue(_values.contains(Integer.parseInt(groupKey._stringKey)));
+      Integer key = (Integer) groupKey._keys[0];
+      assertTrue(_values.contains(key));
       for (int i = 0; i < 6; i++) {
-        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForKey(groupKey, i)).size(), 1);
+        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId)).size(), 1);
       }
     }
     assertEquals(numGroups, _values.size());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountThetaSketchQueriesTest.java
@@ -223,7 +223,7 @@ public class DistinctCountThetaSketchQueriesTest extends BaseQueriesTest {
         numGroups++;
         GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
         for (int i = 0; i < 6; i++) {
-          List<Sketch> sketches = (List<Sketch>) aggregationGroupByResult.getResultForKey(groupKey, i);
+          List<Sketch> sketches = (List<Sketch>) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId);
           assertEquals(sketches.size(), 1);
           Sketch sketch = sketches.get(0);
           if (i < 5) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -18,7 +18,14 @@
  */
 package org.apache.pinot.queries;
 
+import java.io.File;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -49,14 +56,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
 
 
 public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
@@ -249,11 +248,11 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
 
   private void matchGroupResult(AggregationGroupByResult result, String key, long count) {
     Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = result.getGroupKeyIterator();
-    Boolean found = false;
+    boolean found = false;
     while (groupKeyIterator.hasNext()) {
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      if (groupKey._stringKey.equals(key)) {
-        Assert.assertEquals(((Number) result.getResultForKey(groupKey, 0)).longValue(), count);
+      if (groupKey._keys[0].equals(key)) {
+        Assert.assertEquals(((Number) result.getResultForGroupId(0, groupKey._groupId)).longValue(), count);
         found = true;
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -129,9 +129,11 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 30000L, 0L, 90000L, 30000L);
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
-    Assert.assertEquals(firstGroupKey._stringKey, "");
-    Assert.assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).cardinality(), 21L);
-    Assert.assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).cardinality(), 691L);
+    Assert.assertEquals(firstGroupKey._keys[0], "");
+    Assert.assertEquals(
+        ((HyperLogLog) aggregationGroupByResult.getResultForGroupId(0, firstGroupKey._groupId)).cardinality(), 21L);
+    Assert.assertEquals(
+        ((HyperLogLog) aggregationGroupByResult.getResultForGroupId(1, firstGroupKey._groupId)).cardinality(), 691L);
 
     // Test inter segments base query
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(BASE_QUERY);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/IdSetQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/IdSetQueriesTest.java
@@ -274,29 +274,29 @@ public class IdSetQueriesTest extends BaseQueriesTest {
       AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
       assertNotNull(aggregationGroupByResult);
       Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      RoaringBitmapIdSet intIdSet = (RoaringBitmapIdSet) aggregationGroupByResult.getResultForKey(groupKey, 0);
+      int groupId = groupKeyIterator.next()._groupId;
+      RoaringBitmapIdSet intIdSet = (RoaringBitmapIdSet) aggregationGroupByResult.getResultForGroupId(0, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(intIdSet.contains(_values[i]));
       }
       Roaring64NavigableMapIdSet longIdSet =
-          (Roaring64NavigableMapIdSet) aggregationGroupByResult.getResultForKey(groupKey, 1);
+          (Roaring64NavigableMapIdSet) aggregationGroupByResult.getResultForGroupId(1, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(longIdSet.contains(_values[i] + (long) Integer.MAX_VALUE));
       }
-      BloomFilterIdSet floatIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 2);
+      BloomFilterIdSet floatIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForGroupId(2, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(floatIdSet.contains(_values[i] + 0.5f));
       }
-      BloomFilterIdSet doubleIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 3);
+      BloomFilterIdSet doubleIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForGroupId(3, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(doubleIdSet.contains(_values[i] + 0.25));
       }
-      BloomFilterIdSet stringIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 4);
+      BloomFilterIdSet stringIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForGroupId(4, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(stringIdSet.contains(Integer.toString(_values[i])));
       }
-      BloomFilterIdSet bytesIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForKey(groupKey, 5);
+      BloomFilterIdSet bytesIdSet = (BloomFilterIdSet) aggregationGroupByResult.getResultForGroupId(5, groupId);
       for (int i = 0; i < NUM_RECORDS; i++) {
         assertTrue(bytesIdSet.contains(Integer.toString(_values[i]).getBytes()));
       }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/PercentileTDigestQueriesTest.java
@@ -174,7 +174,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     assertTDigest((TDigest) aggregationResult.get(1), doubleList0);
     assertTDigest((TDigest) aggregationResult.get(2), doubleList0);
 
-    DoubleList doubleList3 = (DoubleList)aggregationResult.get(3);
+    DoubleList doubleList3 = (DoubleList) aggregationResult.get(3);
     Collections.sort(doubleList3);
     Assert.assertEquals(doubleList3, doubleList0);
     assertTDigest((TDigest) aggregationResult.get(4), doubleList0);
@@ -211,17 +211,17 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
     Assert.assertNotNull(groupByResult);
     Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
     while (groupKeyIterator.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      DoubleList doubleList0 = (DoubleList) groupByResult.getResultForKey(groupKey, 0);
+      int groupId = groupKeyIterator.next()._groupId;
+      DoubleList doubleList0 = (DoubleList) groupByResult.getResultForGroupId(0, groupId);
       Collections.sort(doubleList0);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 1), doubleList0);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 2), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForGroupId(1, groupId), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForGroupId(2, groupId), doubleList0);
 
-      DoubleList doubleList3 = (DoubleList) groupByResult.getResultForKey(groupKey, 3);
+      DoubleList doubleList3 = (DoubleList) groupByResult.getResultForGroupId(3, groupId);
       Collections.sort(doubleList3);
       Assert.assertEquals(doubleList3, doubleList0);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 4), doubleList0);
-      assertTDigest((TDigest) groupByResult.getResultForKey(groupKey, 5), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForGroupId(4, groupId), doubleList0);
+      assertTDigest((TDigest) groupByResult.getResultForGroupId(5, groupId), doubleList0);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -64,9 +64,9 @@ public class QueriesTestUtils {
   public static void testInnerSegmentAggregationGroupByResult(AggregationGroupByResult aggregationGroupByResult,
       String expectedGroupKey, long expectedCountResult, long expectedSumResult, int expectedMaxResult,
       int expectedMinResult, long expectedAvgResultSum, long expectedAvgResultCount) {
-    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+    Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator = aggregationGroupByResult.getStringGroupKeyIterator();
     while (groupKeyIterator.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
       if (groupKey._stringKey.equals(expectedGroupKey)) {
         Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(groupKey, 0)).longValue(),
             expectedCountResult);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentPartitionedDistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentPartitionedDistinctCountQueriesTest.java
@@ -212,9 +212,10 @@ public class SegmentPartitionedDistinctCountQueriesTest extends BaseQueriesTest 
     while (groupKeyIterator.hasNext()) {
       numGroups++;
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      assertTrue(_values.contains(Integer.parseInt(groupKey._stringKey)));
+      Integer key = (Integer) groupKey._keys[0];
+      assertTrue(_values.contains(key));
       for (int i = 0; i < 6; i++) {
-        assertEquals((long) aggregationGroupByResult.getResultForKey(groupKey, i), 1);
+        assertEquals((long) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId), 1);
       }
     }
     assertEquals(numGroups, _values.size());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SerializedBytesQueriesTest.java
@@ -391,9 +391,9 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
     AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(groupByResult);
 
-    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+    Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator = groupByResult.getStringGroupKeyIterator();
     while (groupKeyIterator.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
       int groupId = Integer.parseInt(groupKey._stringKey.substring(1));
 
       // Avg
@@ -627,9 +627,9 @@ public class SerializedBytesQueriesTest extends BaseQueriesTest {
       expectedTDigest.add(_tDigests[i]);
     }
 
-    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+    Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator = groupByResult.getStringGroupKeyIterator();
     while (groupKeyIterator.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
 
       // Avg
       AvgPair avgPair = (AvgPair) groupByResult.getResultForKey(groupKey, 0);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/StUnionQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/StUnionQueriesTest.java
@@ -218,7 +218,8 @@ public class StUnionQueriesTest extends BaseQueriesTest {
     while (groupKeyIterator.hasNext()) {
       numGroups++;
       GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-      assertTrue(_values.containsKey(Integer.parseInt(groupKey._stringKey)));
+      Integer key = (Integer) groupKey._keys[0];
+      assertTrue(_values.containsKey(key));
     }
     assertEquals(numGroups, _values.size());
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -214,7 +214,8 @@ public class TransformQueriesTest extends BaseQueriesTest {
     IntermediateResultsBlock resultsBlock = aggregationGroupByOperator.nextBlock();
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(aggregationGroupByResult);
-    List<GroupKeyGenerator.GroupKey> groupKeys = ImmutableList.copyOf(aggregationGroupByResult.getGroupKeyIterator());
+    List<GroupKeyGenerator.StringGroupKey> groupKeys =
+        ImmutableList.copyOf(aggregationGroupByResult.getStringGroupKeyIterator());
     assertEquals(groupKeys.size(), 1);
     assertEquals(groupKeys.get(0)._stringKey, expectedStringKey);
     Object resultForKey = aggregationGroupByResult.getResultForKey(groupKeys.get(0), 0);

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -176,7 +176,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     dictionaryBasedGroupKeyGenerator.generateKeysForBlock(_transformBlock, SV_GROUP_KEY_BUFFER);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
     compareSingleValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), 2);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), 2);
   }
 
   @Test
@@ -197,7 +197,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     dictionaryBasedGroupKeyGenerator.generateKeysForBlock(_transformBlock, SV_GROUP_KEY_BUFFER);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 2, _errorMessage);
     compareSingleValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), 2);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), 2);
   }
 
   @Test
@@ -218,7 +218,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     dictionaryBasedGroupKeyGenerator.generateKeysForBlock(_transformBlock, SV_GROUP_KEY_BUFFER);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 2, _errorMessage);
     compareSingleValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), 2);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), 2);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     dictionaryBasedGroupKeyGenerator.generateKeysForBlock(_transformBlock, SV_GROUP_KEY_BUFFER);
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 2, _errorMessage);
     compareSingleValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), 2);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), 2);
   }
 
   /**
@@ -274,7 +274,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     int numUniqueKeys = MV_GROUP_KEY_BUFFER[0].length + MV_GROUP_KEY_BUFFER[1].length;
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound, _errorMessage);
     compareMultiValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numUniqueKeys);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), numUniqueKeys);
   }
 
   @Test
@@ -296,7 +296,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     int numUniqueKeys = MV_GROUP_KEY_BUFFER[0].length + MV_GROUP_KEY_BUFFER[1].length;
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), numUniqueKeys, _errorMessage);
     compareMultiValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numUniqueKeys);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), numUniqueKeys);
   }
 
   @Test
@@ -318,7 +318,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     int numUniqueKeys = MV_GROUP_KEY_BUFFER[0].length + MV_GROUP_KEY_BUFFER[1].length;
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), numUniqueKeys, _errorMessage);
     compareMultiValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numUniqueKeys);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), numUniqueKeys);
   }
 
   @Test
@@ -340,7 +340,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     int numUniqueKeys = MV_GROUP_KEY_BUFFER[0].length + MV_GROUP_KEY_BUFFER[1].length;
     assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), numUniqueKeys, _errorMessage);
     compareMultiValueBuffer();
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numUniqueKeys);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), numUniqueKeys);
   }
 
   @Test
@@ -374,7 +374,7 @@ public class DictionaryBasedGroupKeyGeneratorTest {
       assertEquals(MV_GROUP_KEY_BUFFER[i], MV_GROUP_KEY_BUFFER[0], _errorMessage);
       assertEquals(MV_GROUP_KEY_BUFFER[i + 1], MV_GROUP_KEY_BUFFER[1], _errorMessage);
     }
-    testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numGroupsLimit);
+    testGetStringGroupKeys(dictionaryBasedGroupKeyGenerator.getStringGroupKeys(), numGroupsLimit);
   }
 
   private static ExpressionContext[] getExpressions(String[] columns) {
@@ -401,19 +401,19 @@ public class DictionaryBasedGroupKeyGeneratorTest {
   }
 
   /**
-   * Helper method to test the group key iterator returned by getUniqueGroupKeys().
+   * Helper method to test the group key iterator returned by getStringGroupKeys().
    *
    * @param groupKeyIterator group key iterator.
    * @param numUniqueKeys number of unique keys.
    */
-  private void testGetUniqueGroupKeys(Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator, int numUniqueKeys) {
+  private void testGetStringGroupKeys(Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator, int numUniqueKeys) {
     int count = 0;
     Set<Integer> idSet = new HashSet<>();
     Set<String> groupKeySet = new HashSet<>();
 
     while (groupKeyIterator.hasNext()) {
       count++;
-      GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+      GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
       idSet.add(groupKey._groupId);
       groupKeySet.add(groupKey._stringKey);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -218,12 +218,9 @@ public class NoDictionaryGroupKeyGeneratorTest {
         "Number of group keys mis-match.");
 
     // Assert all group key values are as expected
-    Iterator<GroupKeyGenerator.GroupKey> uniqueGroupKeys = groupKeyGenerator.getUniqueGroupKeys();
-    while (uniqueGroupKeys.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = uniqueGroupKeys.next();
-      if (!expectedGroupKeys.contains(groupKey._stringKey)) {
-        System.out.println(expectedGroupKeys);
-      }
+    Iterator<GroupKeyGenerator.StringGroupKey> stringGroupKeys = groupKeyGenerator.getStringGroupKeys();
+    while (stringGroupKeys.hasNext()) {
+      GroupKeyGenerator.StringGroupKey groupKey = stringGroupKeys.next();
       assertTrue(expectedGroupKeys.contains(groupKey._stringKey), "Unexpected group key: " + groupKey._stringKey);
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/StringGroupKeyTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/groupby/StringGroupKeyTest.java
@@ -23,11 +23,11 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class GroupKeyTest {
+public class StringGroupKeyTest {
 
   @Test
   public void testGetKeys() {
-    GroupKeyGenerator.GroupKey groupKey = new GroupKeyGenerator.GroupKey();
+    GroupKeyGenerator.StringGroupKey groupKey = new GroupKeyGenerator.StringGroupKey();
     groupKey._stringKey = "foo\0bar\0";
     String[] keys = groupKey.getKeys();
     Assert.assertEquals(keys.length, 3);


### PR DESCRIPTION
Currently in the `GroupKeyGenerator.GroupKey` we serialized the keys into a string key, then deserialize the value back within `GroupByOrderByCombineOperator`. This PR modifies the GroupKey to directly store the keys without serializing them into a string to save the overhead of ser/de the group keys, and also reduce the garbage created.
Rename the existing `GroupKey` to `StringGroupKey` to keep the existing behavior of `GroupByCombineOperator` for PQL queries.