### PR TITLE
Fix issue where the error code is checked incorrectly when container does not exist

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -83,7 +83,7 @@ public class ADLSGen2PinotFS extends PinotFS {
   private static final String AZURE_STORAGE_DNS_SUFFIX = ".dfs.core.windows.net";
   private static final String AZURE_BLOB_DNS_SUFFIX = ".blob.core.windows.net";
   private static final String PATH_ALREADY_EXISTS_ERROR_CODE = "PathAlreadyExists";
-  private static final String FILE_SYSTEM_NOT_FOUND_ERROR_CODE = "FilesystemNotFound";
+  private static final String CONTAINER_NOT_FOUND_ERROR_CODE = "ContainerNotFound";
   private static final String IS_DIRECTORY_KEY = "hdi_isfolder";
 
   private static final int NOT_FOUND_STATUS_CODE = 404;
@@ -172,7 +172,7 @@ public class ADLSGen2PinotFS extends PinotFS {
       fileSystemClient.getProperties();
       return fileSystemClient;
     } catch (DataLakeStorageException e) {
-      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE && e.getErrorCode().equals(FILE_SYSTEM_NOT_FOUND_ERROR_CODE)) {
+      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE && e.getErrorCode().equals(CONTAINER_NOT_FOUND_ERROR_CODE)) {
         LOGGER.info("FileSystem with name {} does not exist. Creating one with the same name.", fileSystemName);
         return serviceClient.createFileSystem(fileSystemName);
       } else {

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -126,7 +126,7 @@ public class ADLSGen2PinotFSTest {
     when(_mockServiceClient.createFileSystem(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockFileSystemClient);
     when(_mockFileSystemClient.getProperties()).thenThrow(_mockDataLakeStorageException);
     when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
-    when(_mockDataLakeStorageException.getErrorCode()).thenReturn("FilesystemNotFound");
+    when(_mockDataLakeStorageException.getErrorCode()).thenReturn("ContainerNotFound");
 
     final DataLakeFileSystemClient actual =
         _adlsGen2PinotFsUnderTest.getOrCreateClientWithFileSystem(_mockServiceClient, MOCK_FILE_SYSTEM_NAME);


### PR DESCRIPTION
## Description
Fix issue where the error code is checked incorrectly when container does not exist

## Error message
Caused by: com.azure.storage.file.datalake.models.DataLakeStorageException: Status code 404, "?<?xml version="1.0" encoding="utf-8"?><Error><Code>ContainerNotFound</Code><Message>The specified container does not exist.
RequestId:776dac00-d01e-004d-7c1d-0aa14a000000
Time:2021-02-23T19:51:44.8795600Z</Message></Error>

## Manual testing
3212:2021/02/23 20:47:45.708 INFO [ADLSGen2PinotFS] [main] [pinot-controller] [] FileSystem with name pinotprodcontainer does not exist. Creating one with the same name.
