### PR TITLE
Deprecate PQL endpoint on Broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -63,11 +63,12 @@ public class PinotClientRequest {
   @Inject
   private BrokerMetrics brokerMetrics;
 
+  @Deprecated
   @GET
   @ManagedAsync
   @Produces(MediaType.APPLICATION_JSON)
   @Path("query")
-  @ApiOperation(value = "Querying pinot")
+  @ApiOperation(value = "Querying pinot using PQL")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public void processQueryGet(
       // Query param "bql" is for backward compatibility
@@ -93,11 +94,12 @@ public class PinotClientRequest {
     }
   }
 
+  @Deprecated
   @POST
   @ManagedAsync
   @Produces(MediaType.APPLICATION_JSON)
   @Path("query")
-  @ApiOperation(value = "Querying pinot")
+  @ApiOperation(value = "Querying pinot using PQL")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Query response"), @ApiResponse(code = 500, message = "Internal Server Error")})
   public void processQueryPost(String query, @Suspended AsyncResponse asyncResponse,
       @Context org.glassfish.grizzly.http.server.Request requestContext) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -63,6 +63,12 @@ public class PinotClientRequest {
   @Inject
   private BrokerMetrics brokerMetrics;
 
+  /**
+   * Legacy API to query Pinot using PQL (Pinot Query Language) syntax
+   * and semantics. This API is deprecated and PQL is no longer supported
+   * by Pinot. The API will be removed in the next release. Please use
+   * the standard SQL syntax (API /query/sql) to query Pinot.
+   */
   @Deprecated
   @GET
   @ManagedAsync
@@ -94,6 +100,12 @@ public class PinotClientRequest {
     }
   }
 
+  /**
+   * Legacy API to query Pinot using PQL (Pinot Query Language) syntax
+   * and semantics. This API is deprecated and PQL is no longer supported
+   * by Pinot. The API will be removed in the next release. Please use
+   * the standard SQL syntax (API /query/sql) to query Pinot.
+   */
   @Deprecated
   @POST
   @ManagedAsync


### PR DESCRIPTION
## Description
As discussed on the mailing list and the issue https://github.com/apache/incubator-pinot/issues/5807, we are deprecating PQL restli endpoint `/query` on broker and controller. This PR deprecates the endpoint on broker. The controller endpoint `/pql` is already deprecated 

**Does this PR fix a zero-downtime upgrade introduced earlier?**
No

**Does this PR otherwise need attention when creating release notes? Things to consider:**
Yes PQL endpoint on broker is deprecated. Labelled the PR with release-notes. 
Info for release notes - Apache Pinot has adopted SQL syntax and semantics. Legacy PQL (Pinot Query Language) is deprecated and no longer supported. Please use SQL syntax to query Pinot on broker endpoint `/query/sql` and controller endpoint `/sql`

Will add to docs.pinot.apache.org
