### PR TITLE
Add pinot-yammer to pinot-tools pom

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -123,6 +123,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-yammer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>


### PR DESCRIPTION
## Description
This PR adds pinot-yammer to pinot-tools pom in order to fix the following exception:
```
2021/03/11 20:28:36.874 ERROR [StartServiceManagerCommand] [main] Failed to start a Pinot [CONTROLLER] at 10.357 since launch
java.lang.IllegalStateException: Failed to initialize PinotMetricsFactory. Please check if any pinot-metrics related jar is actually added to the classpath.
	at com.google.common.base.Preconditions.checkState(Preconditions.java:444) ~[guava-20.0.jar:?]
	at org.apache.pinot.common.metrics.PinotMetricUtils.initializePinotMetricsFactory(PinotMetricUtils.java:85) ~[classes/:?]
	at org.apache.pinot.common.metrics.PinotMetricUtils.init(PinotMetricUtils.java:57) ~[classes/:?]
	at org.apache.pinot.controller.ControllerStarter.initControllerMetrics(ControllerStarter.java:483) ~[classes/:?]
	at org.apache.pinot.controller.ControllerStarter.start(ControllerStarter.java:279) ~[classes/:?]
	at org.apache.pinot.tools.service.PinotServiceManager.startController(PinotServiceManager.java:116) ~[classes/:?]
	at org.apache.pinot.tools.service.PinotServiceManager.startRole(PinotServiceManager.java:91) ~[classes/:?]
	at org.apache.pinot.tools.admin.command.StartServiceManagerCommand.lambda$startBootstrapServices$0(StartServiceManagerCommand.java:234) ~[classes/:?]
	at org.apache.pinot.tools.admin.command.StartServiceManagerCommand.startPinotService(StartServiceManagerCommand.java:286) [classes/:?]
	at org.apache.pinot.tools.admin.command.StartServiceManagerCommand.startBootstrapServices(StartServiceManagerCommand.java:233) [classes/:?]
	at org.apache.pinot.tools.admin.command.StartServiceManagerCommand.execute(StartServiceManagerCommand.java:183) [classes/:?]
	at org.apache.pinot.tools.admin.command.StartControllerCommand.execute(StartControllerCommand.java:130) [classes/:?]
	at org.apache.pinot.tools.admin.command.QuickstartRunner.startControllers(QuickstartRunner.java:124) [classes/:?]
	at org.apache.pinot.tools.admin.command.QuickstartRunner.startAll(QuickstartRunner.java:170) [classes/:?]
	at org.apache.pinot.tools.Quickstart.execute(Quickstart.java:169) [classes/:?]
	at org.apache.pinot.tools.admin.command.QuickStartCommand.execute(QuickStartCommand.java:78) [classes/:?]
	at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:164) [classes/:?]
	at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:184) [classes/:?]
```
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
