### PR TITLE
Basic Auth for pinot-controller

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -18,13 +18,33 @@
  */
 package org.apache.pinot.broker.api;
 
+import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
-import org.apache.pinot.common.request.BrokerRequest;
 
 
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public interface AccessControl {
+  /**
+   * First-step access control when processing broker requests. Decides whether request is allowed to acquire resources
+   * for further processing. Request may still be rejected at table-level later on.
+   *
+   * @param requesterIdentity requester identity
+   *
+   * @return {@code true} if authorized, {@code false} otherwise
+   */
+  default boolean hasAccess(RequesterIdentity requesterIdentity) {
+    return true;
+  }
+
+  /**
+   * Fine-grained access control on parsed broker request. May check table, column, permissions, etc.
+   *
+   * @param requesterIdentity requester identity
+   * @param brokerRequest broker request (incl query)
+   *
+   * @return {@code true} if authorized, {@code false} otherwise
+   */
   boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -67,10 +67,10 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
    * Access Control using header-based basic http authentication
    */
   private static class BasicAuthAccessControl implements AccessControl {
-    private final Map<String, BasicAuthPrincipal> _principals;
+    private final Map<String, BasicAuthPrincipal> _token2principal;
 
     public BasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
-      _principals = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
+      _token2principal = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
     }
 
     @Override
@@ -80,7 +80,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
       Collection<String> tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
       Optional<BasicAuthPrincipal> principalOpt =
-          tokens.stream().map(BasicAuthUtils::normalizeBase64Token).map(_principals::get).filter(Objects::nonNull)
+          tokens.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get).filter(Objects::nonNull)
               .findFirst();
 
       if (!principalOpt.isPresent()) {
@@ -89,7 +89,8 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
       }
 
       BasicAuthPrincipal principal = principalOpt.get();
-      if (!brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource().isSetTableName()) {
+      if (brokerRequest == null || !brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource()
+          .isSetTableName()) {
         // no table restrictions? accept
         return true;
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -74,6 +74,11 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     @Override
+    public boolean hasAccess(RequesterIdentity requesterIdentity) {
+      return hasAccess(requesterIdentity, null);
+    }
+
+    @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
       Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity, "HttpRequesterIdentity required");
       HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -184,7 +184,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     // secondary table-level check comes later
     boolean hasAccess = _accessControlFactory.create().hasAccess(requesterIdentity);
     if (!hasAccess) {
-      _brokerMetrics.addMeteredTableValue(null, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
       LOGGER.info("Access denied for requestId {}", requestId);
       requestStatistics.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
       return new BrokerResponseNative(QueryException.ACCESS_DENIED_ERROR);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -182,7 +182,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // first-stage access control to prevent unauthenticated requests from using up resources
     // secondary table-level check comes later
-    boolean hasAccess = _accessControlFactory.create().hasAccess(requesterIdentity, null);
+    boolean hasAccess = _accessControlFactory.create().hasAccess(requesterIdentity);
     if (!hasAccess) {
       _brokerMetrics.addMeteredTableValue(null, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
       LOGGER.info("Access denied for requestId {}", requestId);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.Random;
 import org.apache.pinot.broker.api.RequestStatistics;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.AllowAllAccessControlFactory;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -35,6 +37,7 @@ import org.testng.annotations.Test;
 
 
 public class LiteralOnlyBrokerRequestTest {
+  private static final AccessControlFactory ACCESS_CONTROL_FACTORY = new AllowAllAccessControlFactory();
   private static final Random RANDOM = new Random(System.currentTimeMillis());
   private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
 
@@ -91,9 +94,8 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandler()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null, null,
-            new BrokerMetrics("", PinotMetricUtils.getPinotMetricsRegistry(), true, Collections.emptySet()),
-            null);
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, ACCESS_CONTROL_FACTORY, null, null,
+            new BrokerMetrics("", PinotMetricUtils.getPinotMetricsRegistry(), true, Collections.emptySet()), null);
     long randNum = RANDOM.nextLong();
     byte[] randBytes = new byte[12];
     RANDOM.nextBytes(randBytes);
@@ -119,9 +121,8 @@ public class LiteralOnlyBrokerRequestTest {
   public void testBrokerRequestHandlerWithAsFunction()
       throws Exception {
     SingleConnectionBrokerRequestHandler requestHandler =
-        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, null, null, null,
-            new BrokerMetrics("", PinotMetricUtils.getPinotMetricsRegistry(), true, Collections.emptySet()),
-            null);
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), null, ACCESS_CONTROL_FACTORY, null, null,
+            new BrokerMetrics("", PinotMetricUtils.getPinotMetricsRegistry(), true, Collections.emptySet()), null);
     long currentTsMin = System.currentTimeMillis();
     JsonNode request = new ObjectMapper().readTree(
         "{\"sql\":\"SELECT now() as currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') as firstDayOf2020\"}");

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -40,9 +40,20 @@ public class ConnectionFactory {
    * @return A connection that connects to the brokers in the given Helix cluster
    */
   public static Connection fromZookeeper(String zkUrl) {
+    return fromZookeeper(zkUrl, null);
+  }
+
+  /**
+   * Creates a connection to a Pinot cluster, given its Zookeeper URL
+   *
+   * @param zkUrl The URL to the Zookeeper cluster, must include the cluster name e.g host:port/chroot/pinot-cluster
+   * @param headers Map of key and values of header which need to be used during http call
+   * @return A connection that connects to the brokers in the given Helix cluster
+   */
+  public static Connection fromZookeeper(String zkUrl, Map<String, String> headers) {
     try {
       DynamicBrokerSelector dynamicBrokerSelector = new DynamicBrokerSelector(zkUrl);
-      return new Connection(dynamicBrokerSelector, _transportFactory.buildTransport(null));
+      return new Connection(dynamicBrokerSelector, _transportFactory.buildTransport(headers));
     } catch (Exception e) {
       throw new PinotClientException(e);
     }
@@ -55,8 +66,19 @@ public class ConnectionFactory {
    * @return A connection that connects to the brokers specified in the properties
    */
   public static Connection fromProperties(Properties properties) {
+    return fromProperties(properties, null);
+  }
+
+  /**
+   * Creates a connection from properties containing the connection parameters.
+   *
+   * @param properties The properties to use for the connection
+   * @param headers Map of key and values of header which need to be used during http call
+   * @return A connection that connects to the brokers specified in the properties
+   */
+  public static Connection fromProperties(Properties properties, Map<String, String> headers) {
     return new Connection(Arrays.asList(properties.getProperty("brokerList").split(",")),
-        _transportFactory.buildTransport(null));
+        _transportFactory.buildTransport(headers));
   }
 
   /**
@@ -66,7 +88,7 @@ public class ConnectionFactory {
    * @return A connection to the set of brokers specified
    */
   public static Connection fromHostList(String... brokers) {
-    return new Connection(Arrays.asList(brokers), _transportFactory.buildTransport(null));
+    return fromHostList(Arrays.asList(brokers), null);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -94,6 +94,7 @@ public class SegmentGenerationUtils {
     }
   }
 
+  @Deprecated
   public static TableConfig getTableConfig(String tableConfigURIStr) {
     return getTableConfig(tableConfigURIStr, null);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -316,7 +316,7 @@ public class CommonConstants {
        * Service token for accessing protected controller APIs.
        * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
        */
-      public static final String CONFIG_OF_SEGMENT_UPLOAD_AUTH_TOKEN = "upload.auth.token";
+      public static final String CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN = "auth.token";
 
       public static final int DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 300_000;
       public static final int DEFAULT_OTHER_REQUESTS_TIMEOUT = 10_000;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -27,6 +27,8 @@ public class CommonConstants {
   public static final String HTTP_PROTOCOL = "http";
   public static final String HTTPS_PROTOCOL = "https";
 
+  public static final String KEY_OF_AUTH_TOKEN = "auth.token";
+
   public static class Table {
     public static final String PUSH_FREQUENCY_HOURLY = "hourly";
     public static final String PUSH_FREQUENCY_DAILY = "daily";
@@ -240,7 +242,7 @@ public class CommonConstants {
      * Service token for accessing protected controller APIs.
      * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
      */
-    public static final String CONFIG_OF_AUTH_TOKEN = "auth.token";
+    public static final String CONFIG_OF_AUTH_TOKEN = KEY_OF_AUTH_TOKEN;
 
     // Configuration to consider the server ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this server has crossed the threshold percentage of the total number of tables
@@ -316,7 +318,7 @@ public class CommonConstants {
        * Service token for accessing protected controller APIs.
        * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
        */
-      public static final String CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN = "auth.token";
+      public static final String CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN = KEY_OF_AUTH_TOKEN;
 
       public static final int DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 300_000;
       public static final int DEFAULT_OTHER_REQUESTS_TIMEOUT = 10_000;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -236,6 +236,10 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.server.storage.factory";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
 
+    /**
+     * Service token for accessing protected controller APIs.
+     * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
+     */
     public static final String CONFIG_OF_AUTH_TOKEN = "auth.token";
 
     // Configuration to consider the server ServiceStatus as being STARTED if the percent of resources (tables) that
@@ -307,6 +311,11 @@ public class CommonConstants {
       public static final String CONFIG_OF_CONTROLLER_HTTPS_ENABLED = "enabled";
       public static final String CONFIG_OF_CONTROLLER_HTTPS_PORT = "controller.port";
       public static final String CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = "upload.request.timeout.ms";
+
+      /**
+       * Service token for accessing protected controller APIs.
+       * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
+       */
       public static final String CONFIG_OF_SEGMENT_UPLOAD_AUTH_TOKEN = "upload.auth.token";
 
       public static final int DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 300_000;
@@ -362,6 +371,10 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "segment.uploader";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "crypter";
 
+    /**
+     * Service token for accessing protected controller APIs.
+     * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
+     */
     public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -235,6 +235,9 @@ public class CommonConstants {
         "pinot.server.instance.realtime.alloc.offheap.direct";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.server.storage.factory";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
+
+    public static final String CONFIG_OF_AUTH_TOKEN = "auth.token";
+
     // Configuration to consider the server ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this server has crossed the threshold percentage of the total number of tables
     // that it is expected to serve.
@@ -304,6 +307,7 @@ public class CommonConstants {
       public static final String CONFIG_OF_CONTROLLER_HTTPS_ENABLED = "enabled";
       public static final String CONFIG_OF_CONTROLLER_HTTPS_PORT = "controller.port";
       public static final String CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = "upload.request.timeout.ms";
+      public static final String CONFIG_OF_SEGMENT_UPLOAD_AUTH_TOKEN = "upload.auth.token";
 
       public static final int DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 300_000;
       public static final int DEFAULT_OTHER_REQUESTS_TIMEOUT = 10_000;
@@ -357,6 +361,8 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "segment.fetcher";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "segment.uploader";
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "crypter";
+
+    public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
   }
 
   public static class Segment {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -46,6 +46,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -139,12 +140,18 @@ public class FileUploadDownloadClient implements Closeable {
     return new URI(protocol, null, host, port, path, null, null);
   }
 
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
   @Deprecated
   public static URI getRetrieveTableConfigHttpURI(String host, int port, String rawTableName)
       throws URISyntaxException {
     return getURI(HTTP, host, port, TABLES_PATH + "/" + rawTableName);
   }
 
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
   @Deprecated
   public static URI getDeleteSegmentHttpUri(String host, int port, String rawTableName, String segmentName,
       String tableType)
@@ -153,6 +160,9 @@ public class FileUploadDownloadClient implements Closeable {
         rawTableName + "/" + URIUtils.encode(segmentName) + TYPE_DELIMITER + tableType));
   }
 
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
   @Deprecated
   public static URI getRetrieveAllSegmentWithTableTypeHttpUri(String host, int port, String rawTableName,
       String tableType)
@@ -161,6 +171,9 @@ public class FileUploadDownloadClient implements Closeable {
         rawTableName + TYPE_DELIMITER + tableType));
   }
 
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
   @Deprecated
   public static URI getRetrieveSchemaHttpURI(String host, int port, String schemaName)
       throws URISyntaxException {
@@ -170,6 +183,24 @@ public class FileUploadDownloadClient implements Closeable {
   public static URI getRetrieveSchemaURI(String protocol, String host, int port, String schemaName)
       throws URISyntaxException {
     return getURI(protocol, host, port, SCHEMA_PATH + "/" + schemaName);
+  }
+
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
+  @Deprecated
+  public static URI getUploadSchemaHttpURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTP, host, port, SCHEMA_PATH);
+  }
+
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
+  @Deprecated
+  public static URI getUploadSchemaHttpsURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTPS, host, port, SCHEMA_PATH);
   }
 
   public static URI getUploadSchemaURI(String protocol, String host, int port)
@@ -182,10 +213,46 @@ public class FileUploadDownloadClient implements Closeable {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SCHEMA_PATH);
   }
 
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
+   * getUploadSegmentHttpURI to construct your request.
+   */
+  @Deprecated
+  public static URI getOldUploadSegmentHttpURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTP, host, port, OLD_SEGMENT_PATH);
+  }
+
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
+   * getUploadSegmentHttpsURI to construct your request.
+   */
+  @Deprecated
+  public static URI getOldUploadSegmentHttpsURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTPS, host, port, OLD_SEGMENT_PATH);
+  }
+
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
   @Deprecated
   public static URI getUploadSegmentHttpURI(String host, int port)
       throws URISyntaxException {
     return getURI(HTTP, host, port, SEGMENT_PATH);
+  }
+
+  /**
+   * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   */
+  @Deprecated
+  public static URI getUploadSegmentHttpsURI(String host, int port)
+      throws URISyntaxException {
+    return getURI(HTTPS, host, port, SEGMENT_PATH);
   }
 
   public static URI getUploadSegmentURI(String protocol, String host, int port)
@@ -223,20 +290,6 @@ public class FileUploadDownloadClient implements Closeable {
         RequestBuilder.create(method).setVersion(HttpVersion.HTTP_1_1).setUri(uri).setEntity(entity);
     addHeadersAndParameters(requestBuilder, headers, parameters);
     setTimeout(requestBuilder, socketTimeoutMs);
-    return requestBuilder.build();
-  }
-
-  @Deprecated
-  private static HttpUriRequest constructGetRequest(URI uri) {
-    RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
-    setTimeout(requestBuilder, GET_REQUEST_SOCKET_TIMEOUT_MS);
-    return requestBuilder.build();
-  }
-
-  @Deprecated
-  private static HttpUriRequest constructDeleteRequest(URI uri) {
-    RequestBuilder requestBuilder = RequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_1_1);
-    setTimeout(requestBuilder, DELETE_REQUEST_SOCKET_TIMEOUT_MS);
     return requestBuilder.build();
   }
 
@@ -395,16 +448,44 @@ public class FileUploadDownloadClient implements Closeable {
     return errorMessage;
   }
 
+  /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   */
   @Deprecated
   public SimpleHttpResponse sendGetRequest(URI uri)
       throws IOException, HttpErrorStatusException {
-    return sendRequest(constructGetRequest(uri));
+    RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, GET_REQUEST_SOCKET_TIMEOUT_MS);
+    return sendRequest(requestBuilder.build());
   }
 
+  /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   */
   @Deprecated
   public SimpleHttpResponse sendDeleteRequest(URI uri)
       throws IOException, HttpErrorStatusException {
-    return sendRequest(constructDeleteRequest(uri));
+    RequestBuilder requestBuilder = RequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, DELETE_REQUEST_SOCKET_TIMEOUT_MS);
+    return sendRequest(requestBuilder.build());
+  }
+
+  /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * Add schema.
+   *
+   * @param uri URI
+   * @param schemaName Schema name
+   * @param schemaFile Schema file
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  @Deprecated
+  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile)
+      throws IOException, HttpErrorStatusException {
+    return addSchema(uri, schemaName, schemaFile, Collections.emptyList(), Collections.emptyList());
   }
 
   /**
@@ -426,6 +507,26 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * Update schema.
+   *
+   * @param uri URI
+   * @param schemaName Schema name
+   * @param schemaFile Schema file
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  @Deprecated
+  public SimpleHttpResponse updateSchema(URI uri, String schemaName, File schemaFile)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(
+        getUploadFileRequest(HttpPut.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), null, null,
+            DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  /**
    * Upload segment by sending a zip of creation.meta and metadata.properties.
    *
    * @param uri URI
@@ -443,6 +544,18 @@ public class FileUploadDownloadClient implements Closeable {
       throws IOException, HttpErrorStatusException {
     return sendRequest(
         getUploadSegmentMetadataRequest(uri, segmentName, segmentMetadataFile, headers, parameters, socketTimeoutMs));
+  }
+
+  /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   */
+  @Deprecated
+  // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
+  public SimpleHttpResponse uploadSegmentMetadataFiles(URI uri, Map<String, File> metadataFiles,
+      int segmentUploadRequestTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    return uploadSegmentMetadataFiles(uri, metadataFiles, Collections.emptyList(), Collections.emptyList(),
+        segmentUploadRequestTimeoutMs);
   }
 
   // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
@@ -478,9 +591,9 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Upload segment with segment file using default settings. Include table name as a request parameter.
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
-   * NOTE: does not support auth tokens
+   * Upload segment with segment file using default settings. Include table name as a request parameter.
    *
    * @param uri URI
    * @param segmentName Segment name
@@ -521,6 +634,25 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Upload segment with segment file input stream using default settings. Include table name as a request parameter.
+   *
+   * @param uri URI
+   * @param segmentName Segment name
+   * @param inputStream Segment file input stream
+   * @param rawTableName Raw table name
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse uploadSegment(URI uri, String segmentName, InputStream inputStream, String rawTableName)
+      throws IOException, HttpErrorStatusException {
+    // Add table name as a request parameter
+    NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, rawTableName);
+    List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
+    return uploadSegment(uri, segmentName, inputStream, null, parameters, DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  /**
    * Send segment uri.
    *
    * Note: table name has to be set as a parameter.
@@ -541,6 +673,8 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
    * Send segment uri using default settings. Include table name as a request parameter.
    *
    * @param uri URI
@@ -578,6 +712,8 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
    * Send segment json using default settings.
    *
    * @param uri URI
@@ -593,9 +729,28 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
    * Send segment completion protocol request.
    *
    * @param uri URI
+   * @param socketTimeoutMs Socket timeout in milliseconds
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  @Deprecated
+  public SimpleHttpResponse sendSegmentCompletionProtocolRequest(URI uri, int socketTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    return sendSegmentCompletionProtocolRequest(uri, Collections.emptyList(), Collections.emptyList(), socketTimeoutMs);
+  }
+
+  /**
+   * Send segment completion protocol request.
+   *
+   * @param uri URI
+   * @param headers Optional http headers
+   * @param parameters Optional query parameters
    * @param socketTimeoutMs Socket timeout in milliseconds
    * @return Response
    * @throws IOException
@@ -608,12 +763,30 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
    * Download a file using default settings, with an optional auth token
    *
    * @param uri URI
    * @param socketTimeoutMs Socket timeout in milliseconds
    * @param dest File destination
-   * @param authToken optional auth token, or null
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  @Deprecated
+  public int downloadFile(URI uri, int socketTimeoutMs, File dest)
+      throws IOException, HttpErrorStatusException {
+    return downloadFile(uri, socketTimeoutMs, dest, null);
+  }
+
+  /**
+   * Download a file using default settings, with an optional auth token
+   *
+   * @param uri URI
+   * @param socketTimeoutMs Socket timeout in milliseconds
+   * @param dest File destination
+   * @param authToken auth token
    * @return Response status code
    * @throws IOException
    * @throws HttpErrorStatusException
@@ -648,11 +821,28 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Download a file, with an optional auth token.
+   * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * Download a file.
    *
    * @param uri URI
    * @param dest File destination
-   * @param authToken optional auth token, or null
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  @Deprecated
+  public int downloadFile(URI uri, File dest)
+      throws IOException, HttpErrorStatusException {
+    return downloadFile(uri, dest, null);
+  }
+
+  /**
+   * Download a file.
+   *
+   * @param uri URI
+   * @param dest File destination
+   * @param authToken auth token
    * @return Response status code
    * @throws IOException
    * @throws HttpErrorStatusException

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -142,6 +143,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getRetrieveTableConfigURI(String, String, int, String)
    */
   @Deprecated
   public static URI getRetrieveTableConfigHttpURI(String host, int port, String rawTableName)
@@ -149,8 +152,15 @@ public class FileUploadDownloadClient implements Closeable {
     return getURI(HTTP, host, port, TABLES_PATH + "/" + rawTableName);
   }
 
+  public static URI getRetrieveTableConfigURI(String protocol, String host, int port, String rawTableName)
+      throws URISyntaxException {
+    return getURI(protocol, host, port, TABLES_PATH + "/" + rawTableName);
+  }
+
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * This method calls the old segment endpoint. We will deprecate this behavior soon.
    */
   @Deprecated
   public static URI getDeleteSegmentHttpUri(String host, int port, String rawTableName, String segmentName,
@@ -162,6 +172,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * This method calls the old segment endpoint. We will deprecate this behavior soon.
    */
   @Deprecated
   public static URI getRetrieveAllSegmentWithTableTypeHttpUri(String host, int port, String rawTableName,
@@ -173,6 +185,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getRetrieveSchemaURI(String, String, int, String)
    */
   @Deprecated
   public static URI getRetrieveSchemaHttpURI(String host, int port, String schemaName)
@@ -187,6 +201,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getUploadSchemaURI(String, String, int)
    */
   @Deprecated
   public static URI getUploadSchemaHttpURI(String host, int port)
@@ -196,6 +212,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getUploadSchemaURI(String, String, int)
    */
   @Deprecated
   public static URI getUploadSchemaHttpsURI(String host, int port)
@@ -216,6 +234,8 @@ public class FileUploadDownloadClient implements Closeable {
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
    *
+   * @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
+   *
    * This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
    * getUploadSegmentHttpURI to construct your request.
    */
@@ -228,6 +248,8 @@ public class FileUploadDownloadClient implements Closeable {
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
    *
+   * @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
+   *
    * This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
    * getUploadSegmentHttpsURI to construct your request.
    */
@@ -239,6 +261,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
    */
   @Deprecated
   public static URI getUploadSegmentHttpURI(String host, int port)
@@ -248,6 +272,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
+   *
+   * @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
    */
   @Deprecated
   public static URI getUploadSegmentHttpsURI(String host, int port)
@@ -450,6 +476,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * @see FileUploadDownloadClient#sendGetRequest(URI, String)
    */
   @Deprecated
   public SimpleHttpResponse sendGetRequest(URI uri)
@@ -459,8 +487,18 @@ public class FileUploadDownloadClient implements Closeable {
     return sendRequest(requestBuilder.build());
   }
 
+  public SimpleHttpResponse sendGetRequest(URI uri, String authToken)
+      throws IOException, HttpErrorStatusException {
+    RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    requestBuilder.addHeader("Authorization", authToken);
+    setTimeout(requestBuilder, GET_REQUEST_SOCKET_TIMEOUT_MS);
+    return sendRequest(requestBuilder.build());
+  }
+
   /**
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * @see FileUploadDownloadClient#sendDeleteRequest(URI, String)
    */
   @Deprecated
   public SimpleHttpResponse sendDeleteRequest(URI uri)
@@ -470,10 +508,20 @@ public class FileUploadDownloadClient implements Closeable {
     return sendRequest(requestBuilder.build());
   }
 
+  public SimpleHttpResponse sendDeleteRequest(URI uri, String authToken)
+      throws IOException, HttpErrorStatusException {
+    RequestBuilder requestBuilder = RequestBuilder.delete(uri).setVersion(HttpVersion.HTTP_1_1);
+    requestBuilder.addHeader("Authorization", authToken);
+    setTimeout(requestBuilder, DELETE_REQUEST_SOCKET_TIMEOUT_MS);
+    return sendRequest(requestBuilder.build());
+  }
+
   /**
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
    * Add schema.
+   *
+   * @see FileUploadDownloadClient#addSchema(URI, String, File, List, List)
    *
    * @param uri URI
    * @param schemaName Schema name
@@ -511,6 +559,8 @@ public class FileUploadDownloadClient implements Closeable {
    *
    * Update schema.
    *
+   * @see FileUploadDownloadClient#updateSchema(URI, String, File, List, List)
+   *
    * @param uri URI
    * @param schemaName Schema name
    * @param schemaFile Schema file
@@ -523,6 +573,26 @@ public class FileUploadDownloadClient implements Closeable {
       throws IOException, HttpErrorStatusException {
     return sendRequest(
         getUploadFileRequest(HttpPut.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), null, null,
+            DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  /**
+   * Update schema.
+   *
+   * @param uri URI
+   * @param schemaName Schema name
+   * @param schemaFile Schema file
+   * @param headers HTTP headers
+   * @param parameters HTTP parameters
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse updateSchema(URI uri, String schemaName, File schemaFile, @Nullable List<Header> headers,
+      @Nullable List<NameValuePair> parameters)
+      throws IOException, HttpErrorStatusException {
+    return sendRequest(
+        getUploadFileRequest(HttpPut.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), headers, parameters,
             DEFAULT_SOCKET_TIMEOUT_MS));
   }
 
@@ -548,6 +618,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
+   *
+   * @see FileUploadDownloadClient#uploadSegment(URI, String, InputStream, List, List, int)
    */
   @Deprecated
   // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
@@ -594,6 +666,8 @@ public class FileUploadDownloadClient implements Closeable {
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
    * Upload segment with segment file using default settings. Include table name as a request parameter.
+   *
+   * @see FileUploadDownloadClient#uploadSegment(URI, String, InputStream, List, List, int)
    *
    * @param uri URI
    * @param segmentName Segment name
@@ -677,6 +751,8 @@ public class FileUploadDownloadClient implements Closeable {
    *
    * Send segment uri using default settings. Include table name as a request parameter.
    *
+   * @see FileUploadDownloadClient#sendSegmentUri(URI, String, List, List, int)
+   *
    * @param uri URI
    * @param downloadUri Segment download uri
    * @param rawTableName Raw table name
@@ -716,6 +792,8 @@ public class FileUploadDownloadClient implements Closeable {
    *
    * Send segment json using default settings.
    *
+   * @see FileUploadDownloadClient#sendSegmentJson(URI, String, List, List, int)
+   *
    * @param uri URI
    * @param jsonString Segment json string
    * @return Response
@@ -732,6 +810,8 @@ public class FileUploadDownloadClient implements Closeable {
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
    * Send segment completion protocol request.
+   *
+   * @see FileUploadDownloadClient#sendSegmentCompletionProtocolRequest(URI, List, List, int)
    *
    * @param uri URI
    * @param socketTimeoutMs Socket timeout in milliseconds
@@ -766,6 +846,8 @@ public class FileUploadDownloadClient implements Closeable {
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
    * Download a file using default settings, with an optional auth token
+   *
+   * @see FileUploadDownloadClient#downloadFile(URI, int, File, String)
    *
    * @param uri URI
    * @param socketTimeoutMs Socket timeout in milliseconds
@@ -824,6 +906,8 @@ public class FileUploadDownloadClient implements Closeable {
    * Deprecated due to lack of auth header support. May break for deployments with auth enabled
    *
    * Download a file.
+   *
+   * @see FileUploadDownloadClient#downloadFile(URI, File, String)
    *
    * @param uri URI
    * @param dest File destination

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -383,6 +383,7 @@ public class FileUploadDownloadClient implements Closeable {
   private static HttpUriRequest getSegmentCompletionProtocolRequest(URI uri, @Nullable List<Header> headers,
       @Nullable List<NameValuePair> parameters, int socketTimeoutMs) {
     RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+    addHeadersAndParameters(requestBuilder, headers, parameters);
     setTimeout(requestBuilder, socketTimeoutMs);
     return requestBuilder.build();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -447,21 +447,6 @@ public class FileUploadDownloadClient implements Closeable {
    * @param uri URI
    * @param schemaName Schema name
    * @param schemaFile Schema file
-   * @return Response
-   * @throws IOException
-   * @throws HttpErrorStatusException
-   */
-  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile)
-      throws IOException, HttpErrorStatusException {
-    return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, null, null));
-  }
-
-  /**
-   * Add schema.
-   *
-   * @param uri URI
-   * @param schemaName Schema name
-   * @param schemaFile Schema file
    * @param headers HTTP headers
    * @param parameters HTTP parameters
    * @return Response
@@ -472,21 +457,6 @@ public class FileUploadDownloadClient implements Closeable {
       @Nullable List<NameValuePair> parameters)
       throws IOException, HttpErrorStatusException {
     return sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, headers, parameters));
-  }
-
-  /**
-   * Update schema.
-   *
-   * @param uri URI
-   * @param schemaName Schema name
-   * @param schemaFile Schema file
-   * @return Response
-   * @throws IOException
-   * @throws HttpErrorStatusException
-   */
-  public SimpleHttpResponse updateSchema(URI uri, String schemaName, File schemaFile)
-      throws IOException, HttpErrorStatusException {
-    return sendRequest(getUpdateSchemaRequest(uri, schemaName, schemaFile));
   }
 
   /**
@@ -578,25 +548,6 @@ public class FileUploadDownloadClient implements Closeable {
       @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters, int socketTimeoutMs)
       throws IOException, HttpErrorStatusException {
     return sendRequest(getUploadSegmentRequest(uri, segmentName, inputStream, headers, parameters, socketTimeoutMs));
-  }
-
-  /**
-   * Upload segment with segment file input stream using default settings. Include table name as a request parameter.
-   *
-   * @param uri URI
-   * @param segmentName Segment name
-   * @param inputStream Segment file input stream
-   * @param rawTableName Raw table name
-   * @return Response
-   * @throws IOException
-   * @throws HttpErrorStatusException
-   */
-  public SimpleHttpResponse uploadSegment(URI uri, String segmentName, InputStream inputStream, String rawTableName)
-      throws IOException, HttpErrorStatusException {
-    // Add table name as a request parameter
-    NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, rawTableName);
-    List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
-    return uploadSegment(uri, segmentName, inputStream, null, parameters, DEFAULT_SOCKET_TIMEOUT_MS);
   }
 
   /**
@@ -783,7 +734,7 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Generate an (optional) HTTP Authorization header given an auth token
+   * Generate an (optional) HTTP Authorization header given an auth token.
    *
    * @param authToken auth token
    * @return list of 0 or 1 "Authorization" headers
@@ -793,5 +744,16 @@ public class FileUploadDownloadClient implements Closeable {
       return Collections.emptyList();
     }
     return Collections.singletonList(new BasicHeader("Authorization", authToken));
+  }
+
+  /**
+   * Generate a param list with a table name attribute.
+   *
+   * @param tableName table name
+   * @return param list
+   */
+  public static List<NameValuePair> makeTableParam(String tableName) {
+    return Collections
+        .singletonList(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName));
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Random;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   public static final String RETRY_COUNT_CONFIG_KEY = "retry.count";
   public static final String RETRY_WAIT_MS_CONFIG_KEY = "retry.wait.ms";
   public static final String RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY = "retry.delay.scale.factor";
-  public static final String AUTH_TOKEN = "auth.token";
+  public static final String AUTH_TOKEN = CommonConstants.KEY_OF_AUTH_TOKEN;
   public static final int DEFAULT_RETRY_COUNT = 3;
   public static final int DEFAULT_RETRY_WAIT_MS = 100;
   public static final int DEFAULT_RETRY_DELAY_SCALE_FACTOR = 5;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Random;
-
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
@@ -36,6 +35,7 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   public static final String RETRY_COUNT_CONFIG_KEY = "retry.count";
   public static final String RETRY_WAIT_MS_CONFIG_KEY = "retry.wait.ms";
   public static final String RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY = "retry.delay.scale.factor";
+  public static final String AUTH_TOKEN = "auth.token";
   public static final int DEFAULT_RETRY_COUNT = 3;
   public static final int DEFAULT_RETRY_WAIT_MS = 100;
   public static final int DEFAULT_RETRY_DELAY_SCALE_FACTOR = 5;
@@ -45,12 +45,14 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   protected int _retryCount;
   protected int _retryWaitMs;
   protected int _retryDelayScaleFactor;
+  protected String _authToken;
 
   @Override
   public void init(PinotConfiguration config) {
     _retryCount = config.getProperty(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);
     _retryWaitMs = config.getProperty(RETRY_WAIT_MS_CONFIG_KEY, DEFAULT_RETRY_WAIT_MS);
     _retryDelayScaleFactor = config.getProperty(RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY, DEFAULT_RETRY_DELAY_SCALE_FACTOR);
+    _authToken = config.getProperty(AUTH_TOKEN);
     doInit(config);
     _logger
         .info("Initialized with retryCount: {}, retryWaitMs: {}, retryDelayScaleFactor: {}", _retryCount, _retryWaitMs,

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -41,7 +41,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
       throws Exception {
     RetryPolicies.exponentialBackoffRetryPolicy(_retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(() -> {
       try {
-        int statusCode = _httpClient.downloadFile(uri, dest);
+        int statusCode = _httpClient.downloadFile(uri, dest, _authToken);
         _logger
             .info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
                 statusCode);
@@ -70,7 +70,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   public void fetchSegmentToLocalWithoutRetry(URI uri, File dest)
       throws Exception {
     try {
-      int statusCode = _httpClient.downloadFile(uri, dest);
+      int statusCode = _httpClient.downloadFile(uri, dest, _authToken);
       _logger
           .info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
               statusCode);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -38,7 +38,7 @@ public class SegmentFetcherFactory {
 
   static final String SEGMENT_FETCHER_CLASS_KEY_SUFFIX = ".class";
   private static final String PROTOCOLS_KEY = "protocols";
-  private static final String AUTH_TOKEN_KEY = "auth.token";
+  private static final String AUTH_TOKEN_KEY = CommonConstants.KEY_OF_AUTH_TOKEN;
   private static final String ENCODED_SUFFIX = ".enc";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentFetcherFactory.class);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.crypt.PinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
@@ -34,22 +34,25 @@ import org.slf4j.LoggerFactory;
 
 
 public class SegmentFetcherFactory {
-  private SegmentFetcherFactory() {
-  }
+  private final static SegmentFetcherFactory instance = new SegmentFetcherFactory();
 
   static final String SEGMENT_FETCHER_CLASS_KEY_SUFFIX = ".class";
   private static final String PROTOCOLS_KEY = "protocols";
+  private static final String AUTH_TOKEN_KEY = "auth.token";
   private static final String ENCODED_SUFFIX = ".enc";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentFetcherFactory.class);
-  private static final Map<String, SegmentFetcher> SEGMENT_FETCHER_MAP = new HashMap<>();
-  private static final SegmentFetcher DEFAULT_HTTP_SEGMENT_FETCHER = new HttpSegmentFetcher();
-  private static final SegmentFetcher DEFAULT_PINOT_FS_SEGMENT_FETCHER = new PinotFSSegmentFetcher();
 
-  static {
-    PinotConfiguration emptyConfig = new PinotConfiguration();
-    DEFAULT_HTTP_SEGMENT_FETCHER.init(emptyConfig);
-    DEFAULT_PINOT_FS_SEGMENT_FETCHER.init(emptyConfig);
+  private final Map<String, SegmentFetcher> _segmentFetcherMap = new HashMap<>();
+  private final SegmentFetcher _httpSegmentFetcher = new HttpSegmentFetcher();
+  private final SegmentFetcher _pinotFSSegmentFetcher = new PinotFSSegmentFetcher();
+
+  private SegmentFetcherFactory() {
+    // left blank
+  }
+
+  public static SegmentFetcherFactory getInstance() {
+    return instance;
   }
 
   /**
@@ -57,6 +60,14 @@ public class SegmentFetcherFactory {
    */
   public static void init(PinotConfiguration config)
       throws Exception {
+    getInstance().initInternal(config);
+  }
+
+  private void initInternal(PinotConfiguration config)
+      throws Exception {
+    _httpSegmentFetcher.init(config); // directly, without sub-namespace
+    _pinotFSSegmentFetcher.init(config); // directly, without sub-namespace
+
     List<String> protocols = config.getProperty(PROTOCOLS_KEY, Arrays.asList());
     for (String protocol : protocols) {
       String segmentFetcherClassName = config.getProperty(protocol + SEGMENT_FETCHER_CLASS_KEY_SUFFIX);
@@ -77,8 +88,16 @@ public class SegmentFetcherFactory {
         LOGGER.info("Creating segment fetcher for protocol: {} with class: {}", protocol, segmentFetcherClassName);
         segmentFetcher = (SegmentFetcher) Class.forName(segmentFetcherClassName).newInstance();
       }
-      segmentFetcher.init(config.subset(protocol));
-      SEGMENT_FETCHER_MAP.put(protocol, segmentFetcher);
+
+      String authToken = config.getProperty(AUTH_TOKEN_KEY);
+      Map<String, Object> subConfigMap = config.subset(protocol).toMap();
+      if (!subConfigMap.containsKey(AUTH_TOKEN_KEY) && StringUtils.isNotBlank(authToken)) {
+        subConfigMap.put(AUTH_TOKEN_KEY, authToken);
+      }
+
+      segmentFetcher.init(new PinotConfiguration(subConfigMap));
+
+      _segmentFetcherMap.put(protocol, segmentFetcher);
     }
   }
 
@@ -87,7 +106,11 @@ public class SegmentFetcherFactory {
    * ({@link HttpSegmentFetcher} for "http" and "https", {@link PinotFSSegmentFetcher} for other protocols).
    */
   public static SegmentFetcher getSegmentFetcher(String protocol) {
-    SegmentFetcher segmentFetcher = SEGMENT_FETCHER_MAP.get(protocol);
+    return getInstance().getSegmentFetcherInternal(protocol);
+  }
+
+  private SegmentFetcher getSegmentFetcherInternal(String protocol) {
+    SegmentFetcher segmentFetcher = _segmentFetcherMap.get(protocol);
     if (segmentFetcher != null) {
       return segmentFetcher;
     } else {
@@ -95,9 +118,9 @@ public class SegmentFetcherFactory {
       switch (protocol) {
         case CommonConstants.HTTP_PROTOCOL:
         case CommonConstants.HTTPS_PROTOCOL:
-          return DEFAULT_HTTP_SEGMENT_FETCHER;
+          return _httpSegmentFetcher;
         default:
-          return DEFAULT_PINOT_FS_SEGMENT_FETCHER;
+          return _pinotFSSegmentFetcher;
       }
     }
   }
@@ -107,7 +130,7 @@ public class SegmentFetcherFactory {
    */
   public static void fetchSegmentToLocal(URI uri, File dest)
       throws Exception {
-    getSegmentFetcher(uri.getScheme()).fetchSegmentToLocal(uri, dest);
+    getInstance().fetchSegmentToLocalInternal(uri, dest);
   }
 
   /**
@@ -115,7 +138,12 @@ public class SegmentFetcherFactory {
    */
   public static void fetchSegmentToLocal(String uri, File dest)
       throws Exception {
-    fetchSegmentToLocal(new URI(uri), dest);
+    getInstance().fetchSegmentToLocalInternal(new URI(uri), dest);
+  }
+
+  private void fetchSegmentToLocalInternal(URI uri, File dest)
+      throws Exception {
+    getSegmentFetcher(uri.getScheme()).fetchSegmentToLocal(uri, dest);
   }
 
   /**
@@ -124,6 +152,11 @@ public class SegmentFetcherFactory {
    * @param dest local file
    */
   public static void fetchAndDecryptSegmentToLocal(String uri, File dest, String crypterName)
+      throws Exception {
+    getInstance().fetchAndDecryptSegmentToLocalInternal(uri, dest, crypterName);
+  }
+
+  private void fetchAndDecryptSegmentToLocalInternal(String uri, File dest, String crypterName)
       throws Exception {
     if (crypterName == null) {
       fetchSegmentToLocal(uri, dest);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -20,7 +20,7 @@ package org.apache.pinot.common.utils.fetcher;
 
 import java.io.File;
 import java.net.URI;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class SegmentFetcherFactory {
-  private final static SegmentFetcherFactory instance = new SegmentFetcherFactory();
+  private final static SegmentFetcherFactory INSTANCE = new SegmentFetcherFactory();
 
   static final String SEGMENT_FETCHER_CLASS_KEY_SUFFIX = ".class";
   private static final String PROTOCOLS_KEY = "protocols";
@@ -52,7 +52,7 @@ public class SegmentFetcherFactory {
   }
 
   public static SegmentFetcherFactory getInstance() {
-    return instance;
+    return INSTANCE;
   }
 
   /**
@@ -68,7 +68,7 @@ public class SegmentFetcherFactory {
     _httpSegmentFetcher.init(config); // directly, without sub-namespace
     _pinotFSSegmentFetcher.init(config); // directly, without sub-namespace
 
-    List<String> protocols = config.getProperty(PROTOCOLS_KEY, Arrays.asList());
+    List<String> protocols = config.getProperty(PROTOCOLS_KEY, Collections.emptyList());
     for (String protocol : protocols) {
       String segmentFetcherClassName = config.getProperty(protocol + SEGMENT_FETCHER_CLASS_KEY_SUFFIX);
       SegmentFetcher segmentFetcher;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -389,6 +389,7 @@ public class ControllerStarter implements ServiceStartable {
     final AccessControlFactory accessControlFactory;
     try {
       accessControlFactory = (AccessControlFactory) Class.forName(accessControlFactoryClass).newInstance();
+      accessControlFactory.init(_config);
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while creating new AccessControlFactory instance", e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -68,6 +68,15 @@ public interface AccessControl {
   }
 
   /**
+   * Determine whether authentication is required for annotated (controller) endpoints only
+   *
+   * @return {@code true} if annotated methods are protected only, {@code false} otherwise
+   */
+  default boolean protectAnnotatedOnly() {
+    return true;
+  }
+
+  /**
    * Return workflow info for authenticating users. Not all workflows may be supported by the pinot UI implementation.
    *
    * @return workflow info for user authentication

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -26,6 +26,9 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public interface AccessControl {
+  String WORKFLOW_NONE = "NONE";
+  String WORKFLOW_BASIC = "BASIC";
+  String WORKFLOW_OAUTH2 = "OAUTH2";
 
   /**
    * Return whether the client has data access to the given table.
@@ -54,7 +57,7 @@ public interface AccessControl {
   }
 
   /**
-   * Return whether the client has permission to access the epdpoints with are not table level
+   * Return whether the client has permission to access the endpoints with are not table level
    *
    * @param accessType type of the access
    * @param httpHeaders HTTP headers
@@ -63,5 +66,33 @@ public interface AccessControl {
    */
   default boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
     return true;
+  }
+
+  /**
+   * Return workflow info for authenticating users. Not all workflows may be supported by the pinot UI implementation.
+   *
+   * @return workflow info for user authentication
+   */
+  default AuthWorkflowInfo getAuthWorkflowInfo() {
+    return new AuthWorkflowInfo(WORKFLOW_NONE);
+  }
+
+  /**
+   * Container for authentication workflow info. May be extended by implementations.
+   */
+  class AuthWorkflowInfo {
+    String workflow;
+
+    public AuthWorkflowInfo(String workflow) {
+      this.workflow = workflow;
+    }
+
+    public String getWorkflow() {
+      return workflow;
+    }
+
+    public void setWorkflow(String workflow) {
+      this.workflow = workflow;
+    }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -78,7 +78,11 @@ public interface AccessControl {
   }
 
   /**
-   * Container for authentication workflow info. May be extended by implementations.
+   * Container for authentication workflow info for the Pinot UI. May be extended by implementations.
+   *
+   * Auth workflow info hold any configuration necessary to execute a UI workflow. We currently foresee supporting NONE
+   * (auth disabled), BASIC (basic auth with username and password), and OAUTH2 (token-based workflow via external
+   * issuer)
    */
   class AuthWorkflowInfo {
     String workflow;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -28,7 +28,6 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 public interface AccessControl {
   String WORKFLOW_NONE = "NONE";
   String WORKFLOW_BASIC = "BASIC";
-  String WORKFLOW_OAUTH2 = "OAUTH2";
 
   /**
    * Return whether the client has data access to the given table.
@@ -81,8 +80,7 @@ public interface AccessControl {
    * Container for authentication workflow info for the Pinot UI. May be extended by implementations.
    *
    * Auth workflow info hold any configuration necessary to execute a UI workflow. We currently foresee supporting NONE
-   * (auth disabled), BASIC (basic auth with username and password), and OAUTH2 (token-based workflow via external
-   * issuer)
+   * (auth disabled) and BASIC (basic auth with username and password)
    */
   class AuthWorkflowInfo {
     String workflow;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlFactory.java
@@ -20,11 +20,15 @@ package org.apache.pinot.controller.api.access;
 
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public interface AccessControlFactory {
+  default void init(PinotConfiguration pinotConfiguration) {
+    // left blank
+  }
 
   AccessControl create();
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControlUtils.java
@@ -19,10 +19,8 @@
 
 package org.apache.pinot.controller.api.access;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.controller.api.resources.ControllerApplicationException;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -74,25 +72,25 @@ public class AccessControlUtils {
    */
   public void validatePermission(Optional<String> tableNameOpt, AccessType accessType, HttpHeaders httpHeaders,
       String endpointUrl, AccessControl accessControl) {
-      boolean hasPermission;
-      String accessTypeToEndpointMsg =
-          String.format("access type '%s' to the endpoint '%s'", accessType, endpointUrl) + tableNameOpt
-              .map(name -> String.format(" for table '%s'", name)).orElse("");
-      try {
-        if (tableNameOpt.isPresent()) {
-          String rawTableName = TableNameBuilder.extractRawTableName(tableNameOpt.get());
-          hasPermission = accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl);
-        } else {
-          hasPermission = accessControl.hasAccess(accessType, httpHeaders, endpointUrl);
-        }
-      } catch (Exception e) {
-        throw new ControllerApplicationException(LOGGER,
-            "Caught exception while validating permission for " + accessTypeToEndpointMsg,
-            Response.Status.INTERNAL_SERVER_ERROR, e);
+    boolean hasPermission;
+    String accessTypeToEndpointMsg =
+        String.format("access type '%s' to the endpoint '%s'", accessType, endpointUrl) + tableNameOpt
+            .map(name -> String.format(" for table '%s'", name)).orElse("");
+    try {
+      if (tableNameOpt.isPresent()) {
+        String rawTableName = TableNameBuilder.extractRawTableName(tableNameOpt.get());
+        hasPermission = accessControl.hasAccess(rawTableName, accessType, httpHeaders, endpointUrl);
+      } else {
+        hasPermission = accessControl.hasAccess(accessType, httpHeaders, endpointUrl);
       }
-      if (!hasPermission) {
-        throw new ControllerApplicationException(LOGGER, "Permission is denied for " + accessTypeToEndpointMsg,
-            Response.Status.FORBIDDEN);
-      }
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          "Caught exception while validating permission for " + accessTypeToEndpointMsg,
+          Response.Status.INTERNAL_SERVER_ERROR, e);
     }
+    if (!hasPermission) {
+      throw new ControllerApplicationException(LOGGER, "Permission is denied for " + accessTypeToEndpointMsg,
+          Response.Status.FORBIDDEN);
+    }
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -25,6 +25,9 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Provider;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
@@ -57,24 +60,43 @@ public class AuthenticationFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext)
       throws IOException {
-    // check if authentication is required
     Method endpointMethod = _resourceInfo.getResourceMethod();
-    if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
-      // Perform authentication:
-      // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
-      // followings:
-      //     - "tableName",
-      //     - "tableNameWithType", or
-      //     - "schemaName"
-      // If table name is not available, it means the endpoint is not a table-level endpoint.
-      AccessControlUtils accessControlUtils = new AccessControlUtils();
-      AccessType accessType = endpointMethod.getAnnotation(Authenticate.class).value();
-      String endpointUrl = _requestProvider.get().getRequestURL().toString();
-      UriInfo uriInfo = requestContext.getUriInfo();
-      Optional<String> tableName = extractTableName(uriInfo.getPathParameters(), uriInfo.getQueryParameters());
-      accessControlUtils
-          .validatePermission(tableName, accessType, _httpHeaders, endpointUrl, _accessControlFactory.create());
+    AccessControl accessControl = _accessControlFactory.create();
+
+    // check if authentication is required
+    if (accessControl.protectAnnotatedOnly() && !endpointMethod.isAnnotationPresent(Authenticate.class)) {
+      return;
     }
+
+    String endpointUrl = _requestProvider.get().getRequestURL().toString();
+    UriInfo uriInfo = requestContext.getUriInfo();
+
+    // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
+    // followings:
+    //     - "tableName",
+    //     - "tableNameWithType", or
+    //     - "schemaName"
+    // If table name is not available, it means the endpoint is not a table-level endpoint.
+    Optional<String> tableName = extractTableName(uriInfo.getPathParameters(), uriInfo.getQueryParameters());
+
+    // default access type
+    AccessType accessType = AccessType.READ;
+
+    if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
+      accessType = endpointMethod.getAnnotation(Authenticate.class).value();
+
+    } else if (accessControl.protectAnnotatedOnly()) {
+      // heuristically infer access type via javax.ws.rs annotations
+      if (endpointMethod.getAnnotation(POST.class) != null) {
+        accessType = AccessType.CREATE;
+      } else if (endpointMethod.getAnnotation(PUT.class) != null) {
+        accessType = AccessType.UPDATE;
+      } else if (endpointMethod.getAnnotation(DELETE.class) != null) {
+        accessType = AccessType.DELETE;
+      }
+    }
+
+    new AccessControlUtils().validatePermission(tableName, accessType, _httpHeaders, endpointUrl, accessControl);
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -62,14 +62,18 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       throws IOException {
     Method endpointMethod = _resourceInfo.getResourceMethod();
     AccessControl accessControl = _accessControlFactory.create();
+    String endpointUrl = _requestProvider.get().getRequestURL().toString();
+    UriInfo uriInfo = requestContext.getUriInfo();
+
+    // exclude "/auth" endpoints
+    if (endpointUrl.endsWith("/auth/info") || endpointUrl.endsWith("/auth/verify")) {
+      return;
+    }
 
     // check if authentication is required
     if (accessControl.protectAnnotatedOnly() && !endpointMethod.isAnnotationPresent(Authenticate.class)) {
       return;
     }
-
-    String endpointUrl = _requestProvider.get().getRequestURL().toString();
-    UriInfo uriInfo = requestContext.getUriInfo();
 
     // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
     // followings:

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+/**
+ * Basic Authentication based on http headers. Configured via the "controller.admin.access.control" family of properties.
+ *
+ * <pre>
+ *     Example:
+ *     controller.admin.access.control.principals=admin123,user456
+ *     controller.admin.access.control.principals.admin123.password=verysecret
+ *     controller.admin.access.control.principals.user456.password=kindasecret
+ *     controller.admin.access.control.principals.user456.tables=stuff,lessImportantStuff
+ *     controller.admin.access.control.principals.user456.permissions=read,update
+ * </pre>
+ */
+public class BasicAuthAccessControlFactory implements AccessControlFactory {
+  private static final String PREFIX = "controller.admin.access.control.principals";
+  private static final String PASSWORD = "password";
+  private static final String PERMISSIONS = "permissions";
+  private static final String TABLES = "tables";
+  private static final String ALL = "*";
+
+  private static final String HEADER_AUTHORIZATION = "Authorization";
+
+  private AccessControl _accessControl;
+
+  public void init(PinotConfiguration configuration) {
+    String principalNames = configuration.getProperty(PREFIX);
+    Preconditions.checkArgument(StringUtils.isNotBlank(principalNames), "must provide principals");
+
+    List<BasicAuthPrincipal> principals = Arrays.stream(principalNames.split(",")).map(rawName -> {
+      String name = rawName.trim();
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "%s is not a valid name", name);
+
+      String password = configuration.getProperty(String.format("%s.%s.%s", PREFIX, name, PASSWORD));
+      Preconditions.checkArgument(StringUtils.isNotBlank(password), "must provide a password for %s", name);
+
+      Set<String> tables = new HashSet<>();
+      String tableNames = configuration.getProperty(String.format("%s.%s.%s", PREFIX, name, TABLES));
+      if (StringUtils.isNotBlank(tableNames) && !ALL.equals(tableNames)) {
+        tables = Arrays.stream(tableNames.split(",")).map(String::trim).collect(Collectors.toSet());
+      }
+
+      Set<AccessType> permissions = new HashSet<>();
+      String permissionNames = configuration.getProperty(String.format("%s.%s.%s", PREFIX, name, PERMISSIONS));
+      if (StringUtils.isNotBlank(permissionNames) && !ALL.equals(tableNames)) {
+        permissions = Arrays.stream(permissionNames.split(",")).map(String::trim).map(String::toUpperCase)
+                .map(AccessType::valueOf).collect(Collectors.toSet());
+      }
+
+      return new BasicAuthPrincipal(name, toToken(name, password), tables, permissions);
+    }).collect(Collectors.toList());
+
+    _accessControl = new BasicAuthAccessControl(principals);
+  }
+
+  @Override
+  public AccessControl create() {
+    return _accessControl;
+  }
+
+  /**
+   * Access Control using header-based basic http authentication
+   */
+  private static class BasicAuthAccessControl implements AccessControl {
+    private final Map<String, BasicAuthPrincipal> _principals;
+
+    public BasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
+      this._principals = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
+    }
+
+    @Override
+    public boolean hasDataAccess(HttpHeaders httpHeaders, String tableName) {
+      return getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
+    }
+
+    @Override
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      return getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName) && p.hasPermission(accessType)).isPresent();
+    }
+
+    @Override
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      return getPrincipal(httpHeaders).isPresent();
+    }
+
+    private Optional<BasicAuthPrincipal> getPrincipal(HttpHeaders headers) {
+      return headers.getRequestHeader(HEADER_AUTHORIZATION).stream().map(BasicAuthAccessControlFactory::normalizeToken)
+              .map(_principals::get).filter(Objects::nonNull).findFirst();
+    }
+  }
+
+  /**
+   * Container object for basic auth principal
+   */
+  private static class BasicAuthPrincipal {
+    private final String _name;
+    private final String _token;
+    private final Set<String> _tables;
+    private final Set<AccessType> _permissions;
+
+    public BasicAuthPrincipal(String name, String token, Set<String> tables, Set<AccessType> permissions) {
+      this._name = name;
+      this._token = token;
+      this._tables = tables;
+      this._permissions = permissions;
+    }
+
+    public String getName() {
+      return _name;
+    }
+
+    public String getToken() {
+      return _token;
+    }
+
+    public boolean hasTable(String tableName) {
+      return _tables.isEmpty() || _tables.contains(tableName);
+    }
+
+    public boolean hasPermission(AccessType accessType) {
+      return _permissions.isEmpty() || _permissions.contains(accessType);
+    }
+  }
+
+  private static String toToken(String name, String password) {
+    String identifier = String.format("%s:%s", name, password);
+    return normalizeToken(String.format("Basic %s", Base64.getEncoder().encodeToString(identifier.getBytes())));
+  }
+
+  private static String normalizeToken(String token) {
+    if (token == null) {
+      return null;
+    }
+    return token.trim().replace("=", "");
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -70,25 +70,31 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
 
     @Override
     public boolean hasDataAccess(HttpHeaders httpHeaders, String tableName) {
+      // TODO remove debug
       Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
       boolean response = getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
+
       return getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
     }
 
     @Override
     public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      // TODO remove debug
       Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
       boolean response =
           getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType)))
               .isPresent();
+
       return getPrincipal(httpHeaders)
           .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
     public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      // TODO remove debug
       Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
       boolean response = getPrincipal(httpHeaders).isPresent();
+
       return getPrincipal(httpHeaders).isPresent();
     }
 
@@ -104,6 +110,11 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
 
       return authHeaders.stream().map(BasicAuthUtils::normalizeBase64Token).map(_principals::get)
           .filter(Objects::nonNull).findFirst();
+    }
+
+    @Override
+    public AuthWorkflowInfo getAuthWorkflowInfo() {
+      return new AuthWorkflowInfo(AccessControl.WORKFLOW_BASIC);
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -62,10 +62,10 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
    * Access Control using header-based basic http authentication
    */
   private static class BasicAuthAccessControl implements AccessControl {
-    private final Map<String, BasicAuthPrincipal> _principals;
+    private final Map<String, BasicAuthPrincipal> _token2principal;
 
     public BasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
-      this._principals = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
+      this._token2principal = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
     }
 
     @Override
@@ -94,7 +94,7 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
 
-      return authHeaders.stream().map(BasicAuthUtils::normalizeBase64Token).map(_principals::get)
+      return authHeaders.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get)
           .filter(Objects::nonNull).findFirst();
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -70,31 +70,17 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
 
     @Override
     public boolean hasDataAccess(HttpHeaders httpHeaders, String tableName) {
-      // TODO remove debug
-      Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
-      boolean response = getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
-
       return getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
     }
 
     @Override
     public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
-      // TODO remove debug
-      Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
-      boolean response =
-          getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType)))
-              .isPresent();
-
       return getPrincipal(httpHeaders)
           .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
     public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
-      // TODO remove debug
-      Optional<BasicAuthPrincipal> principal = getPrincipal(httpHeaders);
-      boolean response = getPrincipal(httpHeaders).isPresent();
-
       return getPrincipal(httpHeaders).isPresent();
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -69,6 +69,11 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
     }
 
     @Override
+    public boolean protectAnnotatedOnly() {
+      return false;
+    }
+
+    @Override
     public boolean hasDataAccess(HttpHeaders httpHeaders, String tableName) {
       return getPrincipal(httpHeaders).filter(p -> p.hasTable(tableName)).isPresent();
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -51,7 +51,7 @@ public class PinotControllerAuthResource {
   @Path("auth/verify")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Check whether authentication is enabled")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Verification result"), @ApiResponse(code = 500, message = "Verification error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Verification result provided"), @ApiResponse(code = 500, message = "Verification error")})
   public boolean verify(@ApiParam(value = "Table name without type") @QueryParam("tableName") String tableName,
       @ApiParam(value = "API access type") @QueryParam("accessType") AccessType accessType,
       @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {
@@ -68,7 +68,7 @@ public class PinotControllerAuthResource {
   @Path("auth/info")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Retrieve auth workflow info")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Allowed")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Auth workflow info provided")})
   public AccessControl.AuthWorkflowInfo info() {
     return _accessControlFactory.create().getAuthWorkflowInfo();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -75,7 +75,7 @@ public class PinotControllerAuthResource {
 
   /**
    * Provide the auth workflow configuration for the Pinot UI to perform user authentication. Currently supports NONE
-   * (no auth), BASIC (basic auth with username and password), and OAUTH2 (token-based via external issuer)
+   * (no auth) and BASIC (basic auth with username and password)
    *
    * @return auth workflow info/configuration
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -51,7 +51,7 @@ public class PinotControllerAuthResource {
   @Path("auth/verify")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Check whether authentication is enabled")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Allowed"), @ApiResponse(code = 403, message = "Forbidden"), @ApiResponse(code = 500, message = "Verification error")})
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Verification result"), @ApiResponse(code = 500, message = "Verification error")})
   public boolean verify(@ApiParam(value = "Table name without type") @QueryParam("tableName") String tableName,
       @ApiParam(value = "API access type") @QueryParam("accessType") AccessType accessType,
       @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.controller.api.access.AccessControl;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
+
+
+@Api(tags = "Auth")
+@Path("/")
+public class PinotControllerAuthResource {
+
+  @Inject
+  private AccessControlFactory _accessControlFactory;
+
+  @Context
+  HttpHeaders _httpHeaders;
+
+  @GET
+  @Path("auth/verify")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Check whether authentication is enabled")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Allowed"), @ApiResponse(code = 403, message = "Forbidden"), @ApiResponse(code = 500, message = "Verification error")})
+  public boolean verify(@ApiParam(value = "Table name without type") @QueryParam("tableName") String tableName,
+      @ApiParam(value = "API access type") @QueryParam("accessType") AccessType accessType,
+      @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {
+    AccessControl accessControl = _accessControlFactory.create();
+
+    if (StringUtils.isBlank(tableName)) {
+      return accessControl.hasAccess(accessType, _httpHeaders, endpointUrl);
+    }
+
+    return accessControl.hasAccess(tableName, accessType, _httpHeaders, endpointUrl);
+  }
+
+  @GET
+  @Path("auth/info")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Retrieve auth workflow info")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Allowed")})
+  public AccessControl.AuthWorkflowInfo info() {
+    return _accessControlFactory.create().getAuthWorkflowInfo();
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -47,6 +47,15 @@ public class PinotControllerAuthResource {
   @Context
   HttpHeaders _httpHeaders;
 
+  /**
+   * Verify a token is both authenticated and authorized to perform an operation.
+   *
+   * @param tableName table name (optional)
+   * @param accessType access type (optional)
+   * @param endpointUrl endpoint url (optional)
+   *
+   * @return {@code true} if authenticated and authorized, {@code false} otherwise
+   */
   @GET
   @Path("auth/verify")
   @Produces(MediaType.APPLICATION_JSON)
@@ -64,6 +73,12 @@ public class PinotControllerAuthResource {
     return accessControl.hasAccess(tableName, accessType, _httpHeaders, endpointUrl);
   }
 
+  /**
+   * Provide the auth workflow configuration for the Pinot UI to perform user authentication. Currently supports NONE
+   * (no auth), BASIC (basic auth with username and password), and OAUTH2 (token-based via external issuer)
+   *
+   * @return auth workflow info/configuration
+   */
   @GET
   @Path("auth/info")
   @Produces(MediaType.APPLICATION_JSON)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -36,6 +37,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
@@ -116,8 +118,7 @@ public class PinotIngestionRestletResource {
       + "\n Example usage (query params need encoding):" + "\n```"
       + "\ncurl -X POST -F file=@data.json -H \"Content-Type: multipart/form-data\" \"http://localhost:9000/ingestFromFile?tableNameWithType=foo_OFFLINE&"
       + "\nbatchConfigMapStr={" + "\n  \"inputFormat\":\"csv\"," + "\n  \"recordReader.prop.delimiter\":\"|\""
-      + "\n}\" "
-      + "\n```")
+      + "\n}\" " + "\n```")
   public void ingestFromFile(
       @ApiParam(value = "Name of the table to upload the file to", required = true) @QueryParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Batch config Map as json string. Must pass inputFormat, and optionally record reader properties. e.g. {\"inputFormat\":\"json\"}", required = true) @QueryParam("batchConfigMapStr") String batchConfigMapStr,
@@ -191,8 +192,21 @@ public class PinotIngestionRestletResource {
     Schema schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
 
     FileIngestionHelper fileIngestionHelper =
-        new FileIngestionHelper(tableConfig, schema, batchConfig, _controllerConf.getControllerHost(),
-            Integer.parseInt(_controllerConf.getControllerPort()), new File(_controllerConf.getDataDir(), UPLOAD_DIR));
+        new FileIngestionHelper(tableConfig, schema, batchConfig, getControllerUri(),
+            new File(_controllerConf.getDataDir(), UPLOAD_DIR), getAuthToken());
     return fileIngestionHelper.buildSegmentAndPush(payload);
+  }
+
+  private String getAuthToken() {
+    return _controllerConf
+        .getProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY + ".auth.token");
+  }
+
+  private URI getControllerUri() {
+    try {
+      return new URI(_controllerConf.generateVipUrl());
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException("Controller VIP uri is invalid", e);
+    }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -209,15 +209,16 @@ public class PinotQueryResource {
     String protocol = _controllerConf.getControllerBrokerProtocol();
     int port = _controllerConf.getControllerBrokerPortOverride() > 0 ? _controllerConf.getControllerBrokerPortOverride()
         : Integer.parseInt(instanceConfig.getPort());
-    String url = getQueryURL(protocol, hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1),
-        String.valueOf(port), querySyntax);
+    String url =
+        getQueryURL(protocol, hostNameWithPrefix.substring(hostNameWithPrefix.indexOf("_") + 1), String.valueOf(port),
+            querySyntax);
     ObjectNode requestJson = getRequestJson(query, traceEnabled, queryOptions, querySyntax);
 
     // forward client-supplied headers
-    Map<String, String> headers = httpHeaders.getRequestHeaders().entrySet().stream()
-        .filter(entry -> !entry.getValue().isEmpty())
-        .map(entry -> Pair.of(entry.getKey(), entry.getValue().get(0)))
-        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    Map<String, String> headers =
+        httpHeaders.getRequestHeaders().entrySet().stream().filter(entry -> !entry.getValue().isEmpty())
+            .map(entry -> Pair.of(entry.getKey(), entry.getValue().get(0)))
+            .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
 
     return sendRequestRaw(url, query, requestJson, headers);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -50,18 +50,18 @@ public class FileIngestionHelper {
   private final TableConfig _tableConfig;
   private final Schema _schema;
   private final BatchConfig _batchConfig;
-  private final String _controllerHost;
-  private final int _controllerPort;
+  private final URI _controllerUri;
   private final File _uploadDir;
+  private final String _authToken;
 
-  public FileIngestionHelper(TableConfig tableConfig, Schema schema, BatchConfig batchConfig, String controllerHost,
-      int controllerPort, File uploadDir) {
+  public FileIngestionHelper(TableConfig tableConfig, Schema schema, BatchConfig batchConfig, URI controllerUri,
+      File uploadDir, String authToken) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfig = batchConfig;
-    _controllerHost = controllerHost;
-    _controllerPort = controllerPort;
+    _controllerUri = controllerUri;
     _uploadDir = uploadDir;
+    _authToken = authToken;
   }
 
   /**
@@ -106,8 +106,8 @@ public class FileIngestionHelper {
           new File(segmentTarDir, segmentName + org.apache.pinot.spi.ingestion.batch.spec.Constants.TAR_GZ_FILE_EXT);
       TarGzCompressionUtils.createTarGzFile(new File(outputDir, segmentName), segmentTarFile);
       FileIngestionUtils
-          .uploadSegment(tableNameWithType, Lists.newArrayList(segmentTarFile), _controllerHost, _controllerPort);
-      LOGGER.info("Uploaded tar: {} to {}:{}", segmentTarFile.getAbsolutePath(), _controllerHost, _controllerPort);
+          .uploadSegment(tableNameWithType, Lists.newArrayList(segmentTarFile), _controllerUri, _authToken);
+      LOGGER.info("Uploaded tar: {} to {}", segmentTarFile.getAbsolutePath(), _controllerUri);
 
       return new SuccessResponse(
           "Successfully ingested file into table: " + tableNameWithType + " as segment: " + segmentName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -601,7 +601,7 @@ public abstract class ControllerTest {
   }
 
   public static String sendPostRequest(String urlString, String payload) throws IOException {
-    return sendPostRequest(urlString, payload, Collections.EMPTY_MAP);
+    return sendPostRequest(urlString, payload, Collections.emptyMap());
   }
 
   public static String sendPostRequest(String urlString, String payload, Map<String, String> headers)
@@ -627,9 +627,18 @@ public abstract class ControllerTest {
   }
 
   public static String sendPutRequest(String urlString, String payload) throws IOException {
+    return sendPutRequest(urlString, payload, Collections.emptyMap());
+  }
+
+  public static String sendPutRequest(String urlString, String payload, Map<String, String> headers) throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
     httpConnection.setDoOutput(true);
     httpConnection.setRequestMethod("PUT");
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        httpConnection.setRequestProperty(key, headers.get(key));
+      }
+    }
 
     try (BufferedWriter writer = new BufferedWriter(
         new OutputStreamWriter(httpConnection.getOutputStream(), StandardCharsets.UTF_8))) {
@@ -640,6 +649,7 @@ public abstract class ControllerTest {
     return constructResponse(httpConnection.getInputStream());
   }
 
+  // NOTE: does not support headers
   public static String sendPutRequest(String urlString) throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
     httpConnection.setDoOutput(true);
@@ -648,10 +658,18 @@ public abstract class ControllerTest {
   }
 
   public static String sendDeleteRequest(String urlString) throws IOException {
+    return sendDeleteRequest(urlString, Collections.emptyMap());
+  }
+
+  public static String sendDeleteRequest(String urlString, Map<String, String> headers) throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
     httpConnection.setRequestMethod("DELETE");
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        httpConnection.setRequestProperty(key, headers.get(key));
+      }
+    }
     httpConnection.connect();
-
     return constructResponse(httpConnection.getInputStream());
   }
 
@@ -667,21 +685,39 @@ public abstract class ControllerTest {
   }
 
   public static PostMethod sendMultipartPostRequest(String url, String body) throws IOException {
+    return sendMultipartPostRequest(url, body, Collections.emptyMap());
+  }
+
+  public static PostMethod sendMultipartPostRequest(String url, String body, Map<String, String> headers) throws IOException {
     HttpClient httpClient = new HttpClient();
     PostMethod postMethod = new PostMethod(url);
     // our handlers ignore key...so we can put anything here
     Part[] parts = {new StringPart("body", body)};
     postMethod.setRequestEntity(new MultipartRequestEntity(parts, postMethod.getParams()));
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        postMethod.addRequestHeader(key, headers.get(key));
+      }
+    }
     httpClient.executeMethod(postMethod);
     return postMethod;
   }
 
   public static PutMethod sendMultipartPutRequest(String url, String body) throws IOException {
+    return sendMultipartPutRequest(url, body, Collections.emptyMap());
+  }
+
+  public static PutMethod sendMultipartPutRequest(String url, String body, Map<String, String> headers) throws IOException {
     HttpClient httpClient = new HttpClient();
     PutMethod putMethod = new PutMethod(url);
     // our handlers ignore key...so we can put anything here
     Part[] parts = {new StringPart("body", body)};
     putMethod.setRequestEntity(new MultipartRequestEntity(parts, putMethod.getParams()));
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        putMethod.addRequestHeader(key, headers.get(key));
+      }
+    }
     httpClient.executeMethod(putMethod);
     return putMethod;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -584,6 +584,18 @@ public abstract class ControllerTest {
     return constructResponse(new URL(urlString).openStream());
   }
 
+  public static String sendGetRequest(String urlString, Map<String, String> headers) throws IOException {
+    HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
+    httpConnection.setRequestMethod("GET");
+    if (headers != null) {
+      for (String key : headers.keySet()) {
+        httpConnection.setRequestProperty(key, headers.get(key));
+      }
+    }
+
+    return constructResponse(httpConnection.getInputStream());
+  }
+
   public static String sendGetRequestRaw(String urlString) throws IOException {
     return IOUtils.toString(new URL(urlString).openStream());
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.auth;
 
 import java.util.Set;

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
@@ -1,0 +1,37 @@
+package org.apache.pinot.core.auth;
+
+import java.util.Set;
+
+
+/**
+ * Container object for basic auth principal
+ */
+public class BasicAuthPrincipal {
+  private final String _name;
+  private final String _token;
+  private final Set<String> _tables;
+  private final Set<String> _permissions;
+
+  public BasicAuthPrincipal(String name, String token, Set<String> tables, Set<String> permissions) {
+    this._name = name;
+    this._token = token;
+    this._tables = tables;
+    this._permissions = permissions;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public String getToken() {
+    return _token;
+  }
+
+  public boolean hasTable(String tableName) {
+    return _tables.isEmpty() || _tables.contains(tableName);
+  }
+
+  public boolean hasPermission(String permission) {
+    return _permissions.isEmpty() || _permissions.contains(permission);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
@@ -1,0 +1,100 @@
+package org.apache.pinot.core.auth;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Utility for configuring basic auth and parsing related http tokens
+ */
+public final class BasicAuthUtils {
+  private static final String PASSWORD = "password";
+  private static final String PERMISSIONS = "permissions";
+  private static final String TABLES = "tables";
+  private static final String ALL = "*";
+
+  private BasicAuthUtils() {
+    // left blank
+  }
+
+  /**
+   * Parse a pinot configuration namespace for access control settings, e.g. "controller.admin.access.control.principals".
+   *
+   * <pre>
+   *     Example:
+   *     my.prefix.access.control.principals=admin123,user456
+   *     my.prefix.access.control.principals.admin123.password=verysecret
+   *     my.prefix.access.control.principals.user456.password=kindasecret
+   *     my.prefix.access.control.principals.user456.tables=stuff,lessImportantStuff
+   *     my.prefix.access.control.principals.user456.permissions=read,update
+   * </pre>
+   *
+   * @param configuration pinot configuration
+   * @param prefix configuration namespace
+   * @return list of BasicAuthPrincipals
+   */
+  public static List<BasicAuthPrincipal> extractBasicAuthPrincipals(PinotConfiguration configuration, String prefix) {
+    String principalNames = configuration.getProperty(prefix);
+    Preconditions.checkArgument(StringUtils.isNotBlank(principalNames), "must provide principals");
+
+    return Arrays.stream(principalNames.split(",")).map(rawName -> {
+      String name = rawName.trim();
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "%s is not a valid name", name);
+
+      String password = configuration.getProperty(String.format("%s.%s.%s", prefix, name, PASSWORD));
+      Preconditions.checkArgument(StringUtils.isNotBlank(password), "must provide a password for %s", name);
+
+      Set<String> tables = extractSet(configuration, String.format("%s.%s.%s", prefix, name, TABLES));
+      Set<String> permissions = extractSet(configuration, String.format("%s.%s.%s", prefix, name, PERMISSIONS));
+
+      return new BasicAuthPrincipal(name, toBasicAuthToken(name, password), tables, permissions);
+    }).collect(Collectors.toList());
+  }
+
+  private static Set<String> extractSet(PinotConfiguration configuration, String key) {
+    String input = configuration.getProperty(key);
+    if (StringUtils.isNotBlank(input) && !ALL.equals(input)) {
+      return Arrays.stream(input.split(",")).map(String::trim).collect(Collectors.toSet());
+    }
+    return Collections.emptySet();
+  }
+
+  /**
+   * Convert a pair of name and password into a http header-compliant base64 encoded token
+   *
+   * @param name user name
+   * @param password password
+   * @return base64 encoded basic auth token
+   */
+  @Nullable
+  public static String toBasicAuthToken(String name, String password) {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    String identifier = String.format("%s:%s", name, password);
+    return normalizeBase64Token(String.format("Basic %s", Base64.getEncoder().encodeToString(identifier.getBytes())));
+  }
+
+  /**
+   * Normalize a base64 encoded auth token by stripping redundant padding (spaces, '=')
+   *
+   * @param token base64 encoded auth token
+   * @return normalized auth token
+   */
+  @Nullable
+  public static String normalizeBase64Token(String token) {
+    if (token == null) {
+      return null;
+    }
+    return StringUtils.remove(token.trim(), '=');
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
@@ -1,10 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.auth;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -29,6 +29,7 @@ public class MinionConstants {
   public static final String DOWNLOAD_URL_KEY = "downloadURL";
   public static final String UPLOAD_URL_KEY = "uploadURL";
   public static final String URL_SEPARATOR = ",";
+  public static final String AUTH_TOKEN = "authToken";
 
   /**
    * When minion downloads a segment to do work on, we will save that CRC. We will send that to the controller in an

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -55,6 +55,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected File _indexDir;
   protected Logger _logger;
   protected HelixManager _helixManager;
+  protected String _authToken;
 
   @Override
   public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
@@ -66,6 +67,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = propertyStore;
     _serverMetrics = serverMetrics;
     _helixManager = helixManager;
+    _authToken = tableDataManagerConfig.getAuthToken();
 
     _tableNameWithType = tableDataManagerConfig.getTableName();
     _tableDataDir = tableDataManagerConfig.getDataDir();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -50,4 +50,6 @@ public interface InstanceDataManagerConfig {
   boolean isDirectRealtimeOffHeapAllocation();
 
   int getMaxParallelSegmentBuilds();
+
+  String getAuthToken();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -36,6 +37,7 @@ public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
   private static final String TABLE_IS_DIMENSION = "isDimTable";
+  private static final String TABLE_DATA_MANGER_AUTH_TOKEN = "authToken";
 
   private final Configuration _tableDataManagerConfig;
 
@@ -67,6 +69,10 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getBoolean(TABLE_IS_DIMENSION);
   }
 
+  public String getAuthToken() {
+    return _tableDataManagerConfig.getString(TABLE_DATA_MANGER_AUTH_TOKEN);
+  }
+
   public static TableDataManagerConfig getDefaultHelixTableDataManagerConfig(
       @Nonnull InstanceDataManagerConfig instanceDataManagerConfig, @Nonnull String tableNameWithType) {
     Configuration defaultConfig = new PropertiesConfiguration();
@@ -77,14 +83,16 @@ public class TableDataManagerConfig {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     Preconditions.checkNotNull(tableType);
     defaultConfig.addProperty(TABLE_DATA_MANAGER_TYPE, tableType.name());
+    defaultConfig.addProperty(TABLE_DATA_MANGER_AUTH_TOKEN, instanceDataManagerConfig.getAuthToken());
 
     return new TableDataManagerConfig(defaultConfig);
   }
 
-  public void overrideConfigs(@Nonnull TableConfig tableConfig) {
+  public void overrideConfigs(@Nonnull TableConfig tableConfig, String authToken) {
     // Override table level configs
 
     _tableDataManagerConfig.addProperty(TABLE_IS_DIMENSION, tableConfig.isDimTable());
+    _tableDataManagerConfig.addProperty(TABLE_DATA_MANGER_AUTH_TOKEN, authToken);
 
     // If we wish to override some table level configs using table config, override them here
     // Note: the configs in TableDataManagerConfig is immutable once the table is created, which mean it will not pick

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -63,7 +63,8 @@ public class SegmentCommitterFactory {
 
     segmentUploader = new Server2ControllerSegmentUploader(LOGGER, _protocolHandler.getFileUploadDownloadClient(),
         _protocolHandler.getSegmentCommitUploadURL(params, controllerVipUrl), params.getSegmentName(),
-        ServerSegmentCompletionProtocolHandler.getSegmentUploadRequestTimeoutMs(), _serverMetrics);
+        ServerSegmentCompletionProtocolHandler.getSegmentUploadRequestTimeoutMs(), _serverMetrics,
+        _protocolHandler.getAuthToken());
     return new SplitSegmentCommitter(LOGGER, _protocolHandler, params, segmentUploader);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/Server2ControllerSegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/Server2ControllerSegmentUploader.java
@@ -39,10 +39,11 @@ public class Server2ControllerSegmentUploader implements SegmentUploader {
   private final String _segmentName;
   private final int _segmentUploadRequestTimeoutMs;
   private final ServerMetrics _serverMetrics;
+  private final String _authToken;
 
   public Server2ControllerSegmentUploader(Logger segmentLogger, FileUploadDownloadClient fileUploadDownloadClient,
       String controllerSegmentUploadCommitUrl, String segmentName, int segmentUploadRequestTimeoutMs,
-      ServerMetrics serverMetrics)
+      ServerMetrics serverMetrics, String authToken)
       throws URISyntaxException {
     _segmentLogger = segmentLogger;
     _fileUploadDownloadClient = fileUploadDownloadClient;
@@ -50,10 +51,11 @@ public class Server2ControllerSegmentUploader implements SegmentUploader {
     _segmentName = segmentName;
     _segmentUploadRequestTimeoutMs = segmentUploadRequestTimeoutMs;
     _serverMetrics = serverMetrics;
+    _authToken = authToken;
   }
 
   @Override
-  public URI uploadSegment(File segmentFile,  LLCSegmentName segmentName) {
+  public URI uploadSegment(File segmentFile, LLCSegmentName segmentName) {
     SegmentCompletionProtocol.Response response = uploadSegmentToController(segmentFile);
     if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.UPLOAD_SUCCESS) {
       try {
@@ -69,8 +71,8 @@ public class Server2ControllerSegmentUploader implements SegmentUploader {
     SegmentCompletionProtocol.Response response;
     try {
       String responseStr = _fileUploadDownloadClient
-          .uploadSegment(_controllerSegmentUploadCommitUrl, _segmentName, segmentFile, null, null,
-              _segmentUploadRequestTimeoutMs).getResponse();
+          .uploadSegment(_controllerSegmentUploadCommitUrl, _segmentName, segmentFile,
+              FileUploadDownloadClient.makeAuthHeader(_authToken), null, _segmentUploadRequestTimeoutMs).getResponse();
       response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       _segmentLogger.info("Controller response {} for {}", response.toJsonString(), _controllerSegmentUploadCommitUrl);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -74,7 +74,7 @@ public class ServerSegmentCompletionProtocolHandler {
     }
     _segmentUploadRequestTimeoutMs = uploaderConfig
         .getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
-    _authToken = uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOAD_AUTH_TOKEN);
+    _authToken = uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN);
   }
 
   public ServerSegmentCompletionProtocolHandler(ServerMetrics serverMetrics, String tableNameWithType) {

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -44,6 +44,8 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.common.utils.CommonConstants.Server.SegmentCompletionProtocol.*;
+
 
 /**
  * A class that handles sending segment completion protocol requests to the controller and getting
@@ -58,6 +60,7 @@ public class ServerSegmentCompletionProtocolHandler {
   private static SSLContext _sslContext;
   private static Integer _controllerHttpsPort;
   private static int _segmentUploadRequestTimeoutMs;
+  private static String _authToken;
 
   private final FileUploadDownloadClient _fileUploadDownloadClient;
   private final ServerMetrics _serverMetrics;
@@ -69,8 +72,9 @@ public class ServerSegmentCompletionProtocolHandler {
       _sslContext = new ClientSSLContextGenerator(httpsConfig.subset(CommonConstants.PREFIX_OF_SSL_SUBSET)).generate();
       _controllerHttpsPort = httpsConfig.getProperty(CONFIG_OF_CONTROLLER_HTTPS_PORT, Integer.class);
     }
-    _segmentUploadRequestTimeoutMs =
-        uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
+    _segmentUploadRequestTimeoutMs = uploaderConfig
+        .getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
+    _authToken = uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOAD_AUTH_TOKEN);
   }
 
   public ServerSegmentCompletionProtocolHandler(ServerMetrics serverMetrics, String tableNameWithType) {
@@ -85,6 +89,10 @@ public class ServerSegmentCompletionProtocolHandler {
 
   public FileUploadDownloadClient getFileUploadDownloadClient() {
     return _fileUploadDownloadClient;
+  }
+
+  public String getAuthToken() {
+    return _authToken;
   }
 
   public SegmentCompletionProtocol.Response segmentCommitStart(SegmentCompletionProtocol.Request.Params params) {
@@ -146,10 +154,11 @@ public class ServerSegmentCompletionProtocolHandler {
       return SegmentCompletionProtocol.RESP_NOT_SENT;
     }
 
-    Server2ControllerSegmentUploader segmentUploader= null;
+    Server2ControllerSegmentUploader segmentUploader = null;
     try {
-      segmentUploader = new Server2ControllerSegmentUploader(LOGGER,
-          _fileUploadDownloadClient, url, params.getSegmentName(), _segmentUploadRequestTimeoutMs, _serverMetrics);
+      segmentUploader =
+          new Server2ControllerSegmentUploader(LOGGER, _fileUploadDownloadClient, url, params.getSegmentName(),
+              _segmentUploadRequestTimeoutMs, _serverMetrics, _authToken);
     } catch (URISyntaxException e) {
       LOGGER.error("Segment commit upload url error: ", e);
       return SegmentCompletionProtocol.RESP_NOT_SENT;
@@ -203,9 +212,9 @@ public class ServerSegmentCompletionProtocolHandler {
   private SegmentCompletionProtocol.Response sendRequest(String url) {
     SegmentCompletionProtocol.Response response;
     try {
-      String responseStr =
-          _fileUploadDownloadClient.sendSegmentCompletionProtocolRequest(new URI(url), DEFAULT_OTHER_REQUESTS_TIMEOUT)
-              .getResponse();
+      String responseStr = _fileUploadDownloadClient
+          .sendSegmentCompletionProtocolRequest(new URI(url), FileUploadDownloadClient.makeAuthHeader(_authToken), null,
+              DEFAULT_OTHER_REQUESTS_TIMEOUT).getResponse();
       response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {
@@ -228,7 +237,8 @@ public class ServerSegmentCompletionProtocolHandler {
     SegmentCompletionProtocol.Response response;
     try {
       String responseStr = _fileUploadDownloadClient
-          .uploadSegmentMetadataFiles(new URI(url), metadataFiles, _segmentUploadRequestTimeoutMs).getResponse();
+          .uploadSegmentMetadataFiles(new URI(url), metadataFiles, FileUploadDownloadClient.makeAuthHeader(_authToken),
+              null, _segmentUploadRequestTimeoutMs).getResponse();
       response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
       if (response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER)) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/Server2ControllerSegmentUploaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/Server2ControllerSegmentUploaderTest.java
@@ -91,7 +91,7 @@ public class Server2ControllerSegmentUploaderTest {
       throws URISyntaxException {
     Server2ControllerSegmentUploader uploader =
         new Server2ControllerSegmentUploader(_logger, _fileUploadDownloadClient, GOOD_CONTROLLER_VIP, "segmentName",
-            10000, mock(ServerMetrics.class));
+            10000, mock(ServerMetrics.class), null);
     URI segmentURI = uploader.uploadSegment(_file, _llcSegmentName);
     Assert.assertEquals(segmentURI.toString(), SEGMENT_LOCATION);
   }
@@ -101,7 +101,7 @@ public class Server2ControllerSegmentUploaderTest {
       throws URISyntaxException {
     Server2ControllerSegmentUploader uploader =
         new Server2ControllerSegmentUploader(_logger, _fileUploadDownloadClient, BAD_CONTROLLER_VIP, "segmentName",
-            10000, mock(ServerMetrics.class));
+            10000, mock(ServerMetrics.class), null);
     URI segmentURI = uploader.uploadSegment(_file, _llcSegmentName);
     Assert.assertNull(segmentURI);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -88,9 +88,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected final File _tarDir = new File(_tempDir, "tarDir");
   protected List<StreamDataServerStartable> _kafkaStarters;
 
-  private org.apache.pinot.client.Connection _pinotConnection;
-  private Connection _h2Connection;
-  private QueryGenerator _queryGenerator;
+  protected org.apache.pinot.client.Connection _pinotConnection;
+  protected Connection _h2Connection;
+  protected QueryGenerator _queryGenerator;
 
   /**
    * The following getters can be overridden to change default settings.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -37,24 +37,21 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_HEADER;
+import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_HEADER_USER;
+import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_TOKEN;
+
 
 /**
  * Integration test that provides example of {@link PinotTaskGenerator} and {@link PinotTaskExecutor} and tests simple
  * minion functionality.
  */
-public class BasicAuthClusterIntegrationTest extends ClusterTest {
+public class BasicAuthBatchIntegrationTest extends ClusterTest {
   private static final String BOOTSTRAP_DATA_DIR = "/examples/batch/baseballStats";
   private static final String SCHEMA_FILE = "baseballStats_schema.json";
   private static final String CONFIG_FILE = "baseballStats_offline_table_config.json";
   private static final String DATA_FILE = "baseballStats_data.csv";
   private static final String JOB_FILE = "ingestionJobSpec.yaml";
-
-  private static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
-  private static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ==";
-
-  private static final Map<String, String> AUTH_HEADER = Collections.singletonMap("Authorization", AUTH_TOKEN);
-  private static final Map<String, String> AUTH_HEADER_USER =
-      Collections.singletonMap("Authorization", AUTH_TOKEN_USER);
 
   @BeforeClass
   public void setUp()
@@ -78,45 +75,22 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
 
   @Override
   public Map<String, Object> getDefaultControllerConfiguration() {
-    Map<String, Object> properties = super.getDefaultControllerConfiguration();
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
-    properties.put("controller.admin.access.control.factory.class",
-        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
-    properties.put("controller.admin.access.control.principals", "admin, user");
-    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
-    properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user.tables", "userTableOnly");
-    properties.put("controller.admin.access.control.principals.user.permissions", "read");
-    return properties;
+    return BasicAuthTestUtils.addControllerConfiguration(super.getDefaultControllerConfiguration());
   }
 
   @Override
   protected PinotConfiguration getDefaultBrokerConfiguration() {
-    Map<String, Object> properties = super.getDefaultBrokerConfiguration().toMap();
-    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
-    properties.put("pinot.broker.access.control.principals", "admin, user");
-    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
-    properties.put("pinot.broker.access.control.principals.user.password", "secret");
-    properties.put("pinot.broker.access.control.principals.user.tables", "userTableOnly");
-    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
-    return new PinotConfiguration(properties);
+    return BasicAuthTestUtils.addBrokerConfiguration(super.getDefaultBrokerConfiguration().toMap());
   }
 
   @Override
   protected PinotConfiguration getDefaultServerConfiguration() {
-    Map<String, Object> properties = super.getDefaultServerConfiguration().toMap();
-    properties.put("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
-    properties.put("pinot.server.segment.upload.auth.token", AUTH_TOKEN);
-    properties.put("pinot.server.instance.auth.token", AUTH_TOKEN);
-    return new PinotConfiguration(properties);
+    return BasicAuthTestUtils.addServerConfiguration(super.getDefaultServerConfiguration().toMap());
   }
 
   @Override
   protected PinotConfiguration getDefaultMinionConfiguration() {
-    Map<String, Object> properties = super.getDefaultMinionConfiguration().toMap();
-    properties.put("segment.fetcher.auth.token", AUTH_TOKEN);
-    properties.put("task.auth.token", AUTH_TOKEN);
-    return new PinotConfiguration(properties);
+    return BasicAuthTestUtils.addMinionConfiguration(super.getDefaultMinionConfiguration().toMap());
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -120,6 +121,18 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   }
 
   @Test
+  public void testControllerGetTablesNoAuth()
+      throws Exception {
+    try {
+      // NOTE: the endpoint is protected implicitly (without annotation) by BasicAuthAccessControlFactory
+      sendGetRequest("http://localhost:18998/tables");
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().contains("HTTP"));
+      Assert.assertTrue(e.getMessage().contains("403"));
+    }
+  }
+
+  @Test
   public void testIngestionBatch()
       throws Exception {
     File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
@@ -138,7 +151,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/rawdata/" + DATA_FILE), dataFile);
     FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/" + JOB_FILE), jobFile);
 
-    // patch ingestion job
+    // patch ingestion job file
     String jobFileContents = IOUtils.toString(new FileInputStream(jobFile));
     IOUtils.write(jobFileContents.replaceAll("9000", String.valueOf(DEFAULT_CONTROLLER_PORT)),
         new FileOutputStream(jobFile));
@@ -167,11 +180,4 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     Assert.assertFalse(responseUser.has("resultTable"), "must not return result table");
     Assert.assertTrue(responseUser.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
   }
-
-//  // TODO this endpoint should be protected once UI supports auth
-//  @Test
-//  public void testControllerGetTablesNoAuth()
-//      throws Exception {
-//    System.out.println(sendGetRequest("http://localhost:18998/tables"));
-//  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
@@ -107,7 +107,8 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
       throws Exception {
     JsonNode response =
         JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}"));
-    Assert.assertEquals(response.get("exceptions").get(0).get("errorCode").asInt(), 180, "must return error code");
+    Assert.assertFalse(response.has("resultTable"), "must not return result table");
+    Assert.assertTrue(response.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
   }
 
   @Test
@@ -116,7 +117,7 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
     JsonNode response = JsonUtils.stringToJsonNode(
         sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
     Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
-        "must return LONG value");
+        "must return result with LONG value");
     Assert.assertTrue(response.get("exceptions").isEmpty(), "must not return exception");
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
+import org.apache.pinot.minion.executor.PinotTaskExecutor;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration test that provides example of {@link PinotTaskGenerator} and {@link PinotTaskExecutor} and tests simple
+ * minion functionality.
+ */
+public class BasicAuthClusterIntegrationTest extends ClusterTest {
+  private static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
+  private static final Map<String, String> AUTH_HEADER = Collections.singletonMap("Authorization", AUTH_TOKEN);
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+    startMinion(Collections.emptyList(), Collections.emptyList());
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown()
+      throws Exception {
+    stopMinion();
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+  }
+
+  @Override
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> properties = super.getDefaultControllerConfiguration();
+    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
+    properties.put("controller.admin.access.control.principals.user.permissions", "read");
+    return properties;
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultBrokerConfiguration() {
+    Map<String, Object> properties = super.getDefaultBrokerConfiguration().toMap();
+    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    properties.put("pinot.broker.access.control.principals", "admin, user");
+    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.user.password", "secret");
+    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
+    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
+    return new PinotConfiguration(properties);
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultServerConfiguration() {
+    Map<String, Object> properties = super.getDefaultServerConfiguration().toMap();
+    properties.put("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.server.segment.upload.auth.token", AUTH_TOKEN);
+    properties.put("pinot.server.instance.auth.token", AUTH_TOKEN);
+    return new PinotConfiguration(properties);
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultMinionConfiguration() {
+    Map<String, Object> properties = super.getDefaultMinionConfiguration().toMap();
+    properties.put("segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("task.auth.token", AUTH_TOKEN);
+    return new PinotConfiguration(properties);
+  }
+
+  @Test
+  public void testBrokerNoAuth()
+      throws Exception {
+    JsonNode response =
+        JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}"));
+    Assert.assertEquals(response.get("exceptions").get(0).get("errorCode").asInt(), 180, "must return error code");
+  }
+
+  @Test
+  public void testBroker()
+      throws Exception {
+    JsonNode response = JsonUtils.stringToJsonNode(
+        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
+        "must return LONG value");
+    Assert.assertTrue(response.get("exceptions").isEmpty(), "must not return exception");
+  }
+
+  @Test
+  public void testControllerGetTables()
+      throws Exception {
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest("http://localhost:18998/tables", AUTH_HEADER));
+    Assert.assertTrue(response.get("tables").isArray(), "must return table array");
+  }
+
+//  // TODO this endpoint should be protected once UI supports auth
+//  @Test
+//  public void testControllerGetTablesNoAuth()
+//      throws Exception {
+//    System.out.println(sendGetRequest("http://localhost:18998/tables"));
+//  }
+
+//  // TODO this endpoint should support literal / non-table queries
+//  @Test
+//  public void testControllerQueryRelay()
+//      throws Exception {
+//     System.out.println(sendPostRequest("http://localhost:18998/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
+//  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthClusterIntegrationTest.java
@@ -19,12 +19,19 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.tools.BootstrapTableTool;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -36,8 +43,18 @@ import org.testng.annotations.Test;
  * minion functionality.
  */
 public class BasicAuthClusterIntegrationTest extends ClusterTest {
+  private static final String BOOTSTRAP_DATA_DIR = "/examples/batch/baseballStats";
+  private static final String SCHEMA_FILE = "baseballStats_schema.json";
+  private static final String CONFIG_FILE = "baseballStats_offline_table_config.json";
+  private static final String DATA_FILE = "baseballStats_data.csv";
+  private static final String JOB_FILE = "ingestionJobSpec.yaml";
+
   private static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
+  private static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ==";
+
   private static final Map<String, String> AUTH_HEADER = Collections.singletonMap("Authorization", AUTH_TOKEN);
+  private static final Map<String, String> AUTH_HEADER_USER =
+      Collections.singletonMap("Authorization", AUTH_TOKEN_USER);
 
   @BeforeClass
   public void setUp()
@@ -68,7 +85,7 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
     properties.put("controller.admin.access.control.principals", "admin, user");
     properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
     properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
+    properties.put("controller.admin.access.control.principals.user.tables", "userTableOnly");
     properties.put("controller.admin.access.control.principals.user.permissions", "read");
     return properties;
   }
@@ -80,7 +97,7 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
     properties.put("pinot.broker.access.control.principals", "admin, user");
     properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
     properties.put("pinot.broker.access.control.principals.user.password", "secret");
-    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
+    properties.put("pinot.broker.access.control.principals.user.tables", "userTableOnly");
     properties.put("pinot.broker.access.control.principals.user.permissions", "read");
     return new PinotConfiguration(properties);
   }
@@ -128,17 +145,59 @@ public class BasicAuthClusterIntegrationTest extends ClusterTest {
     Assert.assertTrue(response.get("tables").isArray(), "must return table array");
   }
 
+  @Test
+  public void testIngestionBatch()
+      throws Exception {
+    File quickstartTmpDir = new File(FileUtils.getTempDirectory(), String.valueOf(System.currentTimeMillis()));
+    FileUtils.forceDeleteOnExit(quickstartTmpDir);
+
+    File baseDir = new File(quickstartTmpDir, "baseballStats");
+    File dataDir = new File(baseDir, "rawdata");
+    File schemaFile = new File(baseDir, SCHEMA_FILE);
+    File configFile = new File(baseDir, CONFIG_FILE);
+    File dataFile = new File(dataDir, DATA_FILE);
+    File jobFile = new File(baseDir, JOB_FILE);
+    Preconditions.checkState(dataDir.mkdirs());
+
+    FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/" + SCHEMA_FILE), schemaFile);
+    FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/" + CONFIG_FILE), configFile);
+    FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/rawdata/" + DATA_FILE), dataFile);
+    FileUtils.copyURLToFile(getClass().getResource(BOOTSTRAP_DATA_DIR + "/" + JOB_FILE), jobFile);
+
+    // patch ingestion job
+    String jobFileContents = IOUtils.toString(new FileInputStream(jobFile));
+    IOUtils.write(jobFileContents.replaceAll("9000", String.valueOf(DEFAULT_CONTROLLER_PORT)),
+        new FileOutputStream(jobFile));
+
+    new BootstrapTableTool("http", "localhost", DEFAULT_CONTROLLER_PORT, baseDir.getAbsolutePath(), AUTH_TOKEN)
+        .execute();
+
+    Thread.sleep(5000);
+
+    // admin with full access
+    JsonNode response = JsonUtils.stringToJsonNode(
+        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+            AUTH_HEADER));
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
+        "must return result with LONG value");
+    Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(0).asText(), "count(*)",
+        "must return column name 'count(*)");
+    Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(0).asInt(), 97889,
+        "must return row count 97889");
+    Assert.assertTrue(response.get("exceptions").isEmpty(), "must not return exception");
+
+    // user with valid auth but no table access
+    JsonNode responseUser = JsonUtils.stringToJsonNode(
+        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+            AUTH_HEADER_USER));
+    Assert.assertFalse(responseUser.has("resultTable"), "must not return result table");
+    Assert.assertTrue(responseUser.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
+  }
+
 //  // TODO this endpoint should be protected once UI supports auth
 //  @Test
 //  public void testControllerGetTablesNoAuth()
 //      throws Exception {
 //    System.out.println(sendGetRequest("http://localhost:18998/tables"));
-//  }
-
-//  // TODO this endpoint should support literal / non-table queries
-//  @Test
-//  public void testControllerQueryRelay()
-//      throws Exception {
-//     System.out.println(sendPostRequest("http://localhost:18998/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
 //  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.pinot.client.Connection;
+import org.apache.pinot.client.ConnectionFactory;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_HEADER;
+
+
+public class BasicAuthRealtimeIntegrationTest extends RealtimeClusterIntegrationTest {
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    super.setUp();
+    startMinion(null, null);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown()
+      throws Exception {
+    stopMinion();
+    super.tearDown();
+  }
+
+  @Override
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    return BasicAuthTestUtils.addControllerConfiguration(super.getDefaultControllerConfiguration());
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultBrokerConfiguration() {
+    return BasicAuthTestUtils.addBrokerConfiguration(super.getDefaultBrokerConfiguration().toMap());
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultServerConfiguration() {
+    return BasicAuthTestUtils.addServerConfiguration(super.getDefaultServerConfiguration().toMap());
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultMinionConfiguration() {
+    return BasicAuthTestUtils.addMinionConfiguration(super.getDefaultMinionConfiguration().toMap());
+  }
+
+  @Override
+  protected IngestionConfig getIngestionConfig() {
+    return null;
+//    // TODO build valid ingestion (and table) config for segment flush
+//    return new IngestionConfig(null, new StreamIngestionConfig(Collections
+//        .singletonList(Collections.singletonMap(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "10000"))), null,
+//        null);
+  }
+
+  @Override
+  protected void addSchema(Schema schema)
+      throws IOException {
+    PostMethod response =
+        sendMultipartPostRequest(_controllerRequestURLBuilder.forSchemaCreate(), schema.toSingleLineJsonString(),
+            AUTH_HEADER);
+    Assert.assertEquals(response.getStatusCode(), 200);
+  }
+
+  @Override
+  protected void addTableConfig(TableConfig tableConfig)
+      throws IOException {
+    sendPostRequest(_controllerRequestURLBuilder.forTableCreate(), tableConfig.toJsonString(), AUTH_HEADER);
+  }
+
+  @Override
+  protected Connection getPinotConnection() {
+    if (_pinotConnection == null) {
+      _pinotConnection =
+          ConnectionFactory.fromZookeeper(ZkStarter.DEFAULT_ZK_STR + "/" + getHelixClusterName(), AUTH_HEADER);
+    }
+    return _pinotConnection;
+  }
+
+  @Override
+  protected void testQuery(String pqlQuery, @Nullable List<String> sqlQueries)
+      throws Exception {
+    ClusterIntegrationTestUtils
+        .testPqlQuery(pqlQuery, _brokerBaseApiUrl, getPinotConnection(), sqlQueries, getH2Connection(), AUTH_HEADER);
+  }
+
+  @Override
+  protected void testSqlQuery(String pinotQuery, @Nullable List<String> sqlQueries)
+      throws Exception {
+    ClusterIntegrationTestUtils
+        .testSqlQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), sqlQueries, getH2Connection(), AUTH_HEADER);
+  }
+
+  @Override
+  protected void dropRealtimeTable(String tableName)
+      throws IOException {
+    sendDeleteRequest(
+        _controllerRequestURLBuilder.forTableDelete(TableNameBuilder.REALTIME.tableNameWithType(tableName)),
+        AUTH_HEADER);
+  }
+
+  // TODO end-to-end test involving segment upload and download sequence with auth
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
@@ -110,8 +110,11 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
 
   @Override
   protected TableTaskConfig getTaskConfig() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("bucketTimePeriod", "30d");
+
     return new TableTaskConfig(
-        Collections.singletonMap(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, new HashMap<>()));
+        Collections.singletonMap(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, properties));
   }
 
   @Override
@@ -181,7 +184,7 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
       String segment = offlineSegments.get(i).asText();
       Assert.assertTrue(
           sendGetRequest(_controllerRequestURLBuilder.forSegmentDownload(getTableName(), segment), AUTH_HEADER).length()
-              > 10000); // download segment
+              > 200000); // download segment
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
@@ -157,6 +157,7 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
     final Request query = new Request("sql", "SELECT count(*) FROM " + getTableName());
 
     ResultSetGroup resultBeforeOffline = getPinotConnection().execute(query);
+    Assert.assertTrue(resultBeforeOffline.getResultSet(0).getLong(0) > 0);
 
     // schedule offline segment generation
     Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+public final class BasicAuthTestUtils {
+  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
+  public static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ==";
+
+  public static final Map<String, String> AUTH_HEADER = Collections.singletonMap("Authorization", AUTH_TOKEN);
+  public static final Map<String, String> AUTH_HEADER_USER = Collections.singletonMap("Authorization", AUTH_TOKEN_USER);
+
+  private BasicAuthTestUtils() {
+    // left blank
+  }
+
+  public static Map<String, Object> addControllerConfiguration(Map<String, Object> properties) {
+    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user.tables", "userTableOnly");
+    properties.put("controller.admin.access.control.principals.user.permissions", "read");
+    return properties;
+  }
+
+  public static PinotConfiguration addBrokerConfiguration(Map<String, Object> properties) {
+    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    properties.put("pinot.broker.access.control.principals", "admin, user");
+    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.user.password", "secret");
+    properties.put("pinot.broker.access.control.principals.user.tables", "userTableOnly");
+    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
+    return new PinotConfiguration(properties);
+  }
+
+  public static PinotConfiguration addServerConfiguration(Map<String, Object> properties) {
+    properties.put("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.server.segment.upload.auth.token", AUTH_TOKEN);
+    properties.put("pinot.server.instance.auth.token", AUTH_TOKEN);
+    return new PinotConfiguration(properties);
+  }
+
+  public static PinotConfiguration addMinionConfiguration(Map<String, Object> properties) {
+    properties.put("segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("task.auth.token", AUTH_TOKEN);
+    return new PinotConfiguration(properties);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
@@ -58,7 +58,7 @@ public final class BasicAuthTestUtils {
 
   public static PinotConfiguration addServerConfiguration(Map<String, Object> properties) {
     properties.put("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
-    properties.put("pinot.server.segment.upload.auth.token", AUTH_TOKEN);
+    properties.put("pinot.server.segment.uploader.auth.token", AUTH_TOKEN);
     properties.put("pinot.server.instance.auth.token", AUTH_TOKEN);
     return new PinotConfiguration(properties);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -376,7 +376,15 @@ public abstract class ClusterTest extends ControllerTest {
    */
   public static JsonNode postQuery(PinotQueryRequest r, String brokerBaseApiUrl)
       throws Exception {
-    return postQuery(r.getQuery(), brokerBaseApiUrl, false, r.getQueryFormat());
+    return postQuery(r.getQuery(), brokerBaseApiUrl, false, r.getQueryFormat(), null);
+  }
+
+  /**
+   * Queries the broker's pql query endpoint (/query)
+   */
+  public static JsonNode postQuery(PinotQueryRequest r, String brokerBaseApiUrl, Map<String, String> headers)
+      throws Exception {
+    return postQuery(r.getQuery(), brokerBaseApiUrl, false, r.getQueryFormat(), headers);
   }
 
   /**
@@ -384,11 +392,19 @@ public abstract class ClusterTest extends ControllerTest {
    */
   public static JsonNode postQuery(String query, String brokerBaseApiUrl, boolean enableTrace, String queryType)
       throws Exception {
+    return postQuery(query, brokerBaseApiUrl, enableTrace, queryType, null);
+  }
+
+  /**
+   * Queries the broker's pql query endpoint (/query)
+   */
+  public static JsonNode postQuery(String query, String brokerBaseApiUrl, boolean enableTrace, String queryType, Map<String, String> headers)
+      throws Exception {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put(queryType, query);
     payload.put("trace", enableTrace);
 
-    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString()));
+    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query", payload.toString(), headers));
   }
 
   /**
@@ -404,10 +420,18 @@ public abstract class ClusterTest extends ControllerTest {
    */
   public static JsonNode postSqlQuery(String query, String brokerBaseApiUrl)
       throws Exception {
+    return postSqlQuery(query, brokerBaseApiUrl, null);
+  }
+
+  /**
+   * Queries the broker's sql query endpoint (/sql)
+   */
+  public static JsonNode postSqlQuery(String query, String brokerBaseApiUrl, Map<String, String> headers)
+      throws Exception {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("sql", query);
     payload.put("queryOptions", "groupByMode=sql;responseFormat=sql");
 
-    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query/sql", payload.toString()));
+    return JsonUtils.stringToJsonNode(sendPostRequest(brokerBaseApiUrl + "/query/sql", payload.toString(), headers));
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -91,6 +91,10 @@ public abstract class ClusterTest extends ControllerTest {
   private List<HelixServerStarter> _serverStarters;
   private MinionStarter _minionStarter;
 
+  protected PinotConfiguration getDefaultBrokerConfiguration() {
+    return new PinotConfiguration();
+  }
+
   protected void startBroker()
       throws Exception {
     startBrokers(1);
@@ -111,7 +115,7 @@ public abstract class ClusterTest extends ControllerTest {
     _brokerBaseApiUrl = "http://localhost:" + basePort;
     _brokerStarters = new ArrayList<>(numBrokers);
     for (int i = 0; i < numBrokers; i++) {
-      Map<String, Object> properties = new HashMap<>();
+      Map<String, Object> properties = getDefaultBrokerConfiguration().toMap();
       properties.put(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, 60 * 1000L);
       properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, basePort + i);
       properties.put(Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
@@ -125,7 +129,7 @@ public abstract class ClusterTest extends ControllerTest {
     }
   }
 
-  public static PinotConfiguration getDefaultServerConfiguration() {
+  protected PinotConfiguration getDefaultServerConfiguration() {
     PinotConfiguration configuration = DefaultHelixStarterServerConfig.loadDefaultServerConf();
 
     configuration.setProperty(Helix.KEY_OF_SERVER_NETTY_HOST, LOCAL_HOST);
@@ -177,13 +181,17 @@ public abstract class ClusterTest extends ControllerTest {
     }
   }
 
+  protected PinotConfiguration getDefaultMinionConfiguration() {
+    return new PinotConfiguration();
+  }
+
   // NOTE: We don't allow multiple Minion instances in the same JVM because Minion uses singleton class MinionContext
   //       to manage the instance level configs
   protected void startMinion(@Nullable List<PinotTaskExecutorFactory> taskExecutorFactories,
       @Nullable List<MinionEventObserverFactory> eventObserverFactories) {
     FileUtils.deleteQuietly(new File(Minion.DEFAULT_INSTANCE_BASE_DIR));
     try {
-      _minionStarter = new MinionStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, new PinotConfiguration());
+      _minionStarter = new MinionStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, getDefaultMinionConfiguration());
       // Register task executor factories
       if (taskExecutorFactories != null) {
         for (PinotTaskExecutorFactory taskExecutorFactory : taskExecutorFactories) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -69,6 +69,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   private static final String TABLE_NAME_3 = "testTable3";
   private static final long STATE_TRANSITION_TIMEOUT_MS = 60_000L;  // 1 minute
   private static final int NUM_TASKS = 2;
+  private static final int NUM_CONFIGS = 3;
 
   private static final AtomicBoolean HOLD = new AtomicBoolean();
   private static final AtomicBoolean TASK_START_NOTIFIED = new AtomicBoolean();
@@ -284,7 +285,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
 
           assertEquals(pinotTaskConfig.getTaskType(), TASK_TYPE);
           Map<String, String> configs = pinotTaskConfig.getConfigs();
-          assertEquals(configs.size(), NUM_TASKS);
+          assertEquals(configs.size(), NUM_CONFIGS);
           String offlineTableName = configs.get("tableName");
           assertEquals(TableNameBuilder.getTableTypeFromTableName(offlineTableName), TableType.OFFLINE);
           String rawTableName = TableNameBuilder.extractRawTableName(offlineTableName);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
@@ -45,6 +45,7 @@ public class MinionContext {
 
   // For segment upload
   private SSLContext _sslContext;
+  private String _taskAuthToken;
 
   // For PurgeTask
   private SegmentPurger.RecordPurgerFactory _recordPurgerFactory;
@@ -96,5 +97,13 @@ public class MinionContext {
 
   public void setRecordModifierFactory(SegmentPurger.RecordModifierFactory recordModifierFactory) {
     _recordModifierFactory = recordModifierFactory;
+  }
+
+  public String getTaskAuthToken() {
+    return _taskAuthToken;
+  }
+
+  public void setTaskAuthToken(String taskAuthToken) {
+    _taskAuthToken = taskAuthToken;
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -160,6 +160,9 @@ public class MinionStarter implements ServiceStartable {
     minionMetrics.initializeGlobalMeters();
     minionContext.setMinionMetrics(minionMetrics);
 
+    // initialize authentication
+    minionContext.setTaskAuthToken(_config.getProperty(CommonConstants.Minion.CONFIG_OF_TASK_AUTH_TOKEN));
+
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");
     PinotConfiguration pinotFSConfig = _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -21,10 +21,12 @@ package org.apache.pinot.minion.taskfactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskResult;
+import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
@@ -72,8 +74,10 @@ public class TaskFactoryRegistry {
               MinionMetrics minionMetrics = MinionContext.getInstance().getMinionMetrics();
 
               PinotTaskConfig pinotTaskConfig = PinotTaskConfig.fromHelixTaskConfig(_taskConfig);
-              pinotTaskConfig.getConfigs()
-                  .put(MinionConstants.AUTH_TOKEN, MinionContext.getInstance().getTaskAuthToken());
+              if (StringUtils.isBlank(pinotTaskConfig.getConfigs().get(MinionConstants.AUTH_TOKEN))) {
+                pinotTaskConfig.getConfigs()
+                    .put(MinionConstants.AUTH_TOKEN, MinionContext.getInstance().getTaskAuthToken());
+              }
 
               _eventObserver.notifyTaskStart(pinotTaskConfig);
               minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -25,6 +25,7 @@ import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskResult;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
@@ -71,6 +72,9 @@ public class TaskFactoryRegistry {
               MinionMetrics minionMetrics = MinionContext.getInstance().getMinionMetrics();
 
               PinotTaskConfig pinotTaskConfig = PinotTaskConfig.fromHelixTaskConfig(_taskConfig);
+              pinotTaskConfig.getConfigs()
+                  .put(MinionConstants.AUTH_TOKEN, MinionContext.getInstance().getTaskAuthToken());
+
               _eventObserver.notifyTaskStart(pinotTaskConfig);
               minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
               LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,9 @@ public class SegmentPushUtils implements Serializable {
           try (InputStream inputStream = fileSystem.open(tarFileURI)) {
             SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                 .uploadSegment(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName, inputStream,
-                    tableName);
+                    FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()), Collections.singletonList(
+                        new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName)),
+                    FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
                 controllerURI, response.getStatusCode(), response.getResponse());
             return true;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -120,8 +119,8 @@ public class SegmentPushUtils implements Serializable {
           try (InputStream inputStream = fileSystem.open(tarFileURI)) {
             SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                 .uploadSegment(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName, inputStream,
-                    FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()), Collections.singletonList(
-                        new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName)),
+                    FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()),
+                    FileUploadDownloadClient.makeTableParam(tableName),
                     FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
                 controllerURI, response.getStatusCode(), response.getResponse());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -253,9 +253,7 @@ public class SegmentPushUtils implements Serializable {
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
-              if (StringUtils.isNotBlank(spec.getAuthToken())) {
-                headers.addAll(FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()));
-              }
+              headers.addAll(FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()));
 
               SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                   .uploadSegmentMetadata(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName,

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentPushUtils.java
@@ -19,12 +19,12 @@
 package org.apache.pinot.plugin.ingestion.batch.common;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,9 +33,7 @@ import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
-import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
@@ -177,7 +175,10 @@ public class SegmentPushUtils implements Serializable {
         RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
           try {
             SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
-                .sendSegmentUri(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentUri, tableName);
+                .sendSegmentUri(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentUri,
+                    FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()),
+                    FileUploadDownloadClient.makeTableParam(tableName),
+                    FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response for pushing table {} segment uri {} to location {} - {}: {}", tableName, segmentUri,
                 controllerURI, response.getStatusCode(), response.getResponse());
             return true;
@@ -248,17 +249,18 @@ public class SegmentPushUtils implements Serializable {
           }
           RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
             try {
-              List<Header> headers = ImmutableList
-                  .of(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath),
-                      new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
-                          FileUploadDownloadClient.FileUploadType.METADATA.toString()));
-              // Add table name as a request parameter
-              NameValuePair tableNameValuePair =
-                  new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName);
-              List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
+              List<Header> headers = new ArrayList<>();
+              headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
+              headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
+                  FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+              if (StringUtils.isNotBlank(spec.getAuthToken())) {
+                headers.addAll(FileUploadDownloadClient.makeAuthHeader(spec.getAuthToken()));
+              }
+
               SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                   .uploadSegmentMetadata(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName,
-                      segmentMetadataFile, headers, parameters, FILE_UPLOAD_DOWNLOAD_CLIENT.DEFAULT_SOCKET_TIMEOUT_MS);
+                      segmentMetadataFile, headers, FileUploadDownloadClient.makeTableParam(tableName),
+                      FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
               LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
                   controllerURI, response.getStatusCode(), response.getResponse());
               return true;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
-import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -67,7 +67,8 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
   private File _localTempDir;
 
   @Override
-  public void setup(Context context) throws IOException {
+  public void setup(Context context)
+      throws IOException {
     _jobConf = context.getConfiguration();
     Yaml yaml = new Yaml();
     String segmentGenerationJobSpecStr = _jobConf.get(SEGMENT_GENERATION_JOB_SPEC);
@@ -146,8 +147,9 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
       taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
       taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
-      taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI()));
-      taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
+      taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+      taskSpec.setTableConfig(
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
       taskSpec.setSequenceId(idx);
       taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
       taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -18,12 +18,6 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
-import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
-import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
-import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.getFileName;
-import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
-import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -39,12 +33,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationJobUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
-import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -63,6 +56,13 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.VoidFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
+import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
+import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.getFileName;
+import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.LOCAL_DIRECTORY_SEQUENCE_ID;
+import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
+import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
 
 
 public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Serializable {
@@ -301,8 +301,10 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
           taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
           taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
-          taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI()));
-          taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
+          taskSpec
+              .setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+          taskSpec.setTableConfig(
+              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -60,7 +60,6 @@ import org.slf4j.LoggerFactory;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_DIR;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.PINOT_PLUGINS_TAR_GZ;
 import static org.apache.pinot.common.segment.generation.SegmentGenerationUtils.getFileName;
-import static org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.LOCAL_DIRECTORY_SEQUENCE_ID;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_DIR_PROPERTY_NAME;
 import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY_NAME;
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -194,6 +194,17 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     }
     File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
     try {
+      //create localTempDir for input and output
+      File localInputTempDir = new File(localTempDir, "input");
+      FileUtils.forceMkdir(localInputTempDir);
+      File localOutputTempDir = new File(localTempDir, "output");
+      FileUtils.forceMkdir(localOutputTempDir);
+
+      //Read TableConfig, Schema
+      Schema schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken());
+      TableConfig tableConfig =
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
+
       int numInputFiles = filteredFiles.size();
       _segmentCreationTaskCountDownLatch = new CountDownLatch(numInputFiles);
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -133,7 +133,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateSchemaURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setSchemaURI(schemaURI);
     }
-    _schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI());
+    _schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken());
 
     // Read Table config
     if (_spec.getTableSpec().getTableConfigURI() == null) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -145,7 +145,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
-    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI());
+    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
 
     final int jobParallelism = _spec.getSegmentCreationJobParallelism();
     int numThreads = JobUtils.getNumThreads(jobParallelism);
@@ -194,17 +194,6 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     }
     File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
     try {
-      //create localTempDir for input and output
-      File localInputTempDir = new File(localTempDir, "input");
-      FileUtils.forceMkdir(localInputTempDir);
-      File localOutputTempDir = new File(localTempDir, "output");
-      FileUtils.forceMkdir(localOutputTempDir);
-
-      //Read TableConfig, Schema
-      Schema schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken());
-      TableConfig tableConfig =
-          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
-
       int numInputFiles = filteredFiles.size();
       _segmentCreationTaskCountDownLatch = new CountDownLatch(numInputFiles);
 

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Deprecated. Does not support HTTPS or authentication
  */
+@Deprecated
 public class DefaultControllerRestApi implements ControllerRestApi {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultControllerRestApi.class);
 

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -37,6 +38,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * Deprecated. Does not support HTTPS or authentication
+ */
 public class DefaultControllerRestApi implements ControllerRestApi {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultControllerRestApi.class);
 
@@ -114,7 +118,9 @@ public class DefaultControllerRestApi implements ControllerRestApi {
           try (InputStream inputStream = fileSystem.open(tarFilePath)) {
             SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegment(
                 FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
-                segmentName, inputStream, _rawTableName);
+                segmentName, inputStream, Collections.emptyList(),
+                FileUploadDownloadClient.makeTableParam(_rawTableName),
+                FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());
             break;
           } catch (Exception e) {

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/common/DefaultControllerRestApi.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -118,8 +117,7 @@ public class DefaultControllerRestApi implements ControllerRestApi {
           try (InputStream inputStream = fileSystem.open(tarFilePath)) {
             SimpleHttpResponse response = _fileUploadDownloadClient.uploadSegment(
                 FileUploadDownloadClient.getUploadSegmentHttpURI(pushLocation.getHost(), pushLocation.getPort()),
-                segmentName, inputStream, Collections.emptyList(),
-                FileUploadDownloadClient.makeTableParam(_rawTableName),
+                segmentName, inputStream, null, FileUploadDownloadClient.makeTableParam(_rawTableName),
                 FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response {}: {}", response.getStatusCode(), response.getResponse());
             break;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -88,6 +88,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
     String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
+    String authToken = configs.get(MinionConstants.AUTH_TOKEN);
 
     LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
         tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
@@ -149,8 +150,9 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
             TableNameBuilder.extractRawTableName(tableNameWithType));
         List<NameValuePair> parameters = Arrays.asList(enableParallelPushProtectionParameter, tableNameParameter);
 
-        SegmentConversionUtils.uploadSegment(configs, null, parameters, tableNameWithType, resultSegmentName, uploadURL,
-            convertedTarredSegmentFile);
+        SegmentConversionUtils
+            .uploadSegment(configs, FileUploadDownloadClient.makeAuthHeader(authToken), parameters, tableNameWithType,
+                resultSegmentName, uploadURL, convertedTarredSegmentFile);
       }
 
       String outputSegmentNames = segmentConversionResults.stream().map(SegmentConversionResult::getSegmentName)

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.plugin.minion.tasks;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     String downloadURL = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
     String originalSegmentCrc = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
+    String authToken = configs.get(MinionConstants.AUTH_TOKEN);
 
     LOGGER.info("Start executing {} on table: {}, segment: {} with downloadURL: {}, uploadURL: {}", taskType,
         tableNameWithType, segmentName, downloadURL, uploadURL);
@@ -121,7 +123,10 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
           new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
               segmentZKMetadataCustomMapModifier.toJsonString());
 
-      List<Header> httpHeaders = Arrays.asList(ifMatchHeader, segmentZKMetadataCustomMapModifierHeader);
+      List<Header> httpHeaders = new ArrayList<>();
+      httpHeaders.add(ifMatchHeader);
+      httpHeaders.add(segmentZKMetadataCustomMapModifierHeader);
+      httpHeaders.addAll(FileUploadDownloadClient.makeAuthHeader(authToken));
 
       // Set parameters for upload request.
       NameValuePair enableParallelPushProtectionParameter =

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskExecutor.java
@@ -285,13 +285,15 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
     recordReaderSpec.setConfigClassName(taskConfigs.get(BatchConfigProperties.RECORD_READER_CONFIG_CLASS));
     taskSpec.setRecordReaderSpec(recordReaderSpec);
 
+    String authToken = taskConfigs.get(BatchConfigProperties.AUTH_TOKEN); // TODO
+
     String tableNameWithType = taskConfigs.get(BatchConfigProperties.TABLE_NAME);
     Schema schema;
     if (taskConfigs.containsKey(BatchConfigProperties.SCHEMA)) {
       schema = JsonUtils
           .stringToObject(JsonUtils.objectToString(taskConfigs.get(BatchConfigProperties.SCHEMA)), Schema.class);
     } else if (taskConfigs.containsKey(BatchConfigProperties.SCHEMA_URI)) {
-      schema = SegmentGenerationUtils.getSchema(taskConfigs.get(BatchConfigProperties.SCHEMA_URI));
+      schema = SegmentGenerationUtils.getSchema(taskConfigs.get(BatchConfigProperties.SCHEMA_URI), authToken);
     } else {
       schema = getSchema(tableNameWithType);
     }
@@ -300,7 +302,8 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
     if (taskConfigs.containsKey(BatchConfigProperties.TABLE_CONFIGS)) {
       tableConfig = JsonUtils.stringToObject(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS), TableConfig.class);
     } else if (taskConfigs.containsKey(BatchConfigProperties.TABLE_CONFIGS_URI)) {
-      tableConfig = SegmentGenerationUtils.getTableConfig(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS_URI));
+      tableConfig =
+          SegmentGenerationUtils.getTableConfig(taskConfigs.get(BatchConfigProperties.TABLE_CONFIGS_URI), authToken);
     } else {
       tableConfig = getTableConfig(tableNameWithType);
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -83,6 +83,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _serverMetrics = serverMetrics;
+    _authToken = config.getProperty(CommonConstants.Server.CONFIG_OF_AUTH_TOKEN);
 
     File instanceDataDir = new File(_instanceDataManagerConfig.getInstanceDataDir());
     if (!instanceDataDir.exists()) {
@@ -142,7 +143,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     LOGGER.info("Creating table data manager for table: {}", tableNameWithType);
     TableDataManagerConfig tableDataManagerConfig =
         TableDataManagerConfig.getDefaultHelixTableDataManagerConfig(_instanceDataManagerConfig, tableNameWithType);
-    tableDataManagerConfig.overrideConfigs(tableConfig);
+    tableDataManagerConfig.overrideConfigs(tableConfig, _authToken);
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, _instanceId, _propertyStore, _serverMetrics, _helixManager);
     tableDataManager.start();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -71,6 +71,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private HelixManager _helixManager;
   private ServerMetrics _serverMetrics;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private String _authToken;
 
   @Override
   public synchronized void init(PinotConfiguration config, HelixManager helixManager, ServerMetrics serverMetrics)

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -21,6 +21,7 @@ package org.apache.pinot.server.starter.helix;
 import java.util.Optional;
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.http.auth.AUTH;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.CommonConstants.Server;
 import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
@@ -60,6 +61,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String SEGMENT_FORMAT_VERSION = "segment.format.version";
   // Key of whether to enable reloading consuming segments
   public static final String INSTANCE_RELOAD_CONSUMING_SEGMENT = "reload.consumingSegment";
+  // Key of the auth token
+  public static final String AUTH_TOKEN = "auth.token";
 
   // Key of how many parallel realtime segments can be built.
   // A value of <= 0 indicates unlimited.
@@ -192,6 +195,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   public int getMaxParallelSegmentBuilds() {
     return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_SEGMENT_BUILDS, 0);
+  }
+
+  @Override
+  public String getAuthToken() {
+    return _instanceDataManagerConfiguration.getProperty(AUTH_TOKEN);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -50,6 +50,7 @@ public class BatchConfigProperties {
   public static final String PUSH_SEGMENT_URI_PREFIX = "push.segmentUriPrefix";
   public static final String PUSH_SEGMENT_URI_SUFFIX = "push.segmentUriSuffix";
   public static final String FAIL_ON_EMPTY_SEGMENT = "fail.on.empty.segment";
+  public static final String AUTH_TOKEN = "authToken";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -126,6 +126,11 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private boolean _failOnEmptySegment = false;
 
+  /**
+   * Controller auth token
+   */
+  private String _authToken;
+
   public ExecutionFrameworkSpec getExecutionFrameworkSpec() {
     return _executionFrameworkSpec;
   }
@@ -285,6 +290,14 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setFailOnEmptySegment(boolean failOnEmptySegment) {
     _failOnEmptySegment = failOnEmptySegment;
+  }
+
+  public String getAuthToken() {
+    return _authToken;
+  }
+
+  public void setAuthToken(String authToken) {
+    _authToken = authToken;
   }
 }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -54,7 +54,7 @@ public class AuthQuickstart extends Quickstart {
 
     // server
     properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.segment.upload.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
     properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     // minion

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.spi.plugin.PluginManager;
+
+
+public class AuthQuickstart extends Quickstart {
+
+  @Override
+  public String getAuthToken() {
+    return BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
+  }
+
+  @Override
+  public Map<String, Object> getConfigOverrides() {
+    Map<String, Object> properties = new HashMap<>();
+
+    // controller
+    properties.put("controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("controller.admin.access.control.factory.class", "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
+    properties.put("controller.admin.access.control.principals.user.permissions", "read");
+
+    // broker
+    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    properties.put("pinot.broker.access.control.principals", "admin, user");
+    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.user.password", "secret");
+    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
+    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
+
+    // server
+    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.upload.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    // minion
+    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    return properties;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    PluginManager.get().init();
+    new AuthQuickstart().execute();
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -118,7 +118,7 @@ public class BootstrapTableTool {
     return new AddTableCommand().setSchemaFile(schemaFile.getAbsolutePath())
         .setTableConfigFile(tableConfigFile.getAbsolutePath()).setControllerProtocol(_controllerProtocol)
         .setControllerHost(_controllerHost).setControllerPort(String.valueOf(_controllerPort)).setExecute(true)
-        .execute();
+        .setAuthToken(_token).execute();
   }
 
   private boolean bootstrapOfflineTable(File setupTableTmpDir, String tableName, File schemaFile,
@@ -177,6 +177,8 @@ public class BootstrapTableTool {
             TlsUtils.installDefaultSSLSocketFactory(tlsSpec.getKeyStorePath(), tlsSpec.getKeyStorePassword(),
                 tlsSpec.getTrustStorePath(), tlsSpec.getTrustStorePassword());
           }
+
+          spec.setAuthToken(_token);
 
           IngestionJobLauncher.runIngestionJob(spec);
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -55,20 +55,11 @@ public class BootstrapTableTool {
   private final String _controllerProtocol;
   private final String _controllerHost;
   private final int _controllerPort;
+  private final String _token;
   private final String _tableDir;
   private final MinionClient _minionClient;
 
-  public BootstrapTableTool(String controllerHost, int controllerPort, String tableDir) {
-    Preconditions.checkNotNull(controllerHost);
-    Preconditions.checkNotNull(tableDir);
-    _controllerProtocol = CommonConstants.HTTP_PROTOCOL;
-    _controllerHost = controllerHost;
-    _controllerPort = controllerPort;
-    _tableDir = tableDir;
-    _minionClient = new MinionClient(controllerHost, String.valueOf(controllerPort));
-  }
-
-  public BootstrapTableTool(String controllerProtocol, String controllerHost, int controllerPort, String tableDir) {
+  public BootstrapTableTool(String controllerProtocol, String controllerHost, int controllerPort, String tableDir, String token) {
     Preconditions.checkNotNull(controllerProtocol);
     Preconditions.checkNotNull(controllerHost);
     Preconditions.checkNotNull(tableDir);
@@ -77,6 +68,7 @@ public class BootstrapTableTool {
     _controllerPort = controllerPort;
     _tableDir = tableDir;
     _minionClient = new MinionClient(controllerHost, String.valueOf(controllerPort));
+    _token = token;
   }
 
   public boolean execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.minion.MinionClient;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.util.TlsUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -55,11 +54,12 @@ public class BootstrapTableTool {
   private final String _controllerProtocol;
   private final String _controllerHost;
   private final int _controllerPort;
-  private final String _token;
+  private final String _authToken;
   private final String _tableDir;
   private final MinionClient _minionClient;
 
-  public BootstrapTableTool(String controllerProtocol, String controllerHost, int controllerPort, String tableDir, String token) {
+  public BootstrapTableTool(String controllerProtocol, String controllerHost, int controllerPort, String tableDir,
+      String authToken) {
     Preconditions.checkNotNull(controllerProtocol);
     Preconditions.checkNotNull(controllerHost);
     Preconditions.checkNotNull(tableDir);
@@ -68,7 +68,7 @@ public class BootstrapTableTool {
     _controllerPort = controllerPort;
     _tableDir = tableDir;
     _minionClient = new MinionClient(controllerHost, String.valueOf(controllerPort));
-    _token = token;
+    _authToken = authToken;
   }
 
   public boolean execute()
@@ -118,7 +118,7 @@ public class BootstrapTableTool {
     return new AddTableCommand().setSchemaFile(schemaFile.getAbsolutePath())
         .setTableConfigFile(tableConfigFile.getAbsolutePath()).setControllerProtocol(_controllerProtocol)
         .setControllerHost(_controllerHost).setControllerPort(String.valueOf(_controllerPort)).setExecute(true)
-        .setAuthToken(_token).execute();
+        .setAuthToken(_authToken).execute();
   }
 
   private boolean bootstrapOfflineTable(File setupTableTmpDir, String tableName, File schemaFile,
@@ -178,7 +178,7 @@ public class BootstrapTableTool {
                 tlsSpec.getTrustStorePath(), tlsSpec.getTrustStorePassword());
           }
 
-          spec.setAuthToken(_token);
+          spec.setAuthToken(_authToken);
 
           IngestionJobLauncher.runIngestionJob(spec);
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -26,13 +26,11 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 
 public class Quickstart {
-
   private static final String TAB = "\t\t";
   private static final String NEW_LINE = "\n";
 
@@ -48,6 +46,14 @@ public class Quickstart {
 
   public String getBootstrapDataDir() {
     return "examples/batch/baseballStats";
+  }
+
+  public String getAuthToken() {
+    return null;
+  }
+
+  public Map<String, Object> getConfigOverrides() {
+    return new HashMap<>();
   }
 
   public static void printStatus(Color color, String message) {
@@ -165,32 +171,10 @@ public class Quickstart {
     com.google.common.base.Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, tableConfigFile);
 
-    Map<String, Object> properties = new HashMap<>();
-    properties.put("controller.admin.access.control.factory.class", "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
-    properties.put("controller.admin.access.control.principals", "admin, user");
-    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
-    properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
-    properties.put("controller.admin.access.control.principals.user.permissions", "read");
-    properties.put("controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-
-    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
-    properties.put("pinot.broker.access.control.principals", "admin, user");
-    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
-    properties.put("pinot.broker.access.control.principals.user.password", "secret");
-    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
-    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
-
-    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.segment.upload.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-
-    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-
     QuickstartTableRequest request = new QuickstartTableRequest(baseDir.getAbsolutePath());
-    final QuickstartRunner runner = new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 1, dataDir, true,
-        BasicAuthUtils.toBasicAuthToken("admin", "verysecret"), properties);
+    final QuickstartRunner runner =
+        new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 1, dataDir, true, getAuthToken(),
+            getConfigOverrides());
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -31,10 +31,13 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
+import javax.annotation.Nullable;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 
@@ -83,10 +86,9 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     final URL url = new URL(urlString);
     final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
-    conn.setDoOutput(true);
+    headers.forEach(header -> conn.setRequestProperty(header.getName(), header.getValue()));
     conn.setRequestMethod(requestMethod);
-    headers.stream().flatMap(header -> Arrays.stream(header.getElements()))
-            .forEach(elem -> conn.setRequestProperty(elem.getName(), elem.getValue()));
+    conn.setDoOutput(true);
     if (payload != null) {
       final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(),
           StandardCharsets.UTF_8));
@@ -123,16 +125,35 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     return PinotConfigUtils.readConfigFromFile(configFileName);
   }
 
-  static List<Header> makeBasicAuth(String user, String password) {
-    if (StringUtils.isBlank(user)) {
-      return Collections.emptyList();
+  /**
+   * Generate an (optional) HTTP Authorization header given an auth token
+   * @see FileUploadDownloadClient#makeAuthHeader(String)
+   *
+   * @param authToken auth token
+   * @return list of 0 or 1 "Authorization" headers
+   */
+  static List<Header> makeAuthHeader(String authToken) {
+    return FileUploadDownloadClient.makeAuthHeader(authToken);
+  }
+
+  /**
+   * Generate auth token from pass-thru token or generate basic auth from user/password pair
+   *
+   * @param authToken optional pass-thru token
+   * @param user optional username
+   * @param password optional password
+   * @return auth token, or null if neither pass-thru token nor user info available
+   */
+  @Nullable
+  static String makeAuthToken(String authToken, String user, String password) {
+    if (StringUtils.isNotBlank(authToken)) {
+      return authToken;
     }
 
-    if (StringUtils.isBlank(password)) {
-      password = "";
+    if (StringUtils.isNotBlank(user)) {
+      return BasicAuthUtils.toBasicAuthToken(user, password);
     }
 
-    String token = "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
-    return Collections.singletonList(new BasicHeader("Authorization", token));
+    return null;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -60,6 +60,9 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -80,10 +83,9 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
 
   @Override
   public String toString() {
-    String retString =
-        ("AddSchema -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
-            + " -controllerPort " + _controllerPort + " -schemaFile " + _schemaFile + " -user " + _user + " -password "
-                + "[hidden]");
+    String retString = ("AddSchema -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
+        + " -controllerPort " + _controllerPort + " -schemaFile " + _schemaFile + " -user " + _user + " -password "
+        + "[hidden]");
 
     return ((_exec) ? (retString + " -exec") : retString);
   }
@@ -114,11 +116,15 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   }
 
   public void setUser(String user) {
-    this._user = user;
+    _user = user;
   }
 
   public void setPassword(String password) {
-    this._password = password;
+    _password = password;
+  }
+
+  public void setAuthToken(String authToken) {
+    _authToken = authToken;
   }
 
   public AddSchemaCommand setExecute(boolean exec) {
@@ -147,9 +153,10 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
 
     Schema schema = Schema.fromFile(schemaFile);
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
-      fileUploadDownloadClient.addSchema(
-          FileUploadDownloadClient.getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort)),
-          schema.getSchemaName(), schemaFile, makeBasicAuth(_user, _password), Collections.emptyList());
+      fileUploadDownloadClient.addSchema(FileUploadDownloadClient
+              .getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort)),
+          schema.getSchemaName(), schemaFile, makeAuthHeader(makeAuthToken(_authToken, _user, _password)),
+          Collections.emptyList());
     } catch (Exception e) {
       LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);
       return false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.data.Schema;
@@ -51,6 +54,12 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-exec", required = false, metaVar = "<boolean>", usage = "Execute the command.")
   private boolean _exec;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -73,7 +82,8 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   public String toString() {
     String retString =
         ("AddSchema -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
-            + " -controllerPort " + _controllerPort + " -schemaFile " + _schemaFile);
+            + " -controllerPort " + _controllerPort + " -schemaFile " + _schemaFile + " -user " + _user + " -password "
+                + "[hidden]");
 
     return ((_exec) ? (retString + " -exec") : retString);
   }
@@ -101,6 +111,14 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   public AddSchemaCommand setSchemaFilePath(String schemaFilePath) {
     _schemaFile = schemaFilePath;
     return this;
+  }
+
+  public void setUser(String user) {
+    this._user = user;
+  }
+
+  public void setPassword(String password) {
+    this._password = password;
   }
 
   public AddSchemaCommand setExecute(boolean exec) {
@@ -131,7 +149,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.addSchema(
           FileUploadDownloadClient.getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort)),
-          schema.getSchemaName(), schemaFile);
+          schema.getSchemaName(), schemaFile, makeBasicAuth(_user, _password), Collections.emptyList());
     } catch (Exception e) {
       LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);
       return false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -21,6 +21,8 @@ package org.apache.pinot.tools.admin.command;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.NetUtil;
@@ -58,6 +60,12 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
   @Option(name = "-exec", required = false, metaVar = "<boolean>", usage = "Execute the command.")
   private boolean _exec;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -82,7 +90,8 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
   public String toString() {
     String retString =
         ("AddTable -tableConfigFile " + _tableConfigFile + " -schemaFile " + _schemaFile + " -controllerProtocol "
-            + _controllerProtocol + " -controllerHost " + _controllerHost + " -controllerPort " + _controllerPort);
+            + _controllerProtocol + " -controllerHost " + _controllerHost + " -controllerPort " + _controllerPort
+                + " -user " + _user + " -password " + "[hidden]");
     return ((_exec) ? (retString + " -exec") : retString);
   }
 
@@ -115,6 +124,16 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     return this;
   }
 
+  public AddTableCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public AddTableCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public AddTableCommand setExecute(boolean exec) {
     _exec = exec;
     return this;
@@ -134,7 +153,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.addSchema(
           FileUploadDownloadClient.getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort)),
-          schema.getSchemaName(), schemaFile);
+          schema.getSchemaName(), schemaFile, makeBasicAuth(_user, _password), Collections.emptyList());
     } catch (Exception e) {
       LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);
       throw e;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -67,6 +67,9 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -112,6 +115,11 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public AddTenantCommand setAuthToken(String authToken) {
+    _authToken = authToken;
+    return this;
+  }
+
   public AddTenantCommand setExecute(boolean exec) {
     _exec = exec;
     return this;
@@ -137,7 +145,7 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),
-            tenant.toJsonString(), makeBasicAuth(_user, _password));
+            tenant.toJsonString(), makeAuthHeader(makeAuthToken(_authToken, _user, _password)));
 
     LOGGER.info(res);
     System.out.print(res);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -28,6 +28,8 @@ import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+
 
 public class AddTenantCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(AddTenantCommand.class);
@@ -58,6 +60,12 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
 
   @Option(name = "-exec", required = false, metaVar = "<boolean>", usage = "Execute the command.")
   private boolean _exec;
+
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
 
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
@@ -94,6 +102,16 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public AddTenantCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public AddTenantCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public AddTenantCommand setExecute(boolean exec) {
     _exec = exec;
     return this;
@@ -118,8 +136,8 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     LOGGER.info("Executing command: " + toString());
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
-        .sendPostRequest(ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),
-            tenant.toJsonString());
+        .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),
+            tenant.toJsonString(), makeBasicAuth(_user, _password));
 
     LOGGER.info(res);
     System.out.print(res);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -76,6 +76,12 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
   @Option(name = "-dir", required = false, aliases = {"-d", "-directory"}, metaVar = "<String>", usage = "The directory contains all the configs and data to bootstrap a table")
   private String _dir;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -116,6 +122,7 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
     if (_controllerHost == null) {
       _controllerHost = NetUtil.getHostAddress();
     }
-    return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir).execute();
+    String token = ""; // TODO
+    return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir, token).execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.NetUtil;
+import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.BootstrapTableTool;
@@ -82,6 +84,9 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -122,7 +127,7 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
     if (_controllerHost == null) {
       _controllerHost = NetUtil.getHostAddress();
     }
-    String token = ""; // TODO
+    String token = makeAuthToken(_authToken, _user, _password);
     return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir, token).execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
@@ -50,6 +50,12 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-state", required = true, metaVar = "<String>", usage = "Change Table State(enable|disable|drop)")
   private String _state;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -70,6 +76,7 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
         URI_TABLES_PATH + _tableName, "state=" + stateValue, null);
 
     GetMethod httpGet = new GetMethod(uri.toString());
+    httpGet.setRequestHeader("Authorization", null); // TODO
     int status = httpClient.executeMethod(httpGet);
     if (status != 200) {
       throw new RuntimeException("Failed to change table state, error: " + httpGet.getResponseBodyAsString());
@@ -94,7 +101,8 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
   @Override
   public String toString() {
     return ("ChangeTableState -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
-        + " -controllerPort " + _controllerPort + " -tableName" + _tableName + " -state" + _state);
+        + " -controllerPort " + _controllerPort + " -tableName" + _tableName + " -state" + _state + " -user " + _user
+        + " -password " + "[hidden]");
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpURL;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.NetUtil;
@@ -56,6 +57,9 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -75,8 +79,12 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
     URI uri = new URI(_controllerProtocol, null, _controllerHost, Integer.parseInt(_controllerPort),
         URI_TABLES_PATH + _tableName, "state=" + stateValue, null);
 
+    String token = makeAuthToken(_authToken, _user, _password);
+
     GetMethod httpGet = new GetMethod(uri.toString());
-    httpGet.setRequestHeader("Authorization", null); // TODO
+    if (StringUtils.isNotBlank(token)) {
+      httpGet.setRequestHeader("Authorization", token);
+    }
     int status = httpClient.executeMethod(httpGet);
     if (status != 200) {
       throw new RuntimeException("Failed to change table state, error: " + httpGet.getResponseBodyAsString());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -81,6 +81,9 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-tempDir", metaVar = "<string>", usage = "Temporary directory used to hold data during segment creation.")
   private String _tempDir = new File(FileUtils.getTempDirectory(), getClass().getSimpleName()).getAbsolutePath();
 
@@ -243,11 +246,7 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     spec.setCleanUpOutputDir(true);
     spec.setOverwriteOutput(true);
     spec.setJobType("SegmentCreationAndTarPush");
-
-    if (!StringUtils.isBlank(_user)) {
-      String token = ""; // TODO
-      spec.setAuthToken(token);
-    }
+    spec.setAuthToken(makeAuthToken(_authToken, _user, _password));
 
     // set ExecutionFrameworkSpec
     ExecutionFrameworkSpec executionFrameworkSpec = new ExecutionFrameworkSpec();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -141,6 +141,11 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     return this;
   }
 
+  public ImportDataCommand setAuthToken(String authToken) {
+    _authToken = authToken;
+    return this;
+  }
+
   public List<String> getAdditionalConfigs() {
     return _additionalConfigs;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.controller.helix.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -73,6 +74,12 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
 
   @Option(name = "-controllerURI", metaVar = "<string>", usage = "Pinot Controller URI.")
   private String _controllerURI = "http://localhost:9000";
+
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
 
   @Option(name = "-tempDir", metaVar = "<string>", usage = "Temporary directory used to hold data during segment creation.")
   private String _tempDir = new File(FileUtils.getTempDirectory(), getClass().getSimpleName()).getAbsolutePath();
@@ -121,6 +128,16 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     return this;
   }
 
+  public ImportDataCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public ImportDataCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public List<String> getAdditionalConfigs() {
     return _additionalConfigs;
   }
@@ -153,8 +170,8 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @Override
   public String toString() {
     String results = String
-        .format("InsertData -dataFilePath %s -format %s -table %s -controllerURI %s -tempDir %s", _dataFilePath,
-            _format, _table, _controllerURI, _tempDir);
+        .format("InsertData -dataFilePath %s -format %s -table %s -controllerURI %s -user %s -password %s -tempDir %s",
+            _dataFilePath, _format, _table, _controllerURI, _user, "[hidden]", _tempDir);
     if (_additionalConfigs != null) {
       results += " -additionalConfigs " + Arrays.toString(_additionalConfigs.toArray());
     }
@@ -226,6 +243,11 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     spec.setCleanUpOutputDir(true);
     spec.setOverwriteOutput(true);
     spec.setJobType("SegmentCreationAndTarPush");
+
+    if (!StringUtils.isBlank(_user)) {
+      String token = ""; // TODO
+      spec.setAuthToken(token);
+    }
 
     // set ExecutionFrameworkSpec
     ExecutionFrameworkSpec executionFrameworkSpec = new ExecutionFrameworkSpec();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -46,6 +46,12 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
   @Option(name = "-controllerProtocol", required = false, metaVar = "<String>", usage = "protocol for controller.")
   private String _controllerProtocol = CommonConstants.HTTP_PROTOCOL;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-config", metaVar = "<string>", usage = "Cluster config to operate.")
   private String _config;
 
@@ -100,6 +106,16 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     return this;
   }
 
+  public OperateClusterConfigCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public OperateClusterConfigCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public OperateClusterConfigCommand setConfig(String config) {
     _config = config;
     return this;
@@ -129,8 +145,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
               "Bad config: " + _config + ". Please follow the pattern of [Config Key]=[Config Value]");
         }
         String request = JsonUtils.objectToString(Collections.singletonMap(splits[0], splits[1]));
-        return sendPostRequest(clusterConfigUrl, request);
+        return sendRequest("POST", clusterConfigUrl, request, makeBasicAuth(_user, _password));
       case "GET":
+        // TODO
         String response = IOUtils.toString(new URI(clusterConfigUrl), StandardCharsets.UTF_8);
         JsonNode jsonNode = JsonUtils.stringToJsonNode(response);
         Iterator<String> fieldNamesIterator = jsonNode.fieldNames();
@@ -142,7 +159,8 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
         }
         return results;
       case "DELETE":
-        return sendDeleteRequest(String.format("%s/%s", clusterConfigUrl, _config), null);
+        return sendRequest("DELETE", String.format("%s/%s", clusterConfigUrl, _config), null,
+            makeBasicAuth(_user, _password));
       default:
         throw new UnsupportedOperationException("Unsupported operation: " + _operation);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -19,12 +19,11 @@
 package org.apache.pinot.tools.admin.command;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
-import org.apache.commons.io.IOUtils;
+import java.util.List;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -52,6 +51,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-config", metaVar = "<string>", usage = "Cluster config to operate.")
   private String _config;
 
@@ -73,8 +75,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
 
   @Override
   public String toString() {
-    String toString = "Operate ClusterConfig -controllerProtocol " + _controllerProtocol + " -controllerHost "
-        + _controllerHost + " -controllerPort " + _controllerPort + " -operation " + _operation;
+    String toString =
+        "Operate ClusterConfig -controllerProtocol " + _controllerProtocol + " -controllerHost " + _controllerHost
+            + " -controllerPort " + _controllerPort + " -operation " + _operation;
     if (_config != null) {
       toString += " -config " + _config;
     }
@@ -116,6 +119,11 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     return this;
   }
 
+  public OperateClusterConfigCommand setAuthToken(String authToken) {
+    _authToken = authToken;
+    return this;
+  }
+
   public OperateClusterConfigCommand setConfig(String config) {
     _config = config;
     return this;
@@ -135,7 +143,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     if (StringUtils.isEmpty(_config) && !_operation.equalsIgnoreCase("GET")) {
       throw new UnsupportedOperationException("Empty config: " + _config);
     }
-    String clusterConfigUrl = _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort + "/cluster/configs";
+    String clusterConfigUrl =
+        _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort + "/cluster/configs";
+    List<Header> headers = makeAuthHeader(makeAuthToken(_authToken, _user, _password));
     switch (_operation.toUpperCase()) {
       case "ADD":
       case "UPDATE":
@@ -145,10 +155,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
               "Bad config: " + _config + ". Please follow the pattern of [Config Key]=[Config Value]");
         }
         String request = JsonUtils.objectToString(Collections.singletonMap(splits[0], splits[1]));
-        return sendRequest("POST", clusterConfigUrl, request, makeBasicAuth(_user, _password));
+        return sendRequest("POST", clusterConfigUrl, request, headers);
       case "GET":
-        // TODO
-        String response = IOUtils.toString(new URI(clusterConfigUrl), StandardCharsets.UTF_8);
+        String response = sendRequest("GET", clusterConfigUrl, null, headers);
         JsonNode jsonNode = JsonUtils.stringToJsonNode(response);
         Iterator<String> fieldNamesIterator = jsonNode.fieldNames();
         String results = "";
@@ -159,8 +168,7 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
         }
         return results;
       case "DELETE":
-        return sendRequest("DELETE", String.format("%s/%s", clusterConfigUrl, _config), null,
-            makeBasicAuth(_user, _password));
+        return sendRequest("DELETE", String.format("%s/%s", clusterConfigUrl, _config), null, headers);
       default:
         throw new UnsupportedOperationException("Unsupported operation: " + _operation);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -21,8 +21,8 @@ package org.apache.pinot.tools.admin.command;
 import java.util.Collections;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.CommonConstants.Broker.Request;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.common.utils.NetUtil;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -53,6 +53,9 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -68,8 +71,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
 
   @Override
   public String toString() {
-    return ("PostQuery -brokerProtocol " + _brokerProtocol + " -brokerHost " + _brokerHost + " -brokerPort " +
-        _brokerPort + " -queryType " + _queryType + " -query " + _query);
+    return ("PostQuery -brokerProtocol " + _brokerProtocol + " -brokerHost " + _brokerHost + " -brokerPort "
+        + _brokerPort + " -queryType " + _queryType + " -query " + _query);
   }
 
   @Override
@@ -107,6 +110,11 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public PostQueryCommand setauthToken(String authToken) {
+    _authToken = authToken;
+    return this;
+  }
+
   public PostQueryCommand setQueryType(String queryType) {
     _queryType = queryType;
     return this;
@@ -133,7 +141,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
       request = JsonUtils.objectToString(Collections.singletonMap(Request.PQL, _query));
     }
 
-    return sendRequest("POST", urlString, request, makeBasicAuth(_user, _password));
+    return sendRequest("POST", urlString, request, makeAuthHeader(makeAuthToken(_authToken, _user, _password)));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -110,7 +110,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
-  public PostQueryCommand setauthToken(String authToken) {
+  public PostQueryCommand setAuthToken(String authToken) {
     _authToken = authToken;
     return this;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -47,6 +47,12 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   @Option(name = "-query", required = true, metaVar = "<string>", usage = "Query string to perform.")
   private String _query;
 
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
+
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
@@ -91,6 +97,16 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
+  public PostQueryCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public PostQueryCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public PostQueryCommand setQueryType(String queryType) {
     _queryType = queryType;
     return this;
@@ -117,7 +133,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
       request = JsonUtils.objectToString(Collections.singletonMap(Request.PQL, _query));
     }
 
-    return sendPostRequest(urlString, request);
+    return sendRequest("POST", urlString, request, makeBasicAuth(_user, _password));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -249,9 +249,10 @@ public class QuickstartRunner {
 
   public JsonNode runQuery(String query)
       throws Exception {
+    String token = BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
     return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort))
-        .setQueryType(CommonConstants.Broker.Request.SQL).setQuery(query).run());
+        .setQueryType(CommonConstants.Broker.Request.SQL).setauthToken(token).setQuery(query).run());
   }
 
   public static void registerDefaultPinotFS() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -203,8 +203,8 @@ public class QuickstartRunner {
   public void bootstrapTable()
       throws Exception {
     for (QuickstartTableRequest request : _tableRequests) {
-      if (!new BootstrapTableTool(InetAddress.getLocalHost().getHostName(), _controllerPorts.get(0), request.getBootstrapTableDir())
-          .execute()) {
+      if (!new BootstrapTableTool("http", InetAddress.getLocalHost().getHostName(), _controllerPorts.get(0),
+          request.getBootstrapTableDir(), null).execute()) {
         throw new RuntimeException("Failed to bootstrap table with request - " + request);
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -76,6 +76,8 @@ public class QuickstartRunner {
   private final int _numMinions;
   private final File _tempDir;
   private final boolean _enableTenantIsolation;
+  private final String _authToken;
+  private final Map<String, Object> _configOverrides;
 
   private final List<Integer> _brokerPorts = new ArrayList<>();
   private final List<Integer> _controllerPorts = new ArrayList<>();
@@ -85,11 +87,11 @@ public class QuickstartRunner {
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numServers, int numBrokers,
       int numControllers, File tempDir, boolean enableIsolation)
       throws Exception {
-    this(tableRequests, numServers, numBrokers, numControllers, 1, tempDir, enableIsolation);
+    this(tableRequests, numServers, numBrokers, numControllers, 1, tempDir, enableIsolation, null, null);
   }
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numServers, int numBrokers,
-      int numControllers, int numMinions, File tempDir, boolean enableIsolation)
+      int numControllers, int numMinions, File tempDir, boolean enableIsolation, String authToken, Map<String, Object> configOverrides)
       throws Exception {
     _tableRequests = tableRequests;
     _numServers = numServers;
@@ -98,13 +100,15 @@ public class QuickstartRunner {
     _numMinions = numMinions;
     _tempDir = tempDir;
     _enableTenantIsolation = enableIsolation;
+    _authToken = authToken;
+    _configOverrides = configOverrides;
     clean();
   }
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numServers, int numBrokers,
       int numControllers, File tempDir)
       throws Exception {
-    this(tableRequests, numServers, numBrokers, numControllers, tempDir, true);
+    this(tableRequests, numServers, numBrokers, numControllers, 1, tempDir, true, null, null);
   }
 
   private void startZookeeper()
@@ -121,7 +125,7 @@ public class QuickstartRunner {
       StartControllerCommand controllerStarter = new StartControllerCommand();
       controllerStarter.setControllerPort(String.valueOf(DEFAULT_CONTROLLER_PORT + i)).setZkAddress(ZK_ADDRESS)
           .setClusterName(CLUSTER_NAME).setTenantIsolation(_enableTenantIsolation)
-          .setDataDir(new File(_tempDir, DEFAULT_CONTROLLER_DIR + i).getAbsolutePath());
+          .setDataDir(new File(_tempDir, DEFAULT_CONTROLLER_DIR + i).getAbsolutePath()).setConfigOverrides(_configOverrides);
       controllerStarter.execute();
       _controllerPorts.add(DEFAULT_CONTROLLER_PORT + i);
     }
@@ -131,7 +135,7 @@ public class QuickstartRunner {
       throws Exception {
     for (int i = 0; i < _numBrokers; i++) {
       StartBrokerCommand brokerStarter = new StartBrokerCommand();
-      brokerStarter.setPort(DEFAULT_BROKER_PORT + i).setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME);
+      brokerStarter.setPort(DEFAULT_BROKER_PORT + i).setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME).setConfigOverrides(_configOverrides);
       brokerStarter.execute();
       _brokerPorts.add(DEFAULT_BROKER_PORT + i);
     }
@@ -144,7 +148,7 @@ public class QuickstartRunner {
       serverStarter.setPort(DEFAULT_SERVER_NETTY_PORT + i).setAdminPort(DEFAULT_SERVER_ADMIN_API_PORT + i)
           .setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME)
           .setDataDir(new File(_tempDir, DEFAULT_SERVER_DATA_DIR + i).getAbsolutePath())
-          .setSegmentDir(new File(_tempDir, DEFAULT_SERVER_SEGMENT_DIR + i).getAbsolutePath());
+          .setSegmentDir(new File(_tempDir, DEFAULT_SERVER_SEGMENT_DIR + i).getAbsolutePath()).setConfigOverrides(_configOverrides);
       serverStarter.execute();
     }
   }
@@ -154,7 +158,7 @@ public class QuickstartRunner {
     for (int i = 0; i < _numMinions; i++) {
       StartMinionCommand minionStarter = new StartMinionCommand();
       minionStarter.setMinionPort(DEFAULT_MINION_PORT + i)
-          .setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME);
+          .setZkAddress(ZK_ADDRESS).setClusterName(CLUSTER_NAME).setConfigOverrides(_configOverrides);
       minionStarter.execute();
     }
   }
@@ -203,10 +207,9 @@ public class QuickstartRunner {
 
   public void bootstrapTable()
       throws Exception {
-    String token = BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
     for (QuickstartTableRequest request : _tableRequests) {
       if (!new BootstrapTableTool("http", InetAddress.getLocalHost().getHostName(), _controllerPorts.get(0),
-          request.getBootstrapTableDir(), token).execute()) {
+          request.getBootstrapTableDir(), _authToken).execute()) {
         throw new RuntimeException("Failed to bootstrap table with request - " + request);
       }
     }
@@ -249,10 +252,9 @@ public class QuickstartRunner {
 
   public JsonNode runQuery(String query)
       throws Exception {
-    String token = BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
     return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort))
-        .setQueryType(CommonConstants.Broker.Request.SQL).setauthToken(token).setQuery(query).run());
+        .setQueryType(CommonConstants.Broker.Request.SQL).setAuthToken(_authToken).setQuery(query).run());
   }
 
   public static void registerDefaultPinotFS() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -202,9 +203,10 @@ public class QuickstartRunner {
 
   public void bootstrapTable()
       throws Exception {
+    String token = BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
     for (QuickstartTableRequest request : _tableRequests) {
       if (!new BootstrapTableTool("http", InetAddress.getLocalHost().getHostName(), _controllerPorts.get(0),
-          request.getBootstrapTableDir(), null).execute()) {
+          request.getBootstrapTableDir(), token).execute()) {
         throw new RuntimeException("Failed to bootstrap table with request - " + request);
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -51,6 +52,8 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   @Option(name = "-configFileName", required = false, metaVar = "<Config File Name>", usage = "Broker Starter Config file.", forbids = {"-brokerHost", "-brokerPort"})
   private String _configFileName;
   private HelixBrokerStarter _brokerStarter;
+
+  private Map<String, Object> _configOverrides = new HashMap<>();
 
   public boolean getHelp() {
     return _help;
@@ -102,6 +105,11 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     return this;
   }
 
+  public StartBrokerCommand setConfigOverrides(Map<String, Object> configs) {
+    _configOverrides = configs;
+    return this;
+  }
+
   @Override
   public boolean execute()
       throws Exception {
@@ -123,9 +131,15 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
 
   private Map<String, Object> getBrokerConf()
       throws ConfigurationException {
+    Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {
-      return PinotConfigUtils.readConfigFromFile(_configFileName);
+      properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
+    } else {
+      properties.putAll(PinotConfigUtils.generateBrokerConf(_brokerPort));
     }
-    return PinotConfigUtils.generateBrokerConf(_brokerPort);
+    if (_configOverrides != null) {
+      properties.putAll(_configOverrides);
+    }
+    return properties;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -59,6 +60,8 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
   // This can be set via the set method, or via config file input.
   private boolean _tenantIsolation = true;
 
+  private Map<String, Object> _configOverrides = new HashMap<>();
+
   @Override
   public boolean getHelp() {
     return _help;
@@ -91,6 +94,11 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
 
   public StartControllerCommand setClusterName(String clusterName) {
     _clusterName = clusterName;
+    return this;
+  }
+
+  public StartControllerCommand setConfigOverrides(Map<String, Object> configs) {
+    _configOverrides = configs;
     return this;
   }
 
@@ -140,16 +148,19 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
 
   private Map<String, Object> getControllerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
-    Map<String, Object> properties;
+    Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {
-      properties = PinotConfigUtils.generateControllerConf(_configFileName);
+      properties.putAll(PinotConfigUtils.generateControllerConf(_configFileName));
     } else {
       if (_controllerHost == null) {
         _controllerHost = NetUtil.getHostAddress();
       }
-      properties = PinotConfigUtils
+      properties.putAll(PinotConfigUtils
           .generateControllerConf(_zkAddress, _clusterName, _controllerHost, _controllerPort, _dataDir, _controllerMode,
-              _tenantIsolation);
+              _tenantIsolation));
+    }
+    if (_configOverrides != null) {
+      properties.putAll(_configOverrides);
     }
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -52,6 +53,13 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
   private String _clusterName = "PinotCluster";
   @Option(name = "-configFileName", required = false, metaVar = "<Config File Name>", usage = "Minion Starter Config file.", forbids = {"-minionHost", "-minionPort"})
   private String _configFileName;
+
+  private Map<String, Object> _configOverrides = new HashMap<>();
+
+  public StartMinionCommand setConfigOverrides(Map<String, Object> configs) {
+    _configOverrides = configs;
+    return this;
+  }
 
   public boolean getHelp() {
     return _help;
@@ -101,10 +109,16 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
 
   private Map<String, Object> getMinionConf()
       throws ConfigurationException, SocketException, UnknownHostException {
+    Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {
-      return PinotConfigUtils.readConfigFromFile(_configFileName);
+      properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
+    } else {
+      properties.putAll(PinotConfigUtils.generateMinionConf(_minionHost, _minionPort));
     }
-    return PinotConfigUtils.generateMinionConf(_minionHost, _minionPort);
+    if (_configOverrides != null) {
+      properties.putAll(_configOverrides);
+    }
+    return properties;
   }
 
   public StartMinionCommand setMinionHost(String minionHost) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tools.admin.command;
 import java.io.File;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -57,6 +58,8 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
   private String _clusterName = "PinotCluster";
   @Option(name = "-configFileName", required = false, metaVar = "<Config File Name>", usage = "Server Starter Config file.", forbids = {"-serverHost", "-serverPort", "-dataDir", "-segmentDir",})
   private String _configFileName;
+
+  private Map<String, Object> _configOverrides = new HashMap<>();
 
   @Override
   public boolean getHelp() {
@@ -95,6 +98,11 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
 
   public StartServerCommand setConfigFileName(String configFileName) {
     _configFileName = configFileName;
+    return this;
+  }
+
+  public StartServerCommand setConfigOverrides(Map<String, Object> configs) {
+    _configOverrides = configs;
     return this;
   }
 
@@ -145,13 +153,17 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
     }
   }
 
-
   private Map<String, Object> getServerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
+    Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {
-      return PinotConfigUtils.readConfigFromFile(_configFileName);
+      properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
+    } else {
+      properties.putAll(PinotConfigUtils.generateServerConf(_serverHost, _serverPort, _serverAdminPort, _dataDir, _segmentDir));
     }
-    return PinotConfigUtils
-        .generateServerConf(_serverHost, _serverPort, _serverAdminPort, _dataDir, _segmentDir);
+    if (_configOverrides != null) {
+      properties.putAll(_configOverrides);
+    }
+    return properties;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -21,7 +21,9 @@ package org.apache.pinot.tools.admin.command;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
+import java.util.Collections;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.NetUtil;
@@ -49,6 +51,12 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   @Option(name = "-controllerProtocol", required = false, metaVar = "<String>", usage = "protocol for controller.")
   private String _controllerProtocol = CommonConstants.HTTP_PROTOCOL;
+
+  @Option(name = "-user", required = false, metaVar = "<String>", usage = "Username for basic auth.")
+  private String _user;
+
+  @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
+  private String _password;
 
   @Option(name = "-segmentDir", required = true, metaVar = "<string>", usage = "Path to segment directory.")
   private String _segmentDir = null;
@@ -101,6 +109,16 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
     return this;
   }
 
+  public UploadSegmentCommand setUser(String user) {
+    _user = user;
+    return this;
+  }
+
+  public UploadSegmentCommand setPassword(String password) {
+    _password = password;
+    return this;
+  }
+
   public UploadSegmentCommand setSegmentDir(String segmentDir) {
     _segmentDir = segmentDir;
     return this;
@@ -140,7 +158,10 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
 
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);
         fileUploadDownloadClient
-            .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile, _tableName);
+            .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile,
+                makeBasicAuth(_user, _password), Collections.singletonList(new BasicNameValuePair(
+                    FileUploadDownloadClient.QueryParameters.TABLE_NAME, _tableName)),
+                FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
       }
     } finally {
       // Delete the temporary working directory.

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -58,6 +58,9 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-password", required = false, metaVar = "<String>", usage = "Password for basic auth.")
   private String _password;
 
+  @Option(name = "-authToken", required = false, metaVar = "<String>", usage = "Http auth token.")
+  private String _authToken;
+
   @Option(name = "-segmentDir", required = true, metaVar = "<string>", usage = "Path to segment directory.")
   private String _segmentDir = null;
 
@@ -119,6 +122,11 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
     return this;
   }
 
+  public UploadSegmentCommand setAuthToken(String authToken) {
+    _authToken = authToken;
+    return this;
+  }
+
   public UploadSegmentCommand setSegmentDir(String segmentDir) {
     _segmentDir = segmentDir;
     return this;
@@ -159,7 +167,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);
         fileUploadDownloadClient
             .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile,
-                makeBasicAuth(_user, _password), Collections.singletonList(new BasicNameValuePair(
+                makeAuthHeader(makeAuthToken(_authToken, _user, _password)), Collections.singletonList(new BasicNameValuePair(
                     FileUploadDownloadClient.QueryParameters.TABLE_NAME, _tableName)),
                 FileUploadDownloadClient.DEFAULT_SOCKET_TIMEOUT_MS);
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/backfill/BackfillSegmentUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/backfill/BackfillSegmentUtils.java
@@ -152,7 +152,10 @@ public class BackfillSegmentUtils {
 
   /**
    * Uploads the segment tar to the controller.
+   *
+   * NOTE: this method does not support auth tokens
    */
+  @Deprecated
   public boolean uploadSegment(String rawTableName, String segmentName, File segmentDir, File outputDir) {
     boolean success = true;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -178,6 +178,8 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, serverDataDir);
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, serverSegmentDir);
     properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.upload.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }
@@ -191,6 +193,7 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Helix.KEY_OF_MINION_HOST, minionHost);
     properties.put(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort != 0 ? minionPort : getAvailablePort());
     properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -70,13 +70,6 @@ public class PinotConfigUtils {
     properties.put(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS, 3600);
     properties.put(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, 3600);
     properties.put(ControllerConf.CONTROLLER_MODE, controllerMode.toString());
-    properties.put("controller.admin.access.control.factory.class", "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
-    properties.put("controller.admin.access.control.principals", "admin, user");
-    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
-    properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
-    properties.put("controller.admin.access.control.principals.user.permissions", "read");
-    properties.put("controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }
@@ -150,12 +143,6 @@ public class PinotConfigUtils {
   public static Map<String, Object> generateBrokerConf(int brokerPort) {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, brokerPort != 0 ? brokerPort : getAvailablePort());
-    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
-    properties.put("pinot.broker.access.control.principals", "admin, user");
-    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
-    properties.put("pinot.broker.access.control.principals.user.password", "secret");
-    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
-    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
 
     return properties;
   }
@@ -183,9 +170,6 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT, serverAdminPort);
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, serverDataDir);
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, serverSegmentDir);
-    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.segment.upload.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }
@@ -198,8 +182,6 @@ public class PinotConfigUtils {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.KEY_OF_MINION_HOST, minionHost);
     properties.put(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort != 0 ? minionPort : getAvailablePort());
-    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -70,6 +70,12 @@ public class PinotConfigUtils {
     properties.put(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS, 3600);
     properties.put(ControllerPeriodicTasksConf.BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, 3600);
     properties.put(ControllerConf.CONTROLLER_MODE, controllerMode.toString());
+    properties.put("controller.admin.access.control.factory.class", "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
+    properties.put("controller.admin.access.control.principals.user.permissions", "read");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -76,7 +76,7 @@ public class PinotConfigUtils {
     properties.put("controller.admin.access.control.principals.user.password", "secret");
     properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
     properties.put("controller.admin.access.control.principals.user.permissions", "read");
-    properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -150,6 +150,12 @@ public class PinotConfigUtils {
   public static Map<String, Object> generateBrokerConf(int brokerPort) {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, brokerPort != 0 ? brokerPort : getAvailablePort());
+    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    properties.put("pinot.broker.access.control.principals", "admin, user");
+    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.user.password", "secret");
+    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
+    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -76,6 +76,7 @@ public class PinotConfigUtils {
     properties.put("controller.admin.access.control.principals.user.password", "secret");
     properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
     properties.put("controller.admin.access.control.principals.user.permissions", "read");
+    properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }
@@ -176,6 +177,7 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Server.CONFIG_OF_ADMIN_API_PORT, serverAdminPort);
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_DATA_DIR, serverDataDir);
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, serverSegmentDir);
+    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }
@@ -188,6 +190,7 @@ public class PinotConfigUtils {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.KEY_OF_MINION_HOST, minionHost);
     properties.put(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort != 0 ? minionPort : getAvailablePort());
+    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }


### PR DESCRIPTION
## tl;dr for review
`AuthQuickstart.java` (sample setup with basic auth enabled)
`BasicAuthUtils.java` (shared auth logic)
`BasicAuthAccessControlFactory.java` x 2 (broker, controller auth impl)

`authToken` is used (usually) to authenticate to a controller API via an `Authorization` http header
`authToken = null` (no auth)
`authToken = Basic abcdef...` (basic auth)
`authToken = Bearer 012345...` (token / oauth2)

duplicate config properties for auth tokens due to config subsets being passed around. alternatives considered: single global key with injection into different config subsets (possible), single global key injected via singleton provider (anti-pattern)

auth token for tasks are injected by the minion runner directly, if not provided in the task configs (common case)

## Description
Adds support for token-based authentication in pinot-controller, pinot-broker, pinot-server, minion, and any associated tooling. Furthermore, adds endpoints to manage different auth workflows via UI and provides a sample implementation using basic auth.

**New access control factories**
`org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory`
`org.apache.pinot.broker.broker.BasicAuthAccessControlFactory`

Changes are fully backwards-compatible with authentication disabled by default. Enabling basic auth requires future work for UI support. Builds on #6507, relates to #6435.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)

## Release Notes
Adds support for token-based authentication in pinot-controller, pinot-broker, pinot-server, minion, and any associated tooling. Furthermore, adds endpoints to manage different auth workflows via UI and provides a sample implementation using basic auth.

**New endpoints:**

pinot-controller
`GET /auth/verify` (optional query params tableName, accessType, endpointUrl)
returns true if the provided credentials permit access to the given resource, or false otherwise.

`GET /auth/info`
returns an instance of AuthWorkflowInfo, which at minimum provides a workflow name. Currently supports NONE and BASIC and may be extended later. Support for each type from the UI is optional.

**New configuration properties:**

pinot-controller
`controller.segment.fetcher.auth.token`

pinot-server
`pinot.server.segment.fetcher.auth.token`
`pinot.server.segment.upload.auth.token`
`pinot.server.instance.auth.token`

minion
`segment.fetcher.auth.token`
`task.auth.token`

## Documentation
Quickstart with basic auth
`org.apache.pinot.tools.AuthQuickstart`

curl samples for controller endpoints:
`curl localhost:9000/auth/info` -> `{"workflow":"NONE"}`
`curl localhost:9000/auth/info` -> `{"workflow":"BASIC"}`
`curl localhost:9000/auth/info` -> `{"workflow":"OAUTH2", "issuerUrl":"https://xxxxx"}`
`curl localhost:9000/auth/verify` -> `false`
`curl localhost:9000/auth/verify -H 'Authorization: Basic YWRtaW46dmVyeXNlY3JldA=='` -> `true`

Sample configuration properties for basic auth, plus client auth tokens.

pinot-controller
`controller.segment.fetcher.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA

`controller.admin.access.control.factory.class`=org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
`controller.admin.access.control.principals`=admin,user
`controller.admin.access.control.principals.admin.password`=verysecret
`controller.admin.access.control.principals.user.password`=secret
`controller.admin.access.control.principals.user.tables`=baseballStats
`controller.admin.access.control.principals.user.permissions`=read

pinot-broker
`pinot.broker.access.control.class`=org.apache.pinot.broker.broker.BasicAuthAccessControlFactory
`pinot.broker.access.control.principals`=admin,user
`pinot.broker.access.control.principals.admin.password`=verysecret
`pinot.broker.access.control.principals.user.password`=secret
`pinot.broker.access.control.principals.user.tables`=baseballStats
`pinot.broker.access.control.principals.user.permissions`=read

pinot-server
`pinot.server.segment.fetcher.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA
`pinot.server.segment.uploader.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA
`pinot.server.instance.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA

minion
`segment.fetcher.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA
`task.auth.token`=Basic YWRtaW46dmVyeXNlY3JldA
