### PR TITLE
Improve the test stability of MemoryEstimatorTest by increase total number of docs

### DIFF
--- a/pinot-tools/src/test/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimatorTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimatorTest.java
@@ -40,7 +40,7 @@ public class MemoryEstimatorTest {
   @Test
   public void testSegmentGenerator() throws Exception {
     runTest("memory_estimation/schema-with-metadata.json", metadata -> {
-      assertEquals(extract(metadata, "segment.total.docs = (\\d+)"), "10000");
+      assertEquals(extract(metadata, "segment.total.docs = (\\d+)"), "100000");
       assertEquals(extract(metadata, "column.colInt.cardinality = (\\d+)"), "100");
       assertEquals(extract(metadata, "column.colIntMV.cardinality = (\\d+)"), "150");
       assertEquals(extract(metadata, "column.colFloat.cardinality = (\\d+)"), "200");
@@ -75,7 +75,7 @@ public class MemoryEstimatorTest {
   @Test
   public void testSegmentGenerator_withDateTimeFieldSpec() throws Exception {
     runTest("memory_estimation/schema-with-metadata__dateTimeFieldSpec.json", metadata -> {
-      assertEquals(extract(metadata, "segment.total.docs = (\\d+)"), "10000");
+      assertEquals(extract(metadata, "segment.total.docs = (\\d+)"), "100000");
       assertEquals(extract(metadata, "column.colInt.cardinality = (\\d+)"), "500");
       assertEquals(extract(metadata, "column.colFloat.cardinality = (\\d+)"), "600");
       assertEquals(extract(metadata, "column.colString.cardinality = (\\d+)"), "700");
@@ -99,7 +99,7 @@ public class MemoryEstimatorTest {
     File schemaFile = readFile(schemaFileName);
     File tableConfigFile = readFile("memory_estimation/table-config.json");
     TableConfig tableConfig = JsonUtils.fileToObject(tableConfigFile, TableConfig.class);
-    int numberOfRows = 10_000;
+    int numberOfRows = 100_000;
 
     // act
     MemoryEstimator.SegmentGenerator


### PR DESCRIPTION

## Description
We are seeing increasing failure for MemoryEstimatorTest, as the random data generator cannot guarantee all the unique values been picked in [next()](https://github.com/apache/incubator-pinot/commit/4c3af59e19c33fdb9162589b18cff8040ccb3b75#diff-d1ed5ecef04bc819c64652f035e06c47a03b4c9dfab8fa83213b1baf0bab186dR121) call.

Just increase the total number of docs will significantly increase the probability to select all the unique values. This is a fix to unblock the release. A permanent fix should follow.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
