### PR TITLE
Default to use local directory sequence id for segment name generation

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.common;
+
+import java.io.Serializable;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+
+
+public class SegmentGenerationJobUtils implements Serializable {
+
+  /**
+   * Always use local directory sequence id unless explicitly configured.
+   *
+   */
+  public static boolean useLocalDirectorySequenceId(SegmentNameGeneratorSpec spec) {
+    if (spec == null || spec.getConfigs() == null) {
+      return true;
+    }
+    String useGlobalDirectorySequenceId =
+        spec.getConfigs().get(SegmentGenerationTaskRunner.USE_GLOBAL_DIRECTORY_SEQUENCE_ID);
+    if (useGlobalDirectorySequenceId == null) {
+      String useLocalDirectorySequenceId =
+          spec.getConfigs().get(SegmentGenerationTaskRunner.DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID);
+      if (useLocalDirectorySequenceId != null) {
+        return Boolean.parseBoolean(useLocalDirectorySequenceId);
+      }
+    }
+    return !Boolean.parseBoolean(useGlobalDirectorySequenceId);
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
@@ -25,12 +25,12 @@ import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
 public class SegmentGenerationJobUtils implements Serializable {
 
   /**
-   * Always use local directory sequence id unless explicitly configured.
+   * Always use local directory sequence id unless explicitly config: "use.global.directory.sequence.id".
    *
    */
-  public static boolean useLocalDirectorySequenceId(SegmentNameGeneratorSpec spec) {
+  public static boolean useGlobalDirectorySequenceId(SegmentNameGeneratorSpec spec) {
     if (spec == null || spec.getConfigs() == null) {
-      return true;
+      return false;
     }
     String useGlobalDirectorySequenceId =
         spec.getConfigs().get(SegmentGenerationTaskRunner.USE_GLOBAL_DIRECTORY_SEQUENCE_ID);
@@ -38,9 +38,9 @@ public class SegmentGenerationJobUtils implements Serializable {
       String useLocalDirectorySequenceId =
           spec.getConfigs().get(SegmentGenerationTaskRunner.DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID);
       if (useLocalDirectorySequenceId != null) {
-        return Boolean.parseBoolean(useLocalDirectorySequenceId);
+        return !Boolean.parseBoolean(useLocalDirectorySequenceId);
       }
     }
-    return !Boolean.parseBoolean(useGlobalDirectorySequenceId);
+    return Boolean.parseBoolean(useGlobalDirectorySequenceId);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -60,7 +60,9 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String EXCLUDE_SEQUENCE_ID = "exclude.sequence.id";
 
   // Assign sequence ids to input files based at each local directory level
-  public static final String LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
+  @Deprecated
+  public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
+  public static final String USE_GLOBAL_DIRECTORY_SEQUENCE_ID = "use.global.directory.sequence.id";
 
   private SegmentGenerationTaskSpec _taskSpec;
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
@@ -29,23 +29,23 @@ import org.testng.annotations.Test;
 public class SegmentGenerationJobUtilsTest {
 
   @Test
-  public void testUseLocalDirectorySequenceId() {
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(null));
+  public void testUseGlobalDirectorySequenceId() {
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(null));
     SegmentNameGeneratorSpec spec = new SegmentNameGeneratorSpec();
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(new HashMap<>());
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "false"));
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "FALSE"));
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "True"));
-    Assert.assertFalse(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertTrue(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "true"));
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "TRUE"));
-    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
     spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "False"));
-    Assert.assertFalse(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    Assert.assertTrue(SegmentGenerationJobUtils.useGlobalDirectorySequenceId(spec));
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.plugin.ingestion.batch.common;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SegmentGenerationJobUtilsTest {
+
+  @Test
+  public void testUseLocalDirectorySequenceId() {
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(null));
+    SegmentNameGeneratorSpec spec = new SegmentNameGeneratorSpec();
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(new HashMap<>());
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "false"));
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "FALSE"));
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("use.global.directory.sequence.id", "True"));
+    Assert.assertFalse(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "true"));
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "TRUE"));
+    Assert.assertTrue(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+    spec.setConfigs(ImmutableMap.of("local.directory.sequence.id", "False"));
+    Assert.assertFalse(SegmentGenerationJobUtils.useLocalDirectorySequenceId(spec));
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -219,7 +219,7 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
       throw new RuntimeException(errorMessage);
     } else {
       LOGGER.info("Creating segments with data files: {}", filteredFiles);
-      if (SegmentGenerationJobUtils.useLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
+      if (!SegmentGenerationJobUtils.useGlobalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
         Map<String, List<String>> localDirIndex = new HashMap<>();
         for (String filteredFile : filteredFiles) {
           java.nio.file.Path filteredParentPath = Paths.get(filteredFile).getParent();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -55,7 +55,6 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationTaskSpec;
-import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.spark.SparkContext;
@@ -210,7 +209,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       }
 
       List<String> pathAndIdxList = new ArrayList<>();
-      if (SegmentGenerationJobUtils.useLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
+      if (!SegmentGenerationJobUtils.useGlobalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
         Map<String, List<String>> localDirIndex = new HashMap<>();
         for (String filteredFile : filteredFiles) {
           Path filteredParentPath = Paths.get(filteredFile).getParent();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.LOCAL_DIRECTORY_SEQUENCE_ID;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.getFileName;
@@ -43,6 +42,7 @@ import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationJobUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -210,7 +210,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       }
 
       List<String> pathAndIdxList = new ArrayList<>();
-      if (getLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
+      if (SegmentGenerationJobUtils.useLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
         Map<String, List<String>> localDirIndex = new HashMap<>();
         for (String filteredFile : filteredFiles) {
           Path filteredParentPath = Paths.get(filteredFile).getParent();
@@ -349,13 +349,6 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
         outputDirFS.delete(stagingDirURI, true);
       }
     }
-  }
-
-  private static boolean getLocalDirectorySequenceId(SegmentNameGeneratorSpec spec) {
-    if (spec == null || spec.getConfigs() == null) {
-      return false;
-    }
-    return Boolean.parseBoolean(spec.getConfigs().get(LOCAL_DIRECTORY_SEQUENCE_ID));
   }
 
   protected void addDepsJarToDistributedCache(JavaSparkContext sparkContext, String depsJarDir)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -197,7 +197,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
       int numInputFiles = filteredFiles.size();
       _segmentCreationTaskCountDownLatch = new CountDownLatch(numInputFiles);
 
-      if (SegmentGenerationJobUtils.useLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
+      if (!SegmentGenerationJobUtils.useGlobalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
         Map<String, List<String>> localDirIndex = new HashMap<>();
         for (String filteredFile : filteredFiles) {
           java.nio.file.Path filteredParentPath = Paths.get(filteredFile).getParent();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -19,22 +19,27 @@
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.utils.TarGzCompressionUtils;
-import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationJobUtils;
+import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -58,6 +63,13 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
   private SegmentGenerationJobSpec _spec;
   private ExecutorService _executorService;
+  private PinotFS _inputDirFS;
+  private PinotFS _outputDirFS;
+  private URI _inputDirURI;
+  private URI _outputDirURI;
+  private CountDownLatch _segmentCreationTaskCountDownLatch;
+  private Schema _schema;
+  private TableConfig _tableConfig;
 
   public SegmentGenerationJobRunner() {
   }
@@ -69,12 +81,38 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
   @Override
   public void init(SegmentGenerationJobSpec spec) {
     _spec = spec;
+
+    //Get pinotFS for input
     if (_spec.getInputDirURI() == null) {
       throw new RuntimeException("Missing property 'inputDirURI' in 'jobSpec' file");
     }
+    try {
+      _inputDirURI = SegmentGenerationUtils.getDirectoryURI(_spec.getInputDirURI());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Invalid property: 'inputDirURI'", e);
+    }
+    _inputDirFS = PinotFSFactory.create(_inputDirURI.getScheme());
+
+    //Get outputFS for writing output pinot segments
     if (_spec.getOutputDirURI() == null) {
       throw new RuntimeException("Missing property 'outputDirURI' in 'jobSpec' file");
     }
+    try {
+      _outputDirURI = SegmentGenerationUtils.getDirectoryURI(_spec.getOutputDirURI());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Invalid property: 'outputDirURI'", e);
+    }
+    _outputDirFS = PinotFSFactory.create(_outputDirURI.getScheme());
+    try {
+      if (!_outputDirFS.exists(_outputDirURI)) {
+        _outputDirFS.mkdir(_outputDirURI);
+      } else if (!_outputDirFS.isDirectory(_outputDirURI)) {
+        throw new RuntimeException(String.format("Output Directory URI: %s is not a directory", _outputDirURI));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to validate output 'outputDirURI': " + _outputDirURI, e);
+    }
+
     if (_spec.getRecordReaderSpec() == null) {
       throw new RuntimeException("Missing property 'recordReaderSpec' in 'jobSpec' file");
     }
@@ -84,6 +122,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     if (_spec.getTableSpec().getTableName() == null) {
       throw new RuntimeException("Missing property 'tableName' in 'tableSpec'");
     }
+
+    //Read Schema
     if (_spec.getTableSpec().getSchemaURI() == null) {
       if (_spec.getPinotClusterSpecs() == null || _spec.getPinotClusterSpecs().length == 0) {
         throw new RuntimeException("Missing property 'schemaURI' in 'tableSpec'");
@@ -93,6 +133,9 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateSchemaURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setSchemaURI(schemaURI);
     }
+    _schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI());
+
+    // Read Table config
     if (_spec.getTableSpec().getTableConfigURI() == null) {
       if (_spec.getPinotClusterSpecs() == null || _spec.getPinotClusterSpecs().length == 0) {
         throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
@@ -102,6 +145,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
+    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI());
+
     final int jobParallelism = _spec.getSegmentCreationJobParallelism();
     int numThreads = JobUtils.getNumThreads(jobParallelism);
     LOGGER.info("Creating an executor service with {} threads(Job parallelism: {}, available cores: {}.)", numThreads,
@@ -118,17 +163,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
       PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
-    //Get pinotFS for input
-    final URI inputDirURI = SegmentGenerationUtils.getDirectoryURI(_spec.getInputDirURI());
-    PinotFS inputDirFS = PinotFSFactory.create(inputDirURI.getScheme());
-
-    //Get outputFS for writing output pinot segments
-    final URI outputDirURI = SegmentGenerationUtils.getDirectoryURI(_spec.getOutputDirURI());
-    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
-    outputDirFS.mkdir(outputDirURI);
-
     //Get list of files to process
-    String[] files = inputDirFS.listFiles(inputDirURI, true);
+    String[] files = _inputDirFS.listFiles(_inputDirURI, true);
 
     //TODO: sort input files based on creation time
     List<String> filteredFiles = new ArrayList<>();
@@ -152,86 +188,103 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           continue;
         }
       }
-      if (!inputDirFS.isDirectory(new URI(file))) {
+      if (!_inputDirFS.isDirectory(new URI(file))) {
         filteredFiles.add(file);
       }
     }
     File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
     try {
-      //create localTempDir for input and output
-      File localInputTempDir = new File(localTempDir, "input");
-      FileUtils.forceMkdir(localInputTempDir);
-      File localOutputTempDir = new File(localTempDir, "output");
-      FileUtils.forceMkdir(localOutputTempDir);
-
-      //Read TableConfig, Schema
-      Schema schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI());
-      TableConfig tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI());
-
       int numInputFiles = filteredFiles.size();
-      CountDownLatch segmentCreationTaskCountDownLatch = new CountDownLatch(numInputFiles);
-      //iterate on the file list, for each
-      for (int i = 0; i < numInputFiles; i++) {
-        final URI inputFileURI = SegmentGenerationUtils.getFileURI(filteredFiles.get(i), inputDirURI);
+      _segmentCreationTaskCountDownLatch = new CountDownLatch(numInputFiles);
 
-        //copy input path to local
-        File localInputDataFile = new File(localInputTempDir, new File(inputFileURI.getPath()).getName());
-        inputDirFS.copyToLocalFile(inputFileURI, localInputDataFile);
-
-        //create task spec
-        SegmentGenerationTaskSpec taskSpec = new SegmentGenerationTaskSpec();
-        taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
-        taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
-        taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
-        taskSpec.setSchema(schema);
-        taskSpec.setTableConfig(tableConfig);
-        taskSpec.setSequenceId(i);
-        taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
-        taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
-
-        LOGGER.info("Submitting one Segment Generation Task for {}", inputFileURI);
-        _executorService.submit(() -> {
-          File localSegmentDir = null;
-          File localSegmentTarFile = null;
-          try {
-            //invoke segmentGenerationTask
-            SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
-            String segmentName = taskRunner.run();
-            // Tar segment directory to compress file
-            localSegmentDir = new File(localOutputTempDir, segmentName);
-            String segmentTarFileName = URLEncoder.encode(segmentName + Constants.TAR_GZ_FILE_EXT, "UTF-8");
-            localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
-            LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
-            TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
-            long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
-            long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
-            LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,
-                DataSizeUtils.fromBytes(uncompressedSegmentSize), DataSizeUtils.fromBytes(compressedSegmentSize));
-            //move segment to output PinotFS
-            URI outputSegmentTarURI =
-                SegmentGenerationUtils.getRelativeOutputPath(inputDirURI, inputFileURI, outputDirURI)
-                    .resolve(segmentTarFileName);
-            if (!_spec.isOverwriteOutput() && outputDirFS.exists(outputSegmentTarURI)) {
-              LOGGER
-                  .warn("Not overwrite existing output segment tar file: {}", outputDirFS.exists(outputSegmentTarURI));
-            } else {
-              outputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
-            }
-          } catch (Exception e) {
-            LOGGER.error("Failed to generate Pinot segment for file - {}", inputFileURI, e);
-          } finally {
-            segmentCreationTaskCountDownLatch.countDown();
-            FileUtils.deleteQuietly(localSegmentDir);
-            FileUtils.deleteQuietly(localSegmentTarFile);
-            FileUtils.deleteQuietly(localInputDataFile);
+      if (SegmentGenerationJobUtils.useLocalDirectorySequenceId(_spec.getSegmentNameGeneratorSpec())) {
+        Map<String, List<String>> localDirIndex = new HashMap<>();
+        for (String filteredFile : filteredFiles) {
+          java.nio.file.Path filteredParentPath = Paths.get(filteredFile).getParent();
+          localDirIndex.computeIfAbsent(filteredParentPath.toString(), k -> new ArrayList<>()).add(filteredFile);
+        }
+        for (String parentPath : localDirIndex.keySet()) {
+          List<String> siblingFiles = localDirIndex.get(parentPath);
+          Collections.sort(siblingFiles);
+          for (int i = 0; i < siblingFiles.size(); i++) {
+            URI inputFileURI = SegmentGenerationUtils
+                .getFileURI(siblingFiles.get(i), SegmentGenerationUtils.getDirectoryURI(parentPath));
+            submitSegmentGenTask(localTempDir, inputFileURI, i);
           }
-        });
+        }
+      } else {
+        //iterate on the file list, for each
+        for (int i = 0; i < numInputFiles; i++) {
+          final URI inputFileURI = SegmentGenerationUtils.getFileURI(filteredFiles.get(i), _inputDirURI);
+          submitSegmentGenTask(localTempDir, inputFileURI, i);
+        }
       }
-      segmentCreationTaskCountDownLatch.await();
+      _segmentCreationTaskCountDownLatch.await();
     } finally {
       //clean up
       FileUtils.deleteQuietly(localTempDir);
       _executorService.shutdown();
     }
+  }
+
+  private void submitSegmentGenTask(File localTempDir, URI inputFileURI, int seqId)
+      throws Exception {
+    //create localTempDir for input and output
+    File localInputTempDir = new File(localTempDir, "input");
+    FileUtils.forceMkdir(localInputTempDir);
+    File localOutputTempDir = new File(localTempDir, "output");
+    FileUtils.forceMkdir(localOutputTempDir);
+
+    //copy input path to local
+    File localInputDataFile = new File(localInputTempDir, new File(inputFileURI.getPath()).getName());
+    _inputDirFS.copyToLocalFile(inputFileURI, localInputDataFile);
+
+    //create task spec
+    SegmentGenerationTaskSpec taskSpec = new SegmentGenerationTaskSpec();
+    taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
+    taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
+    taskSpec.setSchema(_schema);
+    taskSpec.setTableConfig(_tableConfig);
+    taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
+    taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
+    taskSpec.setSequenceId(seqId);
+    taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
+
+    LOGGER.info("Submitting one Segment Generation Task for {}", inputFileURI);
+    _executorService.submit(() -> {
+      File localSegmentDir = null;
+      File localSegmentTarFile = null;
+      try {
+        //invoke segmentGenerationTask
+        SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
+        String segmentName = taskRunner.run();
+        // Tar segment directory to compress file
+        localSegmentDir = new File(localOutputTempDir, segmentName);
+        String segmentTarFileName = URLEncoder.encode(segmentName + Constants.TAR_GZ_FILE_EXT, "UTF-8");
+        localSegmentTarFile = new File(localOutputTempDir, segmentTarFileName);
+        LOGGER.info("Tarring segment from: {} to: {}", localSegmentDir, localSegmentTarFile);
+        TarGzCompressionUtils.createTarGzFile(localSegmentDir, localSegmentTarFile);
+        long uncompressedSegmentSize = FileUtils.sizeOf(localSegmentDir);
+        long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
+        LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,
+            DataSizeUtils.fromBytes(uncompressedSegmentSize), DataSizeUtils.fromBytes(compressedSegmentSize));
+        //move segment to output PinotFS
+        URI outputSegmentTarURI =
+            SegmentGenerationUtils.getRelativeOutputPath(_inputDirURI, inputFileURI, _outputDirURI)
+                .resolve(segmentTarFileName);
+        if (!_spec.isOverwriteOutput() && _outputDirFS.exists(outputSegmentTarURI)) {
+          LOGGER.warn("Not overwrite existing output segment tar file: {}", _outputDirFS.exists(outputSegmentTarURI));
+        } else {
+          _outputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
+        }
+      } catch (Exception e) {
+        LOGGER.error("Failed to generate Pinot segment for file - {}", inputFileURI, e);
+      } finally {
+        _segmentCreationTaskCountDownLatch.countDown();
+        FileUtils.deleteQuietly(localSegmentDir);
+        FileUtils.deleteQuietly(localSegmentTarFile);
+        FileUtils.deleteQuietly(localInputDataFile);
+      }
+    });
   }
 }


### PR DESCRIPTION
## Description
- Default to use local directory sequence id for segment name generation.
- Deprecated old config: `local.directory.sequence.id` to use new config: `use.global.directory.sequence.id`.