### PR TITLE
Remove methods in PinotMetricsRegistryListener

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMetricsRegistryListener.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/yammer/YammerMetricsRegistryListener.java
@@ -18,11 +18,7 @@
  */
 package org.apache.pinot.common.metrics.yammer;
 
-import com.yammer.metrics.core.Metric;
-import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistryListener;
-import org.apache.pinot.spi.metrics.PinotMetric;
-import org.apache.pinot.spi.metrics.PinotMetricName;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistryListener;
 
 
@@ -31,16 +27,6 @@ public class YammerMetricsRegistryListener implements PinotMetricsRegistryListen
 
   public YammerMetricsRegistryListener(MetricsRegistryListener metricsRegistryListener) {
     _metricsRegistryListener = metricsRegistryListener;
-  }
-
-  @Override
-  public void onMetricAdded(PinotMetricName name, PinotMetric metric) {
-    _metricsRegistryListener.onMetricAdded((MetricName) name.getMetricName(), (Metric) metric.getMetric());
-  }
-
-  @Override
-  public void onMetricRemoved(PinotMetricName name) {
-    _metricsRegistryListener.onMetricRemoved((MetricName) name.getMetricName());
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricsRegistryListener.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricsRegistryListener.java
@@ -22,20 +22,6 @@ package org.apache.pinot.spi.metrics;
  * Listeners for events from the registry.  Listeners must be thread-safe.
  */
 public interface PinotMetricsRegistryListener {
-  /**
-   * Called when a metric has been added to the {@link PinotMetricsRegistry}.
-   *
-   * @param name   the name of the {@link PinotMetric}
-   * @param metric the {@link PinotMetric}
-   */
-  void onMetricAdded(PinotMetricName name, PinotMetric metric);
-
-  /**
-   * Called when a metric has been removed from the {@link PinotMetricsRegistry}.
-   *
-   * @param name the name of the {@link PinotMetric}
-   */
-  void onMetricRemoved(PinotMetricName name);
 
   /**
    * Returned the actual object of MetricsRegistryListener.


### PR DESCRIPTION
## Description
As a wrapper of the actual listener,  the methods of `PinotMetricsRegistryListener` actually don't get called; it's the actual listener in this wrapper who gets registered to the actual registry get called during the callback. 

Plus, different listener interfaces in different libraries require different methods. E.g.
https://github.com/dropwizard/metrics/blob/1ca6391043830a03520b98d92bdfeb3a7da4d6b6/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java

http://javadox.com/com.yammer.metrics/metrics-core/2.2.0/com/yammer/metrics/core/MetricsRegistryListener.html

Thus, there is no need to specify any methods in `PinotMetricsRegistryListener` interface.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
