### PR TITLE
Override equals and hashCode methods for PinotMetricName

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMetricName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMetricName.java
@@ -23,7 +23,7 @@ import org.apache.pinot.spi.metrics.PinotMetricName;
 
 
 public class YammerMetricName implements PinotMetricName {
-  private MetricName _metricName;
+  private final MetricName _metricName;
 
   public YammerMetricName(Class<?> klass, String name) {
     _metricName = new MetricName(klass, name);
@@ -36,5 +36,28 @@ public class YammerMetricName implements PinotMetricName {
   @Override
   public MetricName getMetricName() {
     return _metricName;
+  }
+
+  /**
+   * Overrides equals method by calling the equals from the actual metric name.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    YammerMetricName that = (YammerMetricName) obj;
+    return _metricName.equals(that._metricName);
+  }
+
+  /**
+   * Overrides hashCode method by calling the hashCode method from the actual metric name.
+   */
+  @Override
+  public int hashCode() {
+    return _metricName.hashCode();
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MetricsHelperTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.spi.metrics.PinotMeter;
+import org.apache.pinot.spi.metrics.PinotMetricName;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
@@ -87,5 +88,16 @@ public class MetricsHelperTest {
 
     pinotMeter.mark(2L);
     Assert.assertEquals(pinotMeter.count(), 3L);
+  }
+
+  @Test
+  public void testPinotMetricName() {
+    PinotMetricName testMetricName1 =
+        PinotMetricUtils.generatePinotMetricName(MetricsHelperTest.class, "testMetricName");
+    PinotMetricName testMetricName2 =
+        PinotMetricUtils.generatePinotMetricName(MetricsHelperTest.class, "testMetricName");
+    Assert.assertNotNull(testMetricName1);
+    Assert.assertNotNull(testMetricName2);
+    Assert.assertEquals(testMetricName1, testMetricName2);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
@@ -23,5 +23,20 @@ package org.apache.pinot.spi.metrics;
  */
 public interface PinotMetricName {
 
+  /**
+   * Returns the actual metric name.
+   */
   Object getMetricName();
+
+  /**
+   * Overrides the equals method. This is needed as {@link PinotMetricName} is used as the key of the key-value pair
+   * inside the hashmap in MetricsRegistry. Without overriding equals() and hashCode() methods, all the existing k-v pairs
+   * stored in hashmap cannot be retrieved by initializing a new key.
+   */
+  boolean equals(Object obj);
+
+  /**
+   * Overrides the hashCode method. This method's contract is the same as equals() method.
+   */
+  int hashCode();
 }


### PR DESCRIPTION
## Description
This PR overrides equals and hashCode methods for PinotMetricName. Unit test added.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
