### PR TITLE
Add toString method in PinotMetricName interface

### DIFF
--- a/pinot-plugins/pinot-metrics/pinot-yammer/src/main/java/org/apache/pinot/plugin/metrics/yammer/YammerMetricName.java
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/src/main/java/org/apache/pinot/plugin/metrics/yammer/YammerMetricName.java
@@ -60,4 +60,9 @@ public class YammerMetricName implements PinotMetricName {
   public int hashCode() {
     return _metricName.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return _metricName.toString();
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetricName.java
@@ -39,4 +39,10 @@ public interface PinotMetricName {
    * Overrides the hashCode method. This method's contract is the same as equals() method.
    */
   int hashCode();
+
+  /**
+   * Overrides the toString method.
+   * This could be used to print out the actual metrics name instead of the memory address under this wrapper.
+   */
+  String toString();
 }


### PR DESCRIPTION
## Description
This PR adds toString method in PinotMetricName interface, so that the actual metric name can explicitly printed instead of just printing the memory address.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
