### PR TITLE
support different row counts per template in generator.sh

### DIFF
--- a/docker/images/pinot/bin/generator.sh
+++ b/docker/images/pinot/bin/generator.sh
@@ -27,15 +27,16 @@ TEMPLATE_BASEDIR="$TEMP_DIR/generator"
 CONTROLLER_HOST="localhost"
 CONTROLLER_PORT="9000"
 
-USAGE="$(basename "$0") [-h] [-a PATH] [-c HOST:PORT] [-j PATH] TEMPLATE_NAME [TABLE_NAME]
+USAGE="$(basename "$0") [-h] [-a PATH] [-c HOST:PORT] [-j PATH] [-n ROWS] TEMPLATE_NAME [TABLE_NAME]
 
   where:
       -h  show this help text
       -a  set pinot-admin path for segement creation
       -c  set the controller host and port (default: 'localhost:9000')
-      -j  set jar path for resource extraction"
+      -j  set jar path for resource extraction
+      -n  number of rows to generate. (optional)"
 
-while getopts ':ha:c:j:' OPTION; do
+while getopts ':ha:c:j:n:' OPTION; do
   case "$OPTION" in
     h) echo "$USAGE"
        exit
@@ -48,6 +49,8 @@ while getopts ':ha:c:j:' OPTION; do
        esac
        ;;
     j) JAR_PATH="$OPTARG"
+       ;;
+    n) NUM_RECORDS="$OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$USAGE" >&2
@@ -71,6 +74,20 @@ TABLE_NAME="$2"
 if [ -z "$TABLE_NAME" ]; then
   echo "No table name specified. Defaulting to '$TEMPLATE_NAME'"
   TABLE_NAME=$TEMPLATE_NAME
+fi
+
+if [ -z "$NUM_RECORDS" ]; then
+  if [ "$TEMPLATE_NAME" = "simpleWebsite" ]; then
+    NUM_RECORDS=354780
+  fi
+  if [ "$TEMPLATE_NAME" = "complexWebsite" ]; then
+    NUM_RECORDS=631152
+  fi
+
+  if [ -z "$NUM_RECORDS" ]; then
+    echo "No row count specified and no defaults available. (Does the template exist?) Aborting."
+    exit 1
+  fi
 fi
 
 DATA_DIR="${TEMP_DIR:?}/${TEMPLATE_NAME}"

--- a/docker/images/pinot/bin/generator.sh
+++ b/docker/images/pinot/bin/generator.sh
@@ -97,9 +97,14 @@ sed -i -e "s/\"tableName\": \"$TEMPLATE_NAME\"/\"tableName\": \"$TABLE_NAME\"/g"
 sed -i -e "s/\"schemaName\": \"$TEMPLATE_NAME\"/\"schemaName\": \"$TABLE_NAME\"/g" "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_config.json"
 sed -i -e "s/\"schemaName\": \"$TEMPLATE_NAME\"/\"schemaName\": \"$TABLE_NAME\"/g" "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_schema.json"
 
+NUM_RECORDS=354780
+if [ "$TEMPLATE_NAME" = "complexWebsite" ]; then
+  NUM_RECORDS=631152
+fi
+
 echo "Generating data for ${TEMPLATE_NAME} in ${DATA_DIR}"
 JAVA_OPTS="" ${ADMIN_PATH} GenerateData \
--numFiles 1 -numRecords 631152  -format csv \
+-numFiles 1 -numRecords $NUM_RECORDS -format csv \
 -schemaFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_schema.json" \
 -schemaAnnotationFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_generator.json" \
 -outDir "$DATA_DIR"


### PR DESCRIPTION
## Description
Generate different numbers of rows for sample data, based on template name.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)

## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
