### PR TITLE
Extend PinotMetered in PinotMeter interface

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
@@ -24,7 +24,7 @@ package org.apache.pinot.spi.metrics;
  *
  * @see <a href="http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">EMA</a>
  */
-public interface PinotMeter {
+public interface PinotMeter extends PinotMetered {
 
 
   /**


### PR DESCRIPTION
## Description
This PR extends PinotMetered in PinotMeter interface, as this is the convention in most of the metric systems. E.g.:
https://github.com/dropwizard/metrics/blob/1ca6391043830a03520b98d92bdfeb3a7da4d6b6/metrics-core/src/main/java/com/codahale/metrics/Meter.java

https://github.com/infusionsoft/yammer-metrics/blob/master/metrics-core/src/main/java/com/codahale/metrics/Meter.java

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
