### PR TITLE
Add an option to fail segment creation job when getting empty files

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -105,6 +105,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
+  private boolean _failOnEmptyRecord = false;
 
   // constructed from FieldConfig
   private Map<String, Map<String, String>> _columnProperties = new HashMap<>();
@@ -669,5 +670,13 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public void setNullHandlingEnabled(boolean nullHandlingEnabled) {
     _nullHandlingEnabled = nullHandlingEnabled;
+  }
+
+  public boolean isFailOnEmptyRecord() {
+    return _failOnEmptyRecord;
+  }
+
+  public void setFailOnEmptyRecord(boolean failOnEmptyRecord) {
+    _failOnEmptyRecord = failOnEmptyRecord;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -105,7 +105,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
-  private boolean _failOnEmptyRecord = false;
+  private boolean _failOnEmptySegment = false;
 
   // constructed from FieldConfig
   private Map<String, Map<String, String>> _columnProperties = new HashMap<>();
@@ -672,11 +672,11 @@ public class SegmentGeneratorConfig implements Serializable {
     _nullHandlingEnabled = nullHandlingEnabled;
   }
 
-  public boolean isFailOnEmptyRecord() {
-    return _failOnEmptyRecord;
+  public boolean isFailOnEmptySegment() {
+    return _failOnEmptySegment;
   }
 
-  public void setFailOnEmptyRecord(boolean failOnEmptyRecord) {
-    _failOnEmptyRecord = failOnEmptyRecord;
+  public void setFailOnEmptySegment(boolean failOnEmptySegment) {
+    _failOnEmptySegment = failOnEmptySegment;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -146,6 +146,9 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     this.config = config;
     recordReader = dataSource.getRecordReader();
     dataSchema = config.getSchema();
+    if (config.isFailOnEmptyRecord()) {
+      Preconditions.checkState(recordReader.hasNext(), "No record in data source");
+    }
 
     _recordTransformer = recordTransformer;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -146,7 +146,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     this.config = config;
     recordReader = dataSource.getRecordReader();
     dataSchema = config.getSchema();
-    if (config.isFailOnEmptyRecord()) {
+    if (config.isFailOnEmptySegment()) {
       Preconditions.checkState(recordReader.hasNext(), "No record in data source");
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -170,8 +170,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       indexDir.mkdirs();
     }
 
-    _ingestionSchemaValidator = SchemaValidatorFactory.getSchemaValidator(dataSchema, recordReader.getClass().getName(),
-        config.getInputFilePath());
+    _ingestionSchemaValidator = SchemaValidatorFactory
+        .getSchemaValidator(dataSchema, recordReader.getClass().getName(), config.getInputFilePath());
 
     // Create a temporary directory used in segment creation
     tempIndexDir = new File(indexDir, "tmp-" + UUID.randomUUID());
@@ -246,6 +246,10 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
         segmentName = config.getSegmentNameGenerator()
             .generateSegmentName(sequenceId, timeColumnStatistics.getMinValue(), timeColumnStatistics.getMaxValue());
       } else {
+        // When totalDoc is 0, check whether 'failOnEmptySegment' option is true. If so, directly fail the segment creation.
+        Preconditions.checkArgument(!config.isFailOnEmptySegment(),
+            "Failing the empty segment creation as the option 'failOnEmptySegment' is set to: " + config
+                .isFailOnEmptySegment());
         // Generate a unique name for a segment with no rows
         long now = System.currentTimeMillis();
         segmentName = config.getSegmentNameGenerator().generateSegmentName(sequenceId, now, now);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -64,7 +64,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
   public static final String USE_GLOBAL_DIRECTORY_SEQUENCE_ID = "use.global.directory.sequence.id";
 
-  private SegmentGenerationTaskSpec _taskSpec;
+  private final SegmentGenerationTaskSpec _taskSpec;
 
   public SegmentGenerationTaskRunner(SegmentGenerationTaskSpec taskSpec) {
     _taskSpec = taskSpec;
@@ -103,6 +103,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
     segmentGeneratorConfig.setRecordReaderPath(_taskSpec.getRecordReaderSpec().getClassName());
     segmentGeneratorConfig.setInputFilePath(_taskSpec.getInputFilePath());
     segmentGeneratorConfig.setCustomProperties(_taskSpec.getCustomProperties());
+    segmentGeneratorConfig.setFailOnEmptySegment(_taskSpec.isFailOnEmptySegment());
 
     //build segment
     SegmentIndexCreationDriverImpl segmentIndexCreationDriver = new SegmentIndexCreationDriverImpl();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -96,7 +96,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
     } else {
       LOGGER.warn("Cannot find local Pinot plugins directory at [{}]", localPluginsTarFile.getAbsolutePath());
     }
-    
+
     // Register file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
@@ -150,6 +150,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
       taskSpec.setSequenceId(idx);
       taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
+      taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
       taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
       // Start a thread that reports progress every minute during segment generation to prevent job getting killed
@@ -186,7 +187,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
           .resolve(segmentTarFileName);
       LOGGER.info("Copying segment tar file from [{}] to [{}]", localSegmentTarFile, outputSegmentTarURI);
       outputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
-      
+
       FileUtils.deleteQuietly(localSegmentDir);
       FileUtils.deleteQuietly(localSegmentTarFile);
       FileUtils.deleteQuietly(localInputDataFile);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunnerTest.java
@@ -56,18 +56,18 @@ public class HadoopSegmentGenerationJobRunnerTest {
     File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
     testDir.delete();
     testDir.mkdirs();
-    
+
     File inputDir = new File(testDir, "input");
     inputDir.mkdirs();
     File inputFile = new File(inputDir, "input.csv");
     FileUtils.writeLines(inputFile, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
-    
+
     final String outputFilename = "myTable_OFFLINE_0.tar.gz";
     final String otherFilename = "myTable_OFFLINE_100.tar.gz";
     File outputDir = new File(testDir, "output");
     FileUtils.touch(new File(outputDir, outputFilename));
     FileUtils.touch(new File(outputDir, otherFilename));
-    
+
     // Set up schema file.
     final String schemaName = "mySchema";
     File schemaFile = new File(testDir, "schema");
@@ -77,7 +77,7 @@ public class HadoopSegmentGenerationJobRunnerTest {
       .addMetric("col2", DataType.INT)
       .build();
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
-    
+
     // Set up table config file.
     File tableConfigFile = new File(testDir, "tableConfig");
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
@@ -86,23 +86,23 @@ public class HadoopSegmentGenerationJobRunnerTest {
       .setNumReplicas(1)
       .build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
-    
+
     File stagingDir = new File(testDir, "staging");
     stagingDir.mkdir();
     // Add the staging output dir, which should cause code to fail unless we've added code to remove
     // the staging dir if it exists.
     FileUtils.touch(new File(stagingDir, "output"));
-    
+
     // Set up a plugins dir, with a sub-directory. We'll use an external jar,
     // since using a class inside of Pinot to find the enclosing jar is somehow
-    // finding the directory of classes vs. the actual jar, on the build server 
+    // finding the directory of classes vs. the actual jar, on the build server
     // (though it works fine in other configurations).
     File pluginsDir = new File(testDir, "plugins");
     File myPluginDir = new File(pluginsDir, "my-plugin");
     myPluginDir.mkdirs();
     File pluginJar = new File(WordUtils.class.getProtectionDomain().getCodeSource().getLocation().toURI());
     FileUtils.copyFile(pluginJar, new File(myPluginDir, pluginJar.getName()));
-    
+
     // Set up dependency jars dir.
     // FUTURE set up jar with class that we need for reading file, so we know it's working
     File dependencyJarsDir = new File(testDir, "jars");
@@ -115,19 +115,19 @@ public class HadoopSegmentGenerationJobRunnerTest {
     jobSpec.setInputDirURI(inputDir.toURI().toString());
     jobSpec.setOutputDirURI(outputDir.toURI().toString());
     jobSpec.setOverwriteOutput(false);
-    
+
     RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
     recordReaderSpec.setDataFormat("csv");
     recordReaderSpec.setClassName(CSVRecordReader.class.getName());
     recordReaderSpec.setConfigClassName(CSVRecordReaderConfig.class.getName());
     jobSpec.setRecordReaderSpec(recordReaderSpec);
-    
+
     TableSpec tableSpec = new TableSpec();
     tableSpec.setTableName("myTable");
     tableSpec.setSchemaURI(schemaFile.toURI().toString());
     tableSpec.setTableConfigURI(tableConfigFile.toURI().toString());
     jobSpec.setTableSpec(tableSpec);
-    
+
     ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
     efSpec.setName("hadoop");
     efSpec.setSegmentGenerationJobRunnerClassName(HadoopSegmentGenerationJobRunner.class.getName());
@@ -136,17 +136,19 @@ public class HadoopSegmentGenerationJobRunnerTest {
     extraConfigs.put("dependencyJarDir", dependencyJarsDir.getAbsolutePath());
     efSpec.setExtraConfigs(extraConfigs);
     jobSpec.setExecutionFrameworkSpec(efSpec);
-    
+
     PinotFSSpec pfsSpec = new PinotFSSpec();
     pfsSpec.setScheme("file");
     pfsSpec.setClassName(LocalPinotFS.class.getName());
     jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
-    
-    System.setProperty(PluginManager.PLUGINS_DIR_PROPERTY_NAME, pluginsDir.getAbsolutePath());    
+
+    jobSpec.setFailOnEmptySegment(true);
+
+    System.setProperty(PluginManager.PLUGINS_DIR_PROPERTY_NAME, pluginsDir.getAbsolutePath());
     HadoopSegmentGenerationJobRunner jobRunner = new HadoopSegmentGenerationJobRunner(jobSpec);
     jobRunner.run();
     Assert.assertFalse(stagingDir.exists());
-    
+
     // The output directory should still have the original file in it.
     File oldSegmentFile = new File(outputDir, otherFilename);
     Assert.assertTrue(oldSegmentFile.exists());
@@ -156,7 +158,7 @@ public class HadoopSegmentGenerationJobRunnerTest {
     Assert.assertTrue(newSegmentFile.exists());
     Assert.assertTrue(newSegmentFile.isFile());
     Assert.assertTrue(newSegmentFile.length() == 0);
-    
+
     // Now run again, but this time with overwriting of output files, and confirm we got a valid segment file.
     jobSpec.setOverwriteOutput(true);
     jobRunner = new HadoopSegmentGenerationJobRunner(jobSpec);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -305,6 +305,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setTableConfig(SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI()));
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
+          taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
           taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
           SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -248,6 +248,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
     taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
     taskSpec.setSequenceId(seqId);
+    taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
     taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
     LOGGER.info("Submitting one Segment Generation Task for {}", inputFileURI);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -257,7 +257,7 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
     segmentGeneratorConfig.setOnHeap(true);
     // Enable failing the job when meeting empty record to early detect potential issue from upstream.
     // This is useful since releasing the constraint in offline job could allow unexpected issues appear without people's notice.
-    segmentGeneratorConfig.setFailOnEmptyRecord(true);
+    segmentGeneratorConfig.setFailOnEmptySegment(true);
 
     addAdditionalSegmentGeneratorConfigs(segmentGeneratorConfig, hdfsInputFile, sequenceId);
 

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -255,6 +255,9 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
       segmentGeneratorConfig.setReaderConfig(getReaderConfig(fileFormat));
     }
     segmentGeneratorConfig.setOnHeap(true);
+    // Enable failing the job when meeting empty record to early detect potential issue from upstream.
+    // This is useful since releasing the constraint in offline job could allow unexpected issues appear without people's notice.
+    segmentGeneratorConfig.setFailOnEmptyRecord(true);
 
     addAdditionalSegmentGeneratorConfigs(segmentGeneratorConfig, hdfsInputFile, sequenceId);
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskExecutor.java
@@ -306,6 +306,9 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
     }
     taskSpec.setTableConfig(tableConfig);
     taskSpec.setSequenceId(Integer.parseInt(taskConfigs.get(BatchConfigProperties.SEQUENCE_ID)));
+    if (taskConfigs.containsKey(BatchConfigProperties.FAIL_ON_EMPTY_SEGMENT)) {
+      taskSpec.setFailOnEmptySegment(Boolean.parseBoolean(taskConfigs.get(BatchConfigProperties.FAIL_ON_EMPTY_SEGMENT)));
+    }
     SegmentNameGeneratorSpec segmentNameGeneratorSpec = new SegmentNameGeneratorSpec();
     segmentNameGeneratorSpec.setType(taskConfigs.get(BatchConfigProperties.SEGMENT_NAME_GENERATOR_TYPE));
     segmentNameGeneratorSpec.setConfigs(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -49,6 +49,7 @@ public class BatchConfigProperties {
   public static final String PUSH_CONTROLLER_URI = "push.controllerUri";
   public static final String PUSH_SEGMENT_URI_PREFIX = "push.segmentUriPrefix";
   public static final String PUSH_SEGMENT_URI_SUFFIX = "push.segmentUriSuffix";
+  public static final String FAIL_ON_EMPTY_SEGMENT = "fail.on.empty.segment";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -121,6 +121,8 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private TlsSpec _tlsSpec;
 
+  private boolean _failOnEmptySegment = false;
+
   public ExecutionFrameworkSpec getExecutionFrameworkSpec() {
     return _executionFrameworkSpec;
   }
@@ -272,6 +274,14 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setTlsSpec(TlsSpec tlsSpec) {
     _tlsSpec = tlsSpec;
+  }
+
+  public boolean isFailOnEmptySegment() {
+    return _failOnEmptySegment;
+  }
+
+  public void setFailOnEmptySegment(boolean failOnEmptySegment) {
+    _failOnEmptySegment = failOnEmptySegment;
   }
 }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -121,6 +121,9 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private TlsSpec _tlsSpec;
 
+  /**
+   * Should fail segment generation if it's an empty segment.
+   */
   private boolean _failOnEmptySegment = false;
 
   public ExecutionFrameworkSpec getExecutionFrameworkSpec() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.spi.ingestion.batch.spec;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -68,6 +67,8 @@ public class SegmentGenerationTaskSpec implements Serializable {
    * sequence id
    */
   private int _sequenceId;
+
+  private boolean _failOnEmptySegment = false;
 
   /**
    * Custom properties set into segment metadata
@@ -128,6 +129,14 @@ public class SegmentGenerationTaskSpec implements Serializable {
 
   public void setSequenceId(int sequenceId) {
     _sequenceId = sequenceId;
+  }
+
+  public boolean isFailOnEmptySegment() {
+    return _failOnEmptySegment;
+  }
+
+  public void setFailOnEmptySegment(boolean failOnEmptySegment) {
+    _failOnEmptySegment = failOnEmptySegment;
   }
 
   public void setCustomProperty(String key, String value) {


### PR DESCRIPTION
## Description
This PR adds an option to fail segment creation job when getting empty files.

Enable failing the job when meeting empty record to early detect potential issue from upstream.
This is useful since releasing the constraint in offline job could allow unexpected issues appear without people's notice.
Plus, even though code has been added to prune for empty segments, the retentions of offline table are much longer than the ones of realtime tables. Holding too many metadata for empty segments in ZK could also be a potential issue.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
