### PR TITLE
Skip loading columns not in the schema

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -21,7 +21,9 @@ package org.apache.pinot.core.indexsegment.immutable;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
@@ -105,12 +107,25 @@ public class ImmutableSegmentLoader {
       return new EmptyIndexSegment(segmentMetadata);
     }
 
+    // Remove columns not in schema from the metadata
+    Map<String, ColumnMetadata> columnMetadataMap = segmentMetadata.getColumnMetadataMap();
+    if (schema != null) {
+      Set<String> columnsInMetadata = new HashSet<>(columnMetadataMap.keySet());
+      columnsInMetadata.removeIf(schema::hasColumn);
+      if (!columnsInMetadata.isEmpty()) {
+        LOGGER.info("Skip loading columns only exist in metadata but not in schema: {}", columnsInMetadata);
+        for (String column : columnsInMetadata) {
+          segmentMetadata.removeColumn(column);
+        }
+      }
+    }
+
     // Load the segment
     ReadMode readMode = indexLoadingConfig.getReadMode();
     SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, readMode);
     SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();
     Map<String, ColumnIndexContainer> indexContainerMap = new HashMap<>();
-    for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
+    for (Map.Entry<String, ColumnMetadata> entry : columnMetadataMap.entrySet()) {
       indexContainerMap.put(entry.getKey(),
           new PhysicalColumnIndexContainer(segmentReader, entry.getValue(), indexLoadingConfig, indexDir));
     }
@@ -124,7 +139,7 @@ public class ImmutableSegmentLoader {
         VirtualColumnContext context = new VirtualColumnContext(fieldSpec, segmentMetadata.getTotalDocs());
         VirtualColumnProvider provider = VirtualColumnProviderFactory.buildProvider(context);
         indexContainerMap.put(columnName, provider.buildColumnIndexContainer(context));
-        segmentMetadata.getColumnMetadataMap().put(columnName, provider.buildMetadata(context));
+        columnMetadataMap.put(columnName, provider.buildMetadata(context));
       }
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import javax.validation.constraints.AssertTrue;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.exception.QueryException;
@@ -111,8 +110,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       "On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema";
   private static final String SCHEMA_FILE_NAME_WITH_MISSING_COLUMNS =
       "On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_missing_columns.schema";
-  private static final String TEST_DEFAULT_COLUMNS_QUERY =
-      "SELECT COUNT(*) FROM mytable WHERE NewAddedIntDimension < 0";
+  private static final String TEST_EXTRA_COLUMNS_QUERY = "SELECT COUNT(*) FROM mytable WHERE NewAddedIntDimension < 0";
+  private static final String TEST_MISSING_COLUMNS_QUERY = "SELECT COUNT(*) FROM mytable WHERE AirlineID > 0";
   private static final String SELECT_STAR_QUERY = "SELECT * FROM mytable";
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =
@@ -442,24 +441,24 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   /** Check if server returns error response quickly without timing out Broker. */
   @Test
   public void testServerErrorWithBrokerTimeout()
-    throws Exception {
-      // Set query timeout
-      long queryTimeout = 5000;
-      TableConfig tableConfig = getOfflineTableConfig();
-      tableConfig.setQueryConfig(new QueryConfig(queryTimeout));
-      updateTableConfig(tableConfig);
+      throws Exception {
+    // Set query timeout
+    long queryTimeout = 5000;
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.setQueryConfig(new QueryConfig(queryTimeout));
+    updateTableConfig(tableConfig);
 
-      long startTime = System.currentTimeMillis();
-      // The query below will fail execution due to use of double quotes around value in IN clause.
-      JsonNode queryResponse = postSqlQuery("SELECT count(*) FROM mytable WHERE Dest IN (\"DFW\")");
-      String result = queryResponse.toPrettyString();
+    long startTime = System.currentTimeMillis();
+    // The query below will fail execution due to use of double quotes around value in IN clause.
+    JsonNode queryResponse = postSqlQuery("SELECT count(*) FROM mytable WHERE Dest IN (\"DFW\")");
+    String result = queryResponse.toPrettyString();
 
-      assertTrue(System.currentTimeMillis() - startTime < queryTimeout);
-      assertTrue(queryResponse.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
+    assertTrue(System.currentTimeMillis() - startTime < queryTimeout);
+    assertTrue(queryResponse.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
-      // Remove timeout
-      tableConfig.setQueryConfig(null);
-      updateTableConfig(tableConfig);
+    // Remove timeout
+    tableConfig.setQueryConfig(null);
+    updateTableConfig(tableConfig);
   }
 
   @Test
@@ -615,66 +614,101 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     long numTotalDocs = getCountStarResult();
 
-    reloadDefaultColumns(true);
+    reloadWithExtraColumns();
     JsonNode queryResponse = postQuery(SELECT_STAR_QUERY);
     assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
     assertEquals(queryResponse.get("selectionResults").get("columns").size(), 91);
 
     testNewAddedColumns();
 
-    reloadDefaultColumns(false);
+    reloadWithMissingColumns();
+    queryResponse = postQuery(SELECT_STAR_QUERY);
+    assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+    assertEquals(queryResponse.get("selectionResults").get("columns").size(), 75);
+
+    reloadWithRegularColumns();
     queryResponse = postQuery(SELECT_STAR_QUERY);
     assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
     assertEquals(queryResponse.get("selectionResults").get("columns").size(), 79);
   }
 
-  private void reloadDefaultColumns(boolean withExtraColumns)
+  private void reloadWithExtraColumns()
       throws Exception {
     long numTotalDocs = getCountStarResult();
 
-    if (withExtraColumns) {
-      // Add columns to the schema first to pass the validation of the table config
-      _schemaFileName = SCHEMA_FILE_NAME_WITH_EXTRA_COLUMNS;
-      addSchema(createSchema());
-      TableConfig tableConfig = getOfflineTableConfig();
-      tableConfig.setIngestionConfig(new IngestionConfig(null, null, null, Arrays
-          .asList(new TransformConfig("NewAddedDerivedHoursSinceEpoch", "times(DaysSinceEpoch, 24)"),
-              new TransformConfig("NewAddedDerivedSecondsSinceEpoch", "times(times(DaysSinceEpoch, 24), 3600)"))));
-      updateTableConfig(tableConfig);
-    } else {
-      // Remove columns from the table config first to pass the validation of the table config
-      TableConfig tableConfig = getOfflineTableConfig();
-      tableConfig.setIngestionConfig(null);
-      updateTableConfig(tableConfig);
-      _schemaFileName = SCHEMA_FILE_NAME_WITH_MISSING_COLUMNS;
-      addSchema(createSchema());
-    }
+    // Add columns to the schema first to pass the validation of the table config
+    _schemaFileName = SCHEMA_FILE_NAME_WITH_EXTRA_COLUMNS;
+    addSchema(createSchema());
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.setIngestionConfig(new IngestionConfig(null, null, null, Arrays
+        .asList(new TransformConfig("NewAddedDerivedHoursSinceEpoch", "times(DaysSinceEpoch, 24)"),
+            new TransformConfig("NewAddedDerivedSecondsSinceEpoch", "times(times(DaysSinceEpoch, 24), 3600)"))));
+    updateTableConfig(tableConfig);
 
     // Trigger reload
     reloadOfflineTable(getTableName());
 
-    String errorMessage;
-    if (withExtraColumns) {
-      errorMessage = "Failed to add default columns";
-    } else {
-      errorMessage = "Failed to remove default columns";
-    }
-
     TestUtils.waitForCondition(aVoid -> {
       try {
-        JsonNode queryResponse = postQuery(TEST_DEFAULT_COLUMNS_QUERY);
+        JsonNode queryResponse = postQuery(TEST_EXTRA_COLUMNS_QUERY);
         // Total docs should not change during reload
         assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
         long count = queryResponse.get("aggregationResults").get(0).get("value").asLong();
-        if (withExtraColumns) {
-          return count == numTotalDocs;
-        } else {
-          return count == 0;
-        }
+        return count == numTotalDocs;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-    }, 600_000L, errorMessage);
+    }, 600_000L, "Failed to add default columns");
+  }
+
+  private void reloadWithMissingColumns()
+      throws Exception {
+    long numTotalDocs = getCountStarResult();
+
+    // Remove columns from the table config first to pass the validation of the table config
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.setIngestionConfig(null);
+    updateTableConfig(tableConfig);
+    _schemaFileName = SCHEMA_FILE_NAME_WITH_MISSING_COLUMNS;
+    addSchema(createSchema());
+
+    // Trigger reload
+    reloadOfflineTable(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse = postQuery(TEST_MISSING_COLUMNS_QUERY);
+        // Total docs should not change during reload
+        assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+        long count = queryResponse.get("aggregationResults").get(0).get("value").asLong();
+        return count == 0;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to skip missing columns");
+  }
+
+  private void reloadWithRegularColumns()
+      throws Exception {
+    long numTotalDocs = getCountStarResult();
+
+    _schemaFileName = DEFAULT_SCHEMA_FILE_NAME;
+    addSchema(createSchema());
+
+    // Trigger reload
+    reloadOfflineTable(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse = postQuery(TEST_MISSING_COLUMNS_QUERY);
+        // Total docs should not change during reload
+        assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+        long count = queryResponse.get("aggregationResults").get(0).get("value").asLong();
+        return count == numTotalDocs;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to reload regular columns");
   }
 
   private void testNewAddedColumns()


### PR DESCRIPTION
## Description
Currently, when a column is added to the schema, server will generate default columns if the segment does not have the new column. But when a column is removed from the schema, the server still load all the columns within the segments. This could cause problem for `select *` queries because different segments might contain different columns.
With the change, server will skip loading the columns not in the schema, and all the segments should have the same set of columns loaded.