### PR TITLE
Make dependency on azure-identity provided in pinot-adls plugin

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/README.md
+++ b/pinot-plugins/pinot-file-system/pinot-adls/README.md
@@ -1,0 +1,3 @@
+## ADLS plugin configuration
+
+To run with the ADLS plugin, please download the [azure-identity jar](https://mvnrepository.com/artifact/com.azure/azure-identity/1.2.2) and put add it to the classpath of your Pinot binary.

--- a/pinot-plugins/pinot-file-system/pinot-adls/README.md
+++ b/pinot-plugins/pinot-file-system/pinot-adls/README.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 ## ADLS plugin configuration
 
 To run with the ADLS plugin, please download the [azure-identity jar](https://mvnrepository.com/artifact/com.azure/azure-identity/1.2.2) and put add it to the classpath of your Pinot binary.

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -50,6 +50,16 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.2.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.madgag.spongycastle</groupId>
+          <artifactId>core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xpp3</groupId>
+          <artifactId>xpp3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -50,16 +50,7 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.2.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.madgag.spongycastle</groupId>
-          <artifactId>core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>xpp3</groupId>
-          <artifactId>xpp3</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
Due to the license issues of two transitive dependencies from azure-identity, we make `azure-identity` provided scope. Users need to download the jar and put it on the classpath to use the plugin per the added README
- https://github.com/rtyley/spongycastle/blob/spongy-master/LICENSE.html
- https://github.com/xmlpull-xpp3/xmlpull-xpp3#readme