### PR TITLE
Adding a check for multi-value column in star tree indexing config

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -371,6 +371,7 @@ public final class TableConfigUtils {
     }
     Map<String, String> columnNameToConfigMap = new HashMap<>();
     Set<String> noDictionaryColumnsSet = new HashSet<>();
+    String STAR_TREE_CONFIG_NAME = "StarTreeIndex Config";
 
     if (indexingConfig.getNoDictionaryColumns() != null) {
       for (String columnName : indexingConfig.getNoDictionaryColumns()) {
@@ -439,7 +440,7 @@ public final class TableConfigUtils {
       for (StarTreeIndexConfig starTreeIndexConfig : starTreeIndexConfigList) {
         // Dimension split order cannot be null
         for (String columnName : starTreeIndexConfig.getDimensionsSplitOrder()) {
-          columnNameToConfigMap.put(columnName, "StarTreeIndex Config");
+          columnNameToConfigMap.put(columnName, STAR_TREE_CONFIG_NAME);
         }
         // Function column pairs cannot be null
         for (String functionColumnPair : starTreeIndexConfig.getFunctionColumnPairs()) {
@@ -452,13 +453,13 @@ public final class TableConfigUtils {
           }
           String columnName = columnPair.getColumn();
           if (!columnName.equals(AggregationFunctionColumnPair.STAR)) {
-            columnNameToConfigMap.put(columnName, "StarTreeIndex Config");
+            columnNameToConfigMap.put(columnName, STAR_TREE_CONFIG_NAME);
           }
         }
         List<String> skipDimensionList = starTreeIndexConfig.getSkipStarNodeCreationForDimensions();
         if (skipDimensionList != null) {
           for (String columnName : skipDimensionList) {
-            columnNameToConfigMap.put(columnName, "StarTreeIndex Config");
+            columnNameToConfigMap.put(columnName, STAR_TREE_CONFIG_NAME);
           }
         }
       }
@@ -467,8 +468,13 @@ public final class TableConfigUtils {
     for (Map.Entry<String, String> entry : columnNameToConfigMap.entrySet()) {
       String columnName = entry.getKey();
       String configName = entry.getValue();
-      Preconditions.checkState(schema.getFieldSpecFor(columnName) != null,
+      FieldSpec columnFieldSpec = schema.getFieldSpecFor(columnName);
+      Preconditions.checkState(columnFieldSpec != null,
           "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
+      if (configName.equals(STAR_TREE_CONFIG_NAME)) {
+        Preconditions.checkState(columnFieldSpec.isSingleValueField(),
+            "Column Name " + columnName + " defined in " + configName + " must be a single value column");
+      }
     }
 
     // Range index semantic validation

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.util;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections.MultiMap;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.config.TagNameUtils;
@@ -369,7 +371,7 @@ public final class TableConfigUtils {
     if (indexingConfig == null || schema == null) {
       return;
     }
-    Map<String, String> columnNameToConfigMap = new HashMap<>();
+    ArrayListMultimap<String, String> columnNameToConfigMap = ArrayListMultimap.create();
     Set<String> noDictionaryColumnsSet = new HashSet<>();
     String STAR_TREE_CONFIG_NAME = "StarTreeIndex Config";
 
@@ -465,7 +467,7 @@ public final class TableConfigUtils {
       }
     }
 
-    for (Map.Entry<String, String> entry : columnNameToConfigMap.entrySet()) {
+    for (Map.Entry<String, String> entry : columnNameToConfigMap.entries()) {
       String columnName = entry.getKey();
       String configName = entry.getValue();
       FieldSpec columnFieldSpec = schema.getFieldSpecFor(columnName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/TableConfigUtils.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections.MultiMap;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.common.utils.config.TagNameUtils;

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/TableConfigUtilsTest.java
@@ -883,6 +883,17 @@ public class TableConfigUtilsTest {
       // expected
     }
 
+    starTreeIndexConfig =
+        new StarTreeIndexConfig(Arrays.asList("multiValCol"), Arrays.asList("multiValCol"), Arrays.asList("SUM__multiValCol"), 1);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for multi-value column name in StarTreeIndex config");
+    } catch (Exception e) {
+      // expected
+    }
+
     FieldConfig fieldConfig = new FieldConfig("myCol2", null, null, null);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(Arrays.asList(fieldConfig)).build();


### PR DESCRIPTION
## Description
Star tree index does not work with multi-value columns. Adding a simple validation check for this.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes?
No
