### PR TITLE
Removing redundant check for column with RAW encoding and noDictionar…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -527,10 +527,6 @@ public final class TableConfigUtils {
 
       List<String> noDictionaryColumns = indexingConfigs.getNoDictionaryColumns();
       switch (fieldConfig.getEncodingType()) {
-        case RAW:
-          Preconditions.checkState(noDictionaryColumns != null && noDictionaryColumns.contains(columnName),
-              "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
-          break;
         case DICTIONARY:
           if (noDictionaryColumns != null) {
             Preconditions.checkArgument(!noDictionaryColumns.contains(columnName),


### PR DESCRIPTION
…y config

## Description
For a given field config with RAW encoding, it shouldn't be necessary to include the column name in noDictionaryColumns array. Removing this check.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? 
No
