### PR TITLE
Add mark and count methods in PinotMeter interface

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMeter.java
@@ -31,8 +31,18 @@ public class YammerMeter extends YammerMetered implements PinotMeter {
   }
 
   @Override
+  public void mark() {
+    _meter.mark();
+  }
+
+  @Override
   public void mark(long unitCount) {
     _meter.mark(unitCount);
+  }
+
+  @Override
+  public long count() {
+    return _meter.count();
   }
 
   @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
@@ -18,15 +18,14 @@
  */
 package org.apache.pinot.common.metrics;
 
-import static org.testng.Assert.assertTrue;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -73,7 +72,20 @@ public class MetricsHelperTest {
         TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS);
 
     // Check that the two listeners fired
-    assertTrue(listenerOneOkay);
-    assertTrue(listenerTwoOkay);
+    Assert.assertTrue(listenerOneOkay);
+    Assert.assertTrue(listenerTwoOkay);
+  }
+
+  @Test
+  public void testMetricValue() {
+    PinotMetricsRegistry registry = PinotMetricUtils.getPinotMetricsRegistry();
+    PinotMeter pinotMeter = MetricsHelper
+        .newMeter(registry, PinotMetricUtils.generatePinotMetricName(MetricsHelperTest.class, "testMeter"), "testMeter",
+            TimeUnit.MILLISECONDS);
+    pinotMeter.mark();
+    Assert.assertEquals(pinotMeter.count(), 1L);
+
+    pinotMeter.mark(2L);
+    Assert.assertEquals(pinotMeter.count(), 3L);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
@@ -20,11 +20,29 @@ package org.apache.pinot.spi.metrics;
 
 /**
  * A meter metric which measures mean throughput and one-, five-, and fifteen-minute
- * exponentially-weighted moving average throughputs.
+ * exponentially-weighted moving average throughput.
  *
  * @see <a href="http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">EMA</a>
  */
 public interface PinotMeter {
 
+
+  /**
+   * Mark the occurrence of an event.
+   */
+  void mark();
+
+  /**
+   * Mark the occurrence of a given number of events.
+   *
+   * @param unitCount the number of events
+   */
   void mark(final long unitCount);
+
+  /**
+   * Returns the number of events which have been marked.
+   *
+   * @return the number of events which have been marked
+   */
+  long count();
 }


### PR DESCRIPTION
## Description
This PR adds `mark` and `count` methods in PinotMeter interface, so that the actual metric value can be validated. Unit test added.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
