### PR TITLE
Shade jackson packages in pinot-spi and pinot-avro-base modules

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -74,6 +74,10 @@
                       <pattern>com.google.common.base</pattern>
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
+                    <relocation>
+                      <pattern>com.fasterxml.jackson</pattern>
+                      <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                    </relocation>
                   </relocations>
                 </configuration>
               </execution>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -171,6 +171,10 @@
                       <pattern>com.google.common.base</pattern>
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
+                    <relocation>
+                      <pattern>com.fasterxml.jackson</pattern>
+                      <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                    </relocation>
                   </relocations>
                 </configuration>
               </execution>


### PR DESCRIPTION
## Description
This PR shades jackson packages in pinot-spi and pinot-avro-base modules, as we encounter version conflicts.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
