### PR TITLE
In PinotDataType, trim the string before converting to other types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -317,22 +317,24 @@ public enum PinotDataType {
   STRING {
     @Override
     public Integer toInteger(Object value) {
-      return Integer.parseInt((String) value);
+      return Integer.valueOf(((String) value).trim());
     }
 
     @Override
     public Long toLong(Object value) {
-      return Long.parseLong((String) value);
+      return Long.valueOf(((String) value).trim());
     }
 
     @Override
     public Float toFloat(Object value) {
-      return Float.parseFloat((String) value);
+      // NOTE: No need to trim here because Float.valueOf() will trim the string
+      return Float.valueOf((String) value);
     }
 
     @Override
     public Double toDouble(Object value) {
-      return Double.parseDouble((String) value);
+      // NOTE: No need to trim here because Double.valueOf() will trim the string
+      return Double.valueOf((String) value);
     }
 
     @Override
@@ -342,7 +344,7 @@ public enum PinotDataType {
 
     @Override
     public byte[] toBytes(Object value) {
-      return BytesUtils.toBytes((String) value);
+      return BytesUtils.toBytes(((String) value).trim());
     }
 
     @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -29,16 +29,16 @@ public class PinotDataTypeTest {
   private static final PinotDataType[] SOURCE_TYPES =
       {BYTE, CHARACTER, SHORT, INTEGER, LONG, FLOAT, DOUBLE, STRING, BYTE_ARRAY, CHARACTER_ARRAY, SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY};
   private static final Object[] SOURCE_VALUES =
-      {(byte) 123, (char) 123, (short) 123, 123, 123L, 123f, 123d, "123", new Object[]{(byte) 123}, new Object[]{(char) 123}, new Object[]{(short) 123}, new Object[]{123}, new Object[]{123L}, new Object[]{123f}, new Object[]{123d}, new Object[]{"123"}};
+      {(byte) 123, (char) 123, (short) 123, 123, 123L, 123f, 123d, " 123", new Object[]{(byte) 123}, new Object[]{(char) 123}, new Object[]{(short) 123}, new Object[]{123}, new Object[]{123L}, new Object[]{123f}, new Object[]{123d}, new Object[]{" 123"}};
   private static final PinotDataType[] DEST_TYPES =
       {INTEGER, LONG, FLOAT, DOUBLE, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
   private static final Object[] EXPECTED_DEST_VALUES =
       {123, 123L, 123f, 123d, new Object[]{123}, new Object[]{123L}, new Object[]{123f}, new Object[]{123d}};
   private static final String[] EXPECTED_STRING_VALUES =
       {Byte.toString((byte) 123), Character.toString((char) 123), Short.toString((short) 123), Integer.toString(
-          123), Long.toString(123L), Float.toString(123f), Double.toString(123d), "123", Byte.toString(
+          123), Long.toString(123L), Float.toString(123f), Double.toString(123d), " 123", Byte.toString(
           (byte) 123), Character.toString((char) 123), Short.toString((short) 123), Integer.toString(
-          123), Long.toString(123L), Float.toString(123f), Double.toString(123d), "123"};
+          123), Long.toString(123L), Float.toString(123f), Double.toString(123d), " 123"};
 
   @Test
   public void testNumberConversion() {


### PR DESCRIPTION
Handle the case where the source string contains leading/trailing spaces and need to be converted to other types