### PR TITLE
Always return a response from query execution.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.Utils;
 public enum ServerMeter implements AbstractMetrics.Meter {
   QUERIES("queries", true),
   UNCAUGHT_EXCEPTIONS("exceptions", true),
-  REQUEST_FETCH_EXCEPTIONS("exceptions", true),
   REQUEST_DESERIALIZATION_EXCEPTIONS("exceptions", true),
   RESPONSE_SERIALIZATION_EXCEPTIONS("exceptions", true),
   SCHEDULING_TIMEOUT_EXCEPTIONS("exceptions", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -306,6 +306,10 @@ public abstract class QueryScheduler {
   protected ListenableFuture<byte[]> immediateErrorResponse(ServerQueryRequest queryRequest,
       ProcessingException error) {
     DataTable result = new DataTableImplV2();
+
+    Map<String, String> dataTableMetadata = result.getMetadata();
+    dataTableMetadata.put(DataTable.REQUEST_ID_METADATA_KEY, Long.toString(queryRequest.getRequestId()));
+
     result.addException(error);
     return Futures.immediateFuture(serializeDataTable(queryRequest, result));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -76,7 +76,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
     byte[] requestBytes = null;
 
     try {
-      // put all inside try block to catch all exceptions.
+      // Put all code inside try block to catch all exceptions.
       int requestSize = msg.readableBytes();
 
       instanceRequest = new InstanceRequest();
@@ -87,7 +87,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
       _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
       _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_RECEIVED, requestSize);
 
-      // parse instance request into ServerQueryRequest.
+      // Parse instance request into ServerQueryRequest.
       msg.readBytes(requestBytes);
       _deserializer.deserialize(instanceRequest, requestBytes);
       queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics, queryArrivalTimeMs);
@@ -99,11 +99,11 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
           createCallback(ctx, queryArrivalTimeMs, instanceRequest, queryRequest), MoreExecutors.directExecutor());
     } catch (Exception e) {
       if (e instanceof TException) {
-        // deserialization exception
+        // Deserialization exception
         _serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
       }
 
-      // send error response
+      // Send error response
       String hexString = requestBytes != null ? BytesUtils.toHexString(requestBytes) : "";
       long reqestId = instanceRequest != null ? instanceRequest.getRequestId() : 0;
       LOGGER.error("Exception while processing instance request: {}", hexString, e);
@@ -159,7 +159,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
     } catch (Exception exception) {
       LOGGER.error("Exception while sending query processing error to Broker.", exception);
     } finally {
-      // log query processing exception
+      // Log query processing exception
       LOGGER.error("Query processing error: ", e);
       _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -25,16 +25,20 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.request.InstanceRequest;
-import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.datatable.DataTableImplV2;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.slf4j.Logger;
@@ -62,65 +66,99 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
-    long queryArrivalTimeMs = System.currentTimeMillis();
+    final long queryArrivalTimeMs = System.currentTimeMillis();
+    final int requestSize = msg.readableBytes();
     _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
-    int requestSize = msg.readableBytes();
     _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_RECEIVED, requestSize);
-    byte[] requestBytes = new byte[requestSize];
-    msg.readBytes(requestBytes);
 
     InstanceRequest instanceRequest = new InstanceRequest();
+    ServerQueryRequest queryRequest;
+    byte[] requestBytes = new byte[requestSize];
+
     try {
+      // parse netty request into a ServerQueryRequest object for execution.
+      msg.readBytes(requestBytes);
       _deserializer.deserialize(instanceRequest, requestBytes);
+      queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics, queryArrivalTimeMs);
+      queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
+          .stopAndRecord();
     } catch (Exception e) {
-      LOGGER
-          .error("Caught exception while deserializing the instance request: {}", BytesUtils.toHexString(requestBytes),
-              e);
-      _serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
+      LOGGER.error("Caught exception while creating query request: {}", BytesUtils.toHexString(requestBytes), e);
+      sendErrorResponse(ctx, instanceRequest.getRequestId(), queryArrivalTimeMs, new DataTableImplV2(), e);
       return;
     }
 
-    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics, queryArrivalTimeMs);
-    queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
-        .stopAndRecord();
-
-    // NOTE: executor must be provided as addCallback(future, callback) is removed from newer guava version
+    // Submit query for execution and register callback for execution results.
     Futures.addCallback(_queryScheduler.submit(queryRequest), new FutureCallback<byte[]>() {
       @Override
       public void onSuccess(@Nullable byte[] responseBytes) {
-        // NOTE: response bytes can be null if data table serialization throws exception
         if (responseBytes != null) {
-          long sendResponseStartTimeMs = System.currentTimeMillis();
-          int queryProcessingTimeMs = (int) (sendResponseStartTimeMs - queryArrivalTimeMs);
-          ctx.writeAndFlush(Unpooled.wrappedBuffer(responseBytes)).addListener(f -> {
-            long sendResponseEndTimeMs = System.currentTimeMillis();
-            int sendResponseLatencyMs = (int) (sendResponseEndTimeMs - sendResponseStartTimeMs);
-            _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_RESPONSES_SENT, 1);
-            _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_SENT, responseBytes.length);
-            _serverMetrics.addTimedValue(ServerTimer.NETTY_CONNECTION_SEND_RESPONSE_LATENCY, sendResponseLatencyMs,
-                TimeUnit.MILLISECONDS);
-
-            int totalQueryTimeMs = (int) (sendResponseEndTimeMs - queryArrivalTimeMs);
-            if (totalQueryTimeMs > SLOW_QUERY_LATENCY_THRESHOLD_MS) {
-              LOGGER.info(
-                  "Slow query: request handler processing time: {}, send response latency: {}, total time to handle request: {}",
-                  queryProcessingTimeMs, sendResponseLatencyMs, totalQueryTimeMs);
-            }
-          });
+          // We have a query response (either serialized query results or serialized error message).
+          sendResponse(ctx, queryArrivalTimeMs, responseBytes);
+        } else {
+          // response should never be null; otherwise, it will cause broker to wait until timeout.
+          sendErrorResponse(ctx, queryRequest.getRequestId(), queryArrivalTimeMs, new DataTableImplV2(),
+              new Exception("Null query response."));
         }
       }
 
       @Override
       public void onFailure(Throwable t) {
+        // Query execution failed.
         LOGGER.error("Caught exception while processing instance request", t);
-        _serverMetrics.addMeteredGlobalValue(ServerMeter.UNCAUGHT_EXCEPTIONS, 1);
+        sendErrorResponse(ctx, instanceRequest.getRequestId(), queryArrivalTimeMs, new DataTableImplV2(),
+            new Exception(t));
       }
     }, MoreExecutors.directExecutor());
   }
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    // This will happen only if there is an unexpected "Throwable" event in channelRead0 function
+    // which has not been caught and handled yet.
     LOGGER.error("Caught exception while fetching instance request", cause);
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_FETCH_EXCEPTIONS, 1);
+    sendErrorResponse(ctx, 0, System.currentTimeMillis(), new DataTableImplV2(), new Exception(cause));
+  }
+
+  /**
+   * Send an exception back to broker as response to the query request.
+   */
+  private void sendErrorResponse(ChannelHandlerContext ctx, long requestId, long queryArrivalTimeMs,
+      DataTable dataTable, Exception e) {
+    try {
+      Map<String, String> dataTableMetadata = dataTable.getMetadata();
+      dataTableMetadata.put(DataTable.REQUEST_ID_METADATA_KEY, Long.toString(requestId));
+
+      dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+      byte[] serializedDataTable = dataTable.toBytes();
+      sendResponse(ctx, queryArrivalTimeMs, serializedDataTable);
+
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
+    } catch (Exception ex2) {
+      // ignore this exception since we are already dealing with a higher level exceptions.
+    }
+  }
+
+  /**
+   * Send a response (either query results or exception) back to broker as response to the query request.
+   */
+  private void sendResponse(ChannelHandlerContext ctx, long queryArrivalTimeMs, byte[] serializedDataTable) {
+    long sendResponseStartTimeMs = System.currentTimeMillis();
+    int queryProcessingTimeMs = (int) (sendResponseStartTimeMs - queryArrivalTimeMs);
+    ctx.writeAndFlush(Unpooled.wrappedBuffer(serializedDataTable)).addListener(f -> {
+      long sendResponseEndTimeMs = System.currentTimeMillis();
+      int sendResponseLatencyMs = (int) (sendResponseEndTimeMs - sendResponseStartTimeMs);
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_RESPONSES_SENT, 1);
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_SENT, serializedDataTable.length);
+      _serverMetrics.addTimedValue(ServerTimer.NETTY_CONNECTION_SEND_RESPONSE_LATENCY, sendResponseLatencyMs,
+          TimeUnit.MILLISECONDS);
+
+      int totalQueryTimeMs = (int) (sendResponseEndTimeMs - queryArrivalTimeMs);
+      if (totalQueryTimeMs > SLOW_QUERY_LATENCY_THRESHOLD_MS) {
+        LOGGER.info(
+            "Slow query: request handler processing time: {}, send response latency: {}, total time to handle request: {}",
+            queryProcessingTimeMs, sendResponseLatencyMs, totalQueryTimeMs);
+      }
+    });
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -25,7 +25,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.util.AttributeKey;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -53,7 +52,6 @@ import org.slf4j.LoggerFactory;
 public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf> {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceRequestHandler.class);
 
-  private final AttributeKey<Integer> auth = AttributeKey.valueOf("auth");
   // TODO: make it configurable
   private static final int SLOW_QUERY_LATENCY_THRESHOLD_MS = 100;
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.AssertTrue;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.exception.QueryException;
@@ -436,6 +437,33 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         throw new RuntimeException(e);
       }
     }, 600_000L, "Failed to generate bloom filter");
+  }
+
+  /** Check if server returns error response quickly without timing out Broker. */
+  @Test
+  public void testServerErrorWithBrokerTimeout() {
+    try {
+      // Set query timeout
+      long queryTimeout = 5000;
+      TableConfig tableConfig = getOfflineTableConfig();
+      tableConfig.setQueryConfig(new QueryConfig(queryTimeout));
+      updateTableConfig(tableConfig);
+
+      long startTime = System.currentTimeMillis();
+      // The query below will fail execution due to use of double quotes around value in IN clause.
+      JsonNode queryResponse = postSqlQuery("SELECT count(*) FROM mytable WHERE Dest IN (\"DFW\")");
+      String result = queryResponse.toPrettyString();
+
+      assertTrue(System.currentTimeMillis() - startTime < queryTimeout);
+      assertTrue(queryResponse.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
+
+      // Remove timeout
+      tableConfig.setQueryConfig(null);
+      updateTableConfig(tableConfig);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -441,8 +441,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
   /** Check if server returns error response quickly without timing out Broker. */
   @Test
-  public void testServerErrorWithBrokerTimeout() {
-    try {
+  public void testServerErrorWithBrokerTimeout()
+    throws Exception {
       // Set query timeout
       long queryTimeout = 5000;
       TableConfig tableConfig = getOfflineTableConfig();
@@ -460,10 +460,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       // Remove timeout
       tableConfig.setQueryConfig(null);
       updateTableConfig(tableConfig);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
   }
 
   @Test


### PR DESCRIPTION
## Description
Server does not return a response for some of the queries that fail. As a result broker will wait until it times out. This causes un-necessary latency for queries on the Broker side. One example of such a query is:

`select playerID from baseballStats where playerID in ("aardsda01")`

This PR fixes the issue by always returning a response back to the Broker irrespective of whether query succeeds or fails. Note that UNCAUGHT_EXCEPTIONS and REQUEST_FETCH_EXCEPTION metrics are no longer being emitted.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
