### PR TITLE
Allow escaping comma characters in CSV files.

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -53,7 +53,9 @@ public class CSVRecordReader implements RecordReader {
     CSVRecordReaderConfig config = (CSVRecordReaderConfig) recordReaderConfig;
     char multiValueDelimiter;
     if (config == null) {
-      _format = CSVFormat.DEFAULT.withDelimiter(CSVRecordReaderConfig.DEFAULT_DELIMITER).withHeader();
+      _format = CSVFormat.DEFAULT.
+          withDelimiter(CSVRecordReaderConfig.DEFAULT_DELIMITER).
+          withEscape(CSVRecordReaderConfig.DEFAULT_ESCAPE).withHeader();
       multiValueDelimiter = CSVRecordReaderConfig.DEFAULT_MULTI_VALUE_DELIMITER;
     } else {
       CSVFormat format;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -87,13 +87,9 @@ public class CSVRecordReader implements RecordReader {
       } else {
         format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }
-
       Character commentMarker = config.getCommentMarker();
       format = format.withCommentMarker(commentMarker);
-
-      char escapeCharacter = config.getEscapeCharacter();
-      format = format.withEscape(escapeCharacter);
-
+      format = format.withEscape(config.getEscapeCharacter());
       _format = format;
       multiValueDelimiter = config.getMultiValueDelimiter();
     }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -53,9 +53,7 @@ public class CSVRecordReader implements RecordReader {
     CSVRecordReaderConfig config = (CSVRecordReaderConfig) recordReaderConfig;
     char multiValueDelimiter;
     if (config == null) {
-      _format = CSVFormat.DEFAULT.
-          withDelimiter(CSVRecordReaderConfig.DEFAULT_DELIMITER).
-          withEscape(CSVRecordReaderConfig.DEFAULT_ESCAPE).withHeader();
+      _format = CSVFormat.DEFAULT.withDelimiter(CSVRecordReaderConfig.DEFAULT_DELIMITER).withHeader();
       multiValueDelimiter = CSVRecordReaderConfig.DEFAULT_MULTI_VALUE_DELIMITER;
     } else {
       CSVFormat format;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -87,8 +87,13 @@ public class CSVRecordReader implements RecordReader {
       } else {
         format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }
+
       Character commentMarker = config.getCommentMarker();
       format = format.withCommentMarker(commentMarker);
+
+      char escapeCharacter = config.getEscapeCharacter();
+      format = format.withEscape(escapeCharacter);
+
       _format = format;
       multiValueDelimiter = config.getMultiValueDelimiter();
     }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -27,13 +27,14 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 public class CSVRecordReaderConfig implements RecordReaderConfig {
   public static final char DEFAULT_DELIMITER = ',';
   public static final char DEFAULT_MULTI_VALUE_DELIMITER = ';';
+  public static final char DEFAULT_ESCAPE = '\\';
 
   private String _fileFormat;
   private String _header;
   private char _delimiter = DEFAULT_DELIMITER;
   private char _multiValueDelimiter = DEFAULT_MULTI_VALUE_DELIMITER;
   private Character _commentMarker;  // Default is null
-  private char _escapeCharacter;
+  private char _escapeCharacter = DEFAULT_ESCAPE;
 
   public String getFileFormat() {
     return _fileFormat;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -27,14 +27,13 @@ import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 public class CSVRecordReaderConfig implements RecordReaderConfig {
   public static final char DEFAULT_DELIMITER = ',';
   public static final char DEFAULT_MULTI_VALUE_DELIMITER = ';';
-  public static final char DEFAULT_ESCAPE = '\\';
 
   private String _fileFormat;
   private String _header;
   private char _delimiter = DEFAULT_DELIMITER;
   private char _multiValueDelimiter = DEFAULT_MULTI_VALUE_DELIMITER;
-  private Character _commentMarker;  // Default is null
-  private char _escapeCharacter = DEFAULT_ESCAPE;
+  private Character _commentMarker;   // Default is null
+  private Character _escapeCharacter; // Default is null
 
   public String getFileFormat() {
     return _fileFormat;
@@ -76,11 +75,11 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
     _commentMarker = commentMarker;
   }
 
-  public char getEscapeCharacter() {
+  public Character getEscapeCharacter() {
     return _escapeCharacter;
   }
 
-  public void setEscapeCharacter(char escapeCharacter) {
+  public void setEscapeCharacter(Character escapeCharacter) {
     _escapeCharacter = escapeCharacter;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -32,8 +32,8 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private String _header;
   private char _delimiter = DEFAULT_DELIMITER;
   private char _multiValueDelimiter = DEFAULT_MULTI_VALUE_DELIMITER;
-
   private Character _commentMarker;  // Default is null
+  private char _escapeCharacter;
 
   public String getFileFormat() {
     return _fileFormat;
@@ -73,6 +73,14 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
 
   public void setCommentMarker(Character commentMarker) {
     _commentMarker = commentMarker;
+  }
+
+  public char getEscapeCharacter() {
+    return _escapeCharacter;
+  }
+
+  public void setEscapeCharacter(char escapeCharacter) {
+    _escapeCharacter = escapeCharacter;
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.plugin.inputformat.csv;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +34,7 @@ import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 /**
@@ -100,5 +103,39 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
         Assert.assertEquals(actualValue, expectedValue == null ? null : String.valueOf(expectedValue));
       }
     }
+  }
+
+  /**
+   * Check if we can parse a CSV file that has escaped comma characters within fields.
+   */
+  @Test
+  public void testEscapeCharacterInCSV()
+    throws Exception {
+    // Create CSV config with backslash as escape character.
+    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
+    csvRecordReaderConfig.setEscapeCharacter('\\');
+
+    // Create a CSV file where records have two values and the second value contains an escaped comma.
+    File escapedFile = new File(_tempDir, "escape.csv");
+    BufferedWriter writer = new BufferedWriter(new FileWriter(escapedFile));
+    writer.write("first,second\n");
+    writer.write("string1, string2\\, string3");
+    writer.flush();
+    writer.close();
+
+    // Try to parse CSV file with escaped comma.
+    CSVRecordReader csvRecordReader = new CSVRecordReader();
+    HashSet<String> fieldsToRead = new HashSet<>();
+    fieldsToRead.add("first");
+    fieldsToRead.add("second");
+    csvRecordReader.init(escapedFile, fieldsToRead, csvRecordReaderConfig);
+
+    GenericRow genericRow = new GenericRow();
+    csvRecordReader.rewind();
+    Assert.assertTrue(csvRecordReader.hasNext());
+    csvRecordReader.next(genericRow);
+
+    Assert.assertEquals(genericRow.getValue("first"), "string1");
+    Assert.assertEquals(genericRow.getValue("second"), " string2, string3");
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -120,7 +120,6 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     BufferedWriter writer = new BufferedWriter(new FileWriter(escapedFile));
     writer.write("first,second\n");
     writer.write("string1, string2\\, string3");
-    writer.flush();
     writer.close();
 
     // Try to parse CSV file with escaped comma.
@@ -129,12 +128,12 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     fieldsToRead.add("first");
     fieldsToRead.add("second");
     csvRecordReader.init(escapedFile, fieldsToRead, csvRecordReaderConfig);
-
     GenericRow genericRow = new GenericRow();
     csvRecordReader.rewind();
+
+    // check if parsing succeeded.
     Assert.assertTrue(csvRecordReader.hasNext());
     csvRecordReader.next(genericRow);
-
     Assert.assertEquals(genericRow.getValue("first"), "string1");
     Assert.assertEquals(genericRow.getValue("second"), " string2, string3");
   }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -113,7 +113,7 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     throws Exception {
     // Create CSV config with backslash as escape character.
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
-    Assert.assertEquals(csvRecordReaderConfig.getEscapeCharacter(), '\\');
+    csvRecordReaderConfig.setEscapeCharacter('\\');
 
     // Create a CSV file where records have two values and the second value contains an escaped comma.
     File escapedFile = new File(_tempDir, "escape.csv");

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -113,7 +113,7 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     throws Exception {
     // Create CSV config with backslash as escape character.
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
-    csvRecordReaderConfig.setEscapeCharacter('\\');
+    Assert.assertEquals(csvRecordReaderConfig.getEscapeCharacter(), '\\');
 
     // Create a CSV file where records have two values and the second value contains an escaped comma.
     File escapedFile = new File(_tempDir, "escape.csv");


### PR DESCRIPTION
## Description
A CSV file can contain fields that contain comma characters. Such a file would be difficult to import as a table since comma is being used as a field delimiter. Note that is not specific to comma character, but can happen with any other delimiter character as well. This PR adds support for escaping delimiters that appear within CSV fields so that they don't get confused with actual delimiters.

Example CSV file with fields containing escaped comma delimiter:
```
id,name,json,ts
1,daffy duck,{"name":"daffy"\, "company":"linkedin"},0
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
