### PR TITLE
emit metric for upsert table memory usage

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -43,6 +43,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
 
   // Upsert metrics
+  UPSERT_METADATA_MEMORY_USED("bytes", false),
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false);
 
   private final String gaugeName;

--- a/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/upsert/PartitionUpsertMetadataManager.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
+import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -133,6 +134,8 @@ public class PartitionUpsertMetadataManager {
     // Update metrics
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_METADATA_MEMORY_USED,
+        ObjectSizeCalculator.getObjectSize(_primaryKeyToRecordLocationMap));
     return validDocIds;
   }
 
@@ -162,6 +165,8 @@ public class PartitionUpsertMetadataManager {
     // Update metrics
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_METADATA_MEMORY_USED,
+        ObjectSizeCalculator.getObjectSize(_primaryKeyToRecordLocationMap));
   }
 
   /**
@@ -183,6 +188,8 @@ public class PartitionUpsertMetadataManager {
     // Update metrics
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_METADATA_MEMORY_USED,
+        ObjectSizeCalculator.getObjectSize(_primaryKeyToRecordLocationMap));
   }
 
   public static final class RecordInfo {


### PR DESCRIPTION
## Description

#6576 Emit metric for upsert table metadata (store mapping from primaryKey to RecordLocation) memory usage in bytes.

[Previous work](https://github.com/apache/incubator-pinot/pull/6204/files#diff-2fc79d140ad00f4fe862b03a12674c564a3cd85bc59e5397cb706a51a19faa39R46 ) emitting metric for PK numbers.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No.

Does this PR fix a zero-downtime upgrade introduced earlier?
No.

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
No.

## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

this is a backward compatible change. 

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
