### PR TITLE
Remove the TableDataManager when there is no segment left for the table

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -211,6 +211,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @Override
+  public int getNumSegments() {
+    return _segmentDataManagerMap.size();
+  }
+
+  @Override
   public String getTableName() {
     return _tableNameWithType;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -114,6 +114,11 @@ public interface TableDataManager {
   void releaseSegment(SegmentDataManager segmentDataManager);
 
   /**
+   * Returns the number of segments managed by this instance.
+   */
+  int getNumSegments();
+
+  /**
    * Returns the table name managed by this instance.
    */
   String getTableName();


### PR DESCRIPTION
## Description
Current behavior: On server side, `TableDataManager` is created when loading the first segment for a table, but never removed during the lifetime of the server. This could cause problem when a table is deleted and recreated without restarting the server because server will treat the recreated table as the old table (e.g. upsert won't be enabled if it is not enabled in the old table but enabled in the new table).
The fix: When the last segment for a table is removed, also remove the `TableDataManager`.