### PR TITLE
Extends GroupByCombineOperator and GroupByOrderByCombineOperator from BaseCombineOperator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -59,7 +59,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
   // deleted/refreshed, the segment will be released after the main thread returns, which would lead to undefined
   // behavior (even JVM crash) when processing queries against it.
   protected final Phaser _phaser = new Phaser(1);
-  protected final Future[] _futures;
+  protected Future[] _futures;
   // Use a _blockingQueue to store the per-segment result
   private final BlockingQueue<IntermediateResultsBlock> _blockingQueue;
 
@@ -79,6 +79,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       long endTimeMs, int numThreads) {
     this(operators, queryContext, executorService, endTimeMs);
     _numThreads = numThreads;
+    _futures = new Future[_numThreads];
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -52,77 +52,102 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
   protected final ExecutorService _executorService;
   protected final long _endTimeMs;
 
+  protected final int _numOperators;
+  protected int _numThreads;
+  // Use a Phaser to ensure all the Futures are done (not scheduled, finished or interrupted) before the main thread
+  // returns. We need to ensure this because the main thread holds the reference to the segments. If a segment is
+  // deleted/refreshed, the segment will be released after the main thread returns, which would lead to undefined
+  // behavior (even JVM crash) when processing queries against it.
+  protected final Phaser _phaser = new Phaser(1);
+  protected final Future[] _futures;
+  // Use a _blockingQueue to store the per-segment result
+  private final BlockingQueue<IntermediateResultsBlock> _blockingQueue;
+
   public BaseCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
       long endTimeMs) {
     _operators = operators;
     _queryContext = queryContext;
     _executorService = executorService;
     _endTimeMs = endTimeMs;
+    _numOperators = _operators.size();
+    _numThreads = CombineOperatorUtils.getNumThreadsForQuery(_numOperators);
+    _blockingQueue = new ArrayBlockingQueue<>(_numOperators);
+    _futures = new Future[_numThreads];
+  }
+
+  public BaseCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
+      long endTimeMs, int numThreads) {
+    this(operators, queryContext, executorService, endTimeMs);
+    _numThreads = numThreads;
   }
 
   @Override
   protected IntermediateResultsBlock getNextBlock() {
-    int numOperators = _operators.size();
-    int numThreads = CombineOperatorUtils.getNumThreadsForQuery(numOperators);
-
-    // Use a BlockingQueue to store the per-segment result
-    BlockingQueue<IntermediateResultsBlock> blockingQueue = new ArrayBlockingQueue<>(numOperators);
-    // Use a Phaser to ensure all the Futures are done (not scheduled, finished or interrupted) before the main thread
-    // returns. We need to ensure this because the main thread holds the reference to the segments. If a segment is
-    // deleted/refreshed, the segment will be released after the main thread returns, which would lead to undefined
-    // behavior (even JVM crash) when processing queries against it.
-    Phaser phaser = new Phaser(1);
-
-    Future[] futures = new Future[numThreads];
-    for (int i = 0; i < numThreads; i++) {
+    for (int i = 0; i < _numThreads; i++) {
       int threadIndex = i;
-      futures[i] = _executorService.submit(new TraceRunnable() {
+      _futures[i] = _executorService.submit(new TraceRunnable() {
         @Override
         public void runJob() {
-          try {
-            // Register the thread to the phaser
-            // NOTE: If the phaser is terminated (returning negative value) when trying to register the thread, that
-            //       means the query execution has finished, and the main thread has deregistered itself and returned
-            //       the result. Directly return as no execution result will be taken.
-            if (phaser.register() < 0) {
-              return;
-            }
-
-            for (int operatorIndex = threadIndex; operatorIndex < numOperators; operatorIndex += numThreads) {
-              try {
-                IntermediateResultsBlock resultsBlock =
-                    (IntermediateResultsBlock) _operators.get(operatorIndex).nextBlock();
-                if (isQuerySatisfied(resultsBlock)) {
-                  // Query is satisfied, skip processing the remaining segments
-                  blockingQueue.offer(resultsBlock);
-                  return;
-                } else {
-                  blockingQueue.offer(resultsBlock);
-                }
-              } catch (EarlyTerminationException e) {
-                // Early-terminated by interruption (canceled by the main thread)
-                return;
-              } catch (Exception e) {
-                // Caught exception, skip processing the remaining operators
-                LOGGER.error("Caught exception while executing operator of index: {} (query: {})", operatorIndex,
-                    _queryContext, e);
-                blockingQueue.offer(new IntermediateResultsBlock(e));
-                return;
-              }
-            }
-          } finally {
-            phaser.arriveAndDeregister();
-          }
+          processSegments(threadIndex);
         }
       });
     }
 
+    IntermediateResultsBlock mergedBlock = mergeResultsFromSegments();
+    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators);
+    return mergedBlock;
+  }
+
+  /**
+   * processSegments will execute query on one or more segments in a single thread.
+   */
+  protected void processSegments(int threadIndex) {
+    try {
+      // Register the thread to the phaser
+      // NOTE: If the phaser is terminated (returning negative value) when trying to register the thread, that
+      //       means the query execution has finished, and the main thread has deregistered itself and returned
+      //       the result. Directly return as no execution result will be taken.
+      if (_phaser.register() < 0) {
+        return;
+      }
+
+      for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
+        try {
+          IntermediateResultsBlock resultsBlock = (IntermediateResultsBlock) _operators.get(operatorIndex).nextBlock();
+          if (isQuerySatisfied(resultsBlock)) {
+            // Query is satisfied, skip processing the remaining segments
+            _blockingQueue.offer(resultsBlock);
+            return;
+          } else {
+            _blockingQueue.offer(resultsBlock);
+          }
+        } catch (EarlyTerminationException e) {
+          // Early-terminated by interruption (canceled by the main thread)
+          return;
+        } catch (Exception e) {
+          // Caught exception, skip processing the remaining operators
+          LOGGER
+              .error("Caught exception while executing operator of index: {} (query: {})", operatorIndex, _queryContext,
+                  e);
+          _blockingQueue.offer(new IntermediateResultsBlock(e));
+          return;
+        }
+      }
+    } finally {
+      _phaser.arriveAndDeregister();
+    }
+  }
+
+  /**
+   * mergeResultsFromSegments will merge multiple intermediate result blocks into a result block.
+   */
+  protected IntermediateResultsBlock mergeResultsFromSegments() {
     IntermediateResultsBlock mergedBlock = null;
     try {
       int numBlocksMerged = 0;
-      while (numBlocksMerged < numOperators) {
+      while (numBlocksMerged < _numOperators) {
         IntermediateResultsBlock blockToMerge =
-            blockingQueue.poll(_endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+            _blockingQueue.poll(_endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
         if (blockToMerge == null) {
           // Query times out, skip merging the remaining results blocks
           LOGGER.error("Timed out while polling results block, numBlocksMerged: {} (query: {})", numBlocksMerged,
@@ -153,16 +178,14 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       mergedBlock = new IntermediateResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));
     } finally {
       // Cancel all ongoing jobs
-      for (Future future : futures) {
+      for (Future future : _futures) {
         if (!future.isDone()) {
           future.cancel(true);
         }
       }
       // Deregister the main thread and wait for all threads done
-      phaser.awaitAdvance(phaser.arriveAndDeregister());
+      _phaser.awaitAdvance(_phaser.arriveAndDeregister());
     }
-
-    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators);
     return mergedBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -27,14 +27,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
@@ -42,19 +40,17 @@ import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmin
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.query.exception.EarlyTerminationException;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
  * Combine operator for aggregation group-by queries with PQL semantic.
- * TODO:
- *   - Use CombineOperatorUtils.getNumThreadsForQuery() to get the parallelism of the query instead of using all threads
- *   - Try to extend BaseCombineOperator to reduce duplicate code
+ * TODO: Use CombineOperatorUtils.getNumThreadsForQuery() to get the parallelism of the query instead of using
+ *   all threads
  */
 @SuppressWarnings("rawtypes")
-public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBlock> {
+public class GroupByCombineOperator extends BaseCombineOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(GroupByCombineOperator.class);
   private static final String OPERATOR_NAME = "GroupByCombineOperator";
 
@@ -63,24 +59,101 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
   // in each segment. We still put a limit across segments to protect cases where data is very skewed across different
   // segments.
   private static final int INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR = 2;
-
-  private final List<Operator> _operators;
-  private final QueryContext _queryContext;
-  private final ExecutorService _executorService;
-  private final long _endTimeMs;
   // Limit on number of groups stored, beyond which no new group will be created
   private final int _innerSegmentNumGroupsLimit;
   private final int _interSegmentNumGroupsLimit;
 
+  private final ConcurrentHashMap<String, Object[]> _resultsMap = new ConcurrentHashMap<>();
+  private final AtomicInteger _numGroups = new AtomicInteger();
+  private final ConcurrentLinkedQueue<ProcessingException> _mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
+  private final AggregationFunction[] _aggregationFunctions;
+  private final int _numAggregationFunctions;
+  // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
+  // _futures (try to interrupt the execution if it already started).
+  // Besides the CountDownLatch, we also use a Phaser to ensure all the Futures are done (not scheduled, finished or
+  // interrupted) before the main thread returns. We need to ensure no execution left before the main thread returning
+  // because the main thread holds the reference to the segments, and if the segments are deleted/refreshed, the
+  // segments can be released after the main thread returns, which would lead to undefined behavior (even JVM crash)
+  // when executing queries against them.
+  private final CountDownLatch _operatorLatch;
+
   public GroupByCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
       long endTimeMs, int innerSegmentNumGroupsLimit) {
-    _operators = operators;
-    _queryContext = queryContext;
-    _executorService = executorService;
-    _endTimeMs = endTimeMs;
+    super(operators, queryContext, executorService, endTimeMs, operators.size());
     _innerSegmentNumGroupsLimit = innerSegmentNumGroupsLimit;
     _interSegmentNumGroupsLimit =
         (int) Math.min((long) innerSegmentNumGroupsLimit * INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR, Integer.MAX_VALUE);
+
+    _aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert _aggregationFunctions != null;
+    _numAggregationFunctions = _aggregationFunctions.length;
+    int numOperators = _operators.size();
+    _operatorLatch = new CountDownLatch(numOperators);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p> Execute query on one or more segments in a single thread, and store multiple intermediate result blocks into a
+   * map
+   */
+  @Override
+  protected void processSegments(int threadIndex) {
+    try {
+      // Register the thread to the _phaser.
+      // If the _phaser is terminated (returning negative value) when trying to register the thread, that means the
+      // query execution has timed out, and the main thread has deregistered itself and returned the result.
+      // Directly return as no execution result will be taken.
+      if (_phaser.register() < 0) {
+        return;
+      }
+
+      IntermediateResultsBlock intermediateResultsBlock =
+          (IntermediateResultsBlock) _operators.get(threadIndex).nextBlock();
+
+      // Merge processing exceptions.
+      List<ProcessingException> processingExceptionsToMerge = intermediateResultsBlock.getProcessingExceptions();
+      if (processingExceptionsToMerge != null) {
+        _mergedProcessingExceptions.addAll(processingExceptionsToMerge);
+      }
+
+      // Merge aggregation group-by result.
+      AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
+      if (aggregationGroupByResult != null) {
+        // Iterate over the group-by keys, for each key, update the group-by result in the _resultsMap.
+        Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator =
+            aggregationGroupByResult.getStringGroupKeyIterator();
+        while (groupKeyIterator.hasNext()) {
+          GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
+          _resultsMap.compute(groupKey._stringKey, (key, value) -> {
+            if (value == null) {
+              if (_numGroups.getAndIncrement() < _interSegmentNumGroupsLimit) {
+                value = new Object[_numAggregationFunctions];
+                for (int i = 0; i < _numAggregationFunctions; i++) {
+                  value[i] = aggregationGroupByResult.getResultForKey(groupKey, i);
+                }
+              }
+            } else {
+              for (int i = 0; i < _numAggregationFunctions; i++) {
+                value[i] =
+                    _aggregationFunctions[i].merge(value[i], aggregationGroupByResult.getResultForKey(groupKey, i));
+              }
+            }
+            return value;
+          });
+        }
+      }
+    } catch (EarlyTerminationException e) {
+      // Early-terminated because query times out or is already satisfied
+    } catch (Exception e) {
+      LOGGER.error(
+          "Caught exception while processing and combining group-by for index: {}, operator: {}, queryContext: {}",
+          threadIndex, _operators.get(threadIndex).getClass().getName(), _queryContext, e);
+      _mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+    } finally {
+      _operatorLatch.countDown();
+      _phaser.arriveAndDeregister();
+    }
   }
 
   /**
@@ -90,7 +163,7 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
    * result block.
    * <ul>
    *   <li>
-   *     Concurrently merge group-by results form multiple result blocks into a map from group key to group results
+   *     Merge group-by results form multiple result blocks into a map from group key to group results
    *   </li>
    *   <li>
    *     Sort and trim the results map based on {@code TOP N} in the request
@@ -103,95 +176,10 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
    * </ul>
    */
   @Override
-  protected IntermediateResultsBlock getNextBlock() {
-    ConcurrentHashMap<String, Object[]> resultsMap = new ConcurrentHashMap<>();
-    AtomicInteger numGroups = new AtomicInteger();
-    ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
-
-    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null;
-    int numAggregationFunctions = aggregationFunctions.length;
-
-    // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
-    // futures (try to interrupt the execution if it already started).
-    // Besides the CountDownLatch, we also use a Phaser to ensure all the Futures are done (not scheduled, finished or
-    // interrupted) before the main thread returns. We need to ensure no execution left before the main thread returning
-    // because the main thread holds the reference to the segments, and if the segments are deleted/refreshed, the
-    // segments can be released after the main thread returns, which would lead to undefined behavior (even JVM crash)
-    // when executing queries against them.
-    int numOperators = _operators.size();
-    CountDownLatch operatorLatch = new CountDownLatch(numOperators);
-    Phaser phaser = new Phaser(1);
-
-    Future[] futures = new Future[numOperators];
-    for (int i = 0; i < numOperators; i++) {
-      int index = i;
-      futures[i] = _executorService.submit(new TraceRunnable() {
-        @SuppressWarnings("unchecked")
-        @Override
-        public void runJob() {
-          try {
-            // Register the thread to the phaser.
-            // If the phaser is terminated (returning negative value) when trying to register the thread, that means the
-            // query execution has timed out, and the main thread has deregistered itself and returned the result.
-            // Directly return as no execution result will be taken.
-            if (phaser.register() < 0) {
-              return;
-            }
-
-            IntermediateResultsBlock intermediateResultsBlock =
-                (IntermediateResultsBlock) _operators.get(index).nextBlock();
-
-            // Merge processing exceptions.
-            List<ProcessingException> processingExceptionsToMerge = intermediateResultsBlock.getProcessingExceptions();
-            if (processingExceptionsToMerge != null) {
-              mergedProcessingExceptions.addAll(processingExceptionsToMerge);
-            }
-
-            // Merge aggregation group-by result.
-            AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
-            if (aggregationGroupByResult != null) {
-              // Iterate over the group-by keys, for each key, update the group-by result in the resultsMap.
-              Iterator<GroupKeyGenerator.StringGroupKey> groupKeyIterator =
-                  aggregationGroupByResult.getStringGroupKeyIterator();
-              while (groupKeyIterator.hasNext()) {
-                GroupKeyGenerator.StringGroupKey groupKey = groupKeyIterator.next();
-                resultsMap.compute(groupKey._stringKey, (key, value) -> {
-                  if (value == null) {
-                    if (numGroups.getAndIncrement() < _interSegmentNumGroupsLimit) {
-                      value = new Object[numAggregationFunctions];
-                      for (int i = 0; i < numAggregationFunctions; i++) {
-                        value[i] = aggregationGroupByResult.getResultForKey(groupKey, i);
-                      }
-                    }
-                  } else {
-                    for (int i = 0; i < numAggregationFunctions; i++) {
-                      value[i] = aggregationFunctions[i]
-                          .merge(value[i], aggregationGroupByResult.getResultForKey(groupKey, i));
-                    }
-                  }
-                  return value;
-                });
-              }
-            }
-          } catch (EarlyTerminationException e) {
-            // Early-terminated because query times out or is already satisfied
-          } catch (Exception e) {
-            LOGGER.error(
-                "Caught exception while processing and combining group-by for index: {}, operator: {}, queryContext: {}",
-                index, _operators.get(index).getClass().getName(), _queryContext, e);
-            mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
-          } finally {
-            operatorLatch.countDown();
-            phaser.arriveAndDeregister();
-          }
-        }
-      });
-    }
-
+  protected IntermediateResultsBlock mergeResultsFromSegments() {
     try {
       long timeoutMs = _endTimeMs - System.currentTimeMillis();
-      boolean opCompleted = operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+      boolean opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
         String errorMessage = String
@@ -205,20 +193,16 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
       AggregationGroupByTrimmingService aggregationGroupByTrimmingService =
           new AggregationGroupByTrimmingService(_queryContext);
       List<Map<String, Object>> trimmedResults =
-          aggregationGroupByTrimmingService.trimIntermediateResultsMap(resultsMap);
-      IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(aggregationFunctions, trimmedResults, true);
+          aggregationGroupByTrimmingService.trimIntermediateResultsMap(_resultsMap);
+      IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(_aggregationFunctions, trimmedResults, true);
 
       // Set the processing exceptions.
-      if (!mergedProcessingExceptions.isEmpty()) {
-        mergedBlock.setProcessingExceptions(new ArrayList<>(mergedProcessingExceptions));
+      if (!_mergedProcessingExceptions.isEmpty()) {
+        mergedBlock.setProcessingExceptions(new ArrayList<>(_mergedProcessingExceptions));
       }
-
-      // Set the execution statistics.
-      CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators);
-
       // TODO: this value should be set in the inner-segment operators. Setting it here might cause false positive as we
       //       are comparing number of groups across segments with the groups limit for each segment.
-      if (resultsMap.size() >= _innerSegmentNumGroupsLimit) {
+      if (_resultsMap.size() >= _innerSegmentNumGroupsLimit) {
         mergedBlock.setNumGroupsLimitReached(true);
       }
 
@@ -227,14 +211,18 @@ public class GroupByCombineOperator extends BaseOperator<IntermediateResultsBloc
       return new IntermediateResultsBlock(e);
     } finally {
       // Cancel all ongoing jobs
-      for (Future future : futures) {
+      for (Future future : _futures) {
         if (!future.isDone()) {
           future.cancel(true);
         }
       }
       // Deregister the main thread and wait for all threads done
-      phaser.awaitAdvance(phaser.arriveAndDeregister());
+      _phaser.awaitAdvance(_phaser.arriveAndDeregister());
     }
+  }
+
+  @Override
+  protected void mergeResultsBlocks(IntermediateResultsBlock mergedBlock, IntermediateResultsBlock blockToMerge) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
@@ -39,7 +38,6 @@ import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.data.table.UnboundedConcurrentIndexedTable;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
@@ -47,52 +45,135 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.query.exception.EarlyTerminationException;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.util.GroupByUtils;
-import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
  * Combine operator for aggregation group-by queries with SQL semantic.
- * TODO:
- *   - Use CombineOperatorUtils.getNumThreadsForQuery() to get the parallelism of the query instead of using all threads
- *   - Try to extend BaseCombineOperator to reduce duplicate code
+ * TODO: Use CombineOperatorUtils.getNumThreadsForQuery() to get the parallelism of the query instead of using
+ *   all threads
  */
 @SuppressWarnings("rawtypes")
-public class GroupByOrderByCombineOperator extends BaseOperator<IntermediateResultsBlock> {
+public class GroupByOrderByCombineOperator extends BaseCombineOperator {
+  public static final int MAX_TRIM_THRESHOLD = 1_000_000_000;
   private static final Logger LOGGER = LoggerFactory.getLogger(GroupByOrderByCombineOperator.class);
   private static final String OPERATOR_NAME = "GroupByOrderByCombineOperator";
-  public static final int MAX_TRIM_THRESHOLD = 1_000_000_000;
-
-  private final List<Operator> _operators;
-  private final QueryContext _queryContext;
-  private final ExecutorService _executorService;
-  private final long _endTimeMs;
   private final int _trimSize;
   private final int _trimThreshold;
   private final Lock _initLock;
+  private final int _numAggregationFunctions;
+  private final int _numGroupByExpressions;
+  private final int _numColumns;
+  private final ConcurrentLinkedQueue<ProcessingException> _mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
+  // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
+  // _futures (try to interrupt the execution if it already started).
+  // Besides the CountDownLatch, we also use a Phaser to ensure all the Futures are done (not scheduled, finished or
+  // interrupted) before the main thread returns. We need to ensure no execution left before the main thread returning
+  // because the main thread holds the reference to the segments, and if the segments are deleted/refreshed, the
+  // segments can be released after the main thread returns, which would lead to undefined behavior (even JVM crash)
+  // when executing queries against them.
+  private final CountDownLatch _operatorLatch;
   private DataSchema _dataSchema;
   private ConcurrentIndexedTable _indexedTable;
 
   public GroupByOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService, long endTimeMs, int trimThreshold) {
-    _operators = operators;
-    _queryContext = queryContext;
-    _executorService = executorService;
-    _endTimeMs = endTimeMs;
+    super(operators, queryContext, executorService, endTimeMs, operators.size());
     _initLock = new ReentrantLock();
     _trimSize = GroupByUtils.getTableCapacity(_queryContext);
     _trimThreshold = trimThreshold;
+
+    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+    _numAggregationFunctions = aggregationFunctions.length;
+    assert _queryContext.getGroupByExpressions() != null;
+    _numGroupByExpressions = _queryContext.getGroupByExpressions().size();
+    _numColumns = _numGroupByExpressions + _numAggregationFunctions;
+    int numOperators = _operators.size();
+    _operatorLatch = new CountDownLatch(numOperators);
   }
 
   /**
    * {@inheritDoc}
    *
-   * <p>Combines the group-by result blocks from underlying operators and returns a merged and trimmed group-by
-   * result block.
+   * <p> Execute query on one or more segments in a single thread, and store multiple intermediate result blocks
+   * into {@link org.apache.pinot.core.data.table.IndexedTable}
+   */
+  @Override
+  protected void processSegments(int threadIndex) {
+    try {
+      // Register the thread to the _phaser.
+      // If the _phaser is terminated (returning negative value) when trying to register the thread, that means the
+      // query execution has timed out, and the main thread has deregistered itself and returned the result.
+      // Directly return as no execution result will be taken.
+      if (_phaser.register() < 0) {
+        return;
+      }
+
+      IntermediateResultsBlock intermediateResultsBlock =
+          (IntermediateResultsBlock) _operators.get(threadIndex).nextBlock();
+
+      _initLock.lock();
+      try {
+        if (_dataSchema == null) {
+          _dataSchema = intermediateResultsBlock.getDataSchema();
+          if (_trimThreshold >= MAX_TRIM_THRESHOLD) {
+            // special case of trim threshold where it is set to max value.
+            // there won't be any trimming during upsert in this case.
+            // thus we can avoid the overhead of read-lock and write-lock
+            // in the upsert method.
+            _indexedTable = new UnboundedConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
+          } else {
+            _indexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
+          }
+        }
+      } finally {
+        _initLock.unlock();
+      }
+
+      // Merge processing exceptions.
+      List<ProcessingException> processingExceptionsToMerge = intermediateResultsBlock.getProcessingExceptions();
+      if (processingExceptionsToMerge != null) {
+        _mergedProcessingExceptions.addAll(processingExceptionsToMerge);
+      }
+
+      // Merge aggregation group-by result.
+      AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
+      if (aggregationGroupByResult != null) {
+        // Iterate over the group-by keys, for each key, update the group-by result in the indexedTable
+        Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
+        while (groupKeyIterator.hasNext()) {
+          GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+          Object[] keys = groupKey._keys;
+          Object[] values = Arrays.copyOf(keys, _numColumns);
+          int groupId = groupKey._groupId;
+          for (int i = 0; i < _numAggregationFunctions; i++) {
+            values[_numGroupByExpressions + i] = aggregationGroupByResult.getResultForGroupId(i, groupId);
+          }
+          _indexedTable.upsert(new Key(keys), new Record(values));
+        }
+      }
+    } catch (EarlyTerminationException e) {
+      // Early-terminated because query times out or is already satisfied
+    } catch (Exception e) {
+      LOGGER.error(
+          "Caught exception while processing and combining group-by order-by for index: {}, operator: {}, queryContext: {}",
+          threadIndex, _operators.get(threadIndex).getClass().getName(), _queryContext, e);
+      _mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+    } finally {
+      _operatorLatch.countDown();
+      _phaser.arriveAndDeregister();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Combines intermediate selection result blocks from underlying operators and returns a merged one.
    * <ul>
    *   <li>
-   *     Concurrently merge group-by results from multiple result blocks into {@link org.apache.pinot.core.data.table.IndexedTable}
+   *     Merges multiple intermediate selection result blocks as a merged one.
    *   </li>
    *   <li>
    *     Set all exceptions encountered during execution into the merged result block
@@ -100,104 +181,10 @@ public class GroupByOrderByCombineOperator extends BaseOperator<IntermediateResu
    * </ul>
    */
   @Override
-  protected IntermediateResultsBlock getNextBlock() {
-    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null;
-    int numAggregationFunctions = aggregationFunctions.length;
-    assert _queryContext.getGroupByExpressions() != null;
-    int numGroupByExpressions = _queryContext.getGroupByExpressions().size();
-    int numColumns = numGroupByExpressions + numAggregationFunctions;
-    ConcurrentLinkedQueue<ProcessingException> mergedProcessingExceptions = new ConcurrentLinkedQueue<>();
-
-    // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
-    // futures (try to interrupt the execution if it already started).
-    // Besides the CountDownLatch, we also use a Phaser to ensure all the Futures are done (not scheduled, finished or
-    // interrupted) before the main thread returns. We need to ensure no execution left before the main thread returning
-    // because the main thread holds the reference to the segments, and if the segments are deleted/refreshed, the
-    // segments can be released after the main thread returns, which would lead to undefined behavior (even JVM crash)
-    // when executing queries against them.
-    int numOperators = _operators.size();
-    CountDownLatch operatorLatch = new CountDownLatch(numOperators);
-    Phaser phaser = new Phaser(1);
-
-    Future[] futures = new Future[numOperators];
-    for (int i = 0; i < numOperators; i++) {
-      int index = i;
-      futures[i] = _executorService.submit(new TraceRunnable() {
-        @SuppressWarnings("unchecked")
-        @Override
-        public void runJob() {
-          try {
-            // Register the thread to the phaser.
-            // If the phaser is terminated (returning negative value) when trying to register the thread, that means the
-            // query execution has timed out, and the main thread has deregistered itself and returned the result.
-            // Directly return as no execution result will be taken.
-            if (phaser.register() < 0) {
-              return;
-            }
-
-            IntermediateResultsBlock intermediateResultsBlock =
-                (IntermediateResultsBlock) _operators.get(index).nextBlock();
-
-            _initLock.lock();
-            try {
-              if (_dataSchema == null) {
-                _dataSchema = intermediateResultsBlock.getDataSchema();
-                if (_trimThreshold >= MAX_TRIM_THRESHOLD) {
-                  // special case of trim threshold where it is set to max value.
-                  // there won't be any trimming during upsert in this case.
-                  // thus we can avoid the overhead of read-lock and write-lock
-                  // in the upsert method.
-                  _indexedTable =
-                      new UnboundedConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
-                } else {
-                  _indexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
-                }
-              }
-            } finally {
-              _initLock.unlock();
-            }
-
-            // Merge processing exceptions.
-            List<ProcessingException> processingExceptionsToMerge = intermediateResultsBlock.getProcessingExceptions();
-            if (processingExceptionsToMerge != null) {
-              mergedProcessingExceptions.addAll(processingExceptionsToMerge);
-            }
-
-            // Merge aggregation group-by result.
-            AggregationGroupByResult aggregationGroupByResult = intermediateResultsBlock.getAggregationGroupByResult();
-            if (aggregationGroupByResult != null) {
-              // Iterate over the group-by keys, for each key, update the group-by result in the indexedTable
-              Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = aggregationGroupByResult.getGroupKeyIterator();
-              while (groupKeyIterator.hasNext()) {
-                GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
-                Object[] keys = groupKey._keys;
-                Object[] values = Arrays.copyOf(keys, numColumns);
-                int groupId = groupKey._groupId;
-                for (int i = 0; i < numAggregationFunctions; i++) {
-                  values[numGroupByExpressions + i] = aggregationGroupByResult.getResultForGroupId(i, groupId);
-                }
-                _indexedTable.upsert(new Key(keys), new Record(values));
-              }
-            }
-          } catch (EarlyTerminationException e) {
-            // Early-terminated because query times out or is already satisfied
-          } catch (Exception e) {
-            LOGGER.error(
-                "Caught exception while processing and combining group-by order-by for index: {}, operator: {}, queryContext: {}",
-                index, _operators.get(index).getClass().getName(), _queryContext, e);
-            mergedProcessingExceptions.add(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
-          } finally {
-            operatorLatch.countDown();
-            phaser.arriveAndDeregister();
-          }
-        }
-      });
-    }
-
+  protected IntermediateResultsBlock mergeResultsFromSegments() {
     try {
       long timeoutMs = _endTimeMs - System.currentTimeMillis();
-      boolean opCompleted = operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
+      boolean opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
       if (!opCompleted) {
         // If this happens, the broker side should already timed out, just log the error and return
         String errorMessage = String
@@ -211,30 +198,31 @@ public class GroupByOrderByCombineOperator extends BaseOperator<IntermediateResu
       IntermediateResultsBlock mergedBlock = new IntermediateResultsBlock(_indexedTable);
 
       // Set the processing exceptions.
-      if (!mergedProcessingExceptions.isEmpty()) {
-        mergedBlock.setProcessingExceptions(new ArrayList<>(mergedProcessingExceptions));
+      if (!_mergedProcessingExceptions.isEmpty()) {
+        mergedBlock.setProcessingExceptions(new ArrayList<>(_mergedProcessingExceptions));
       }
 
-      // Set the execution statistics.
-      CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators);
       mergedBlock.setNumResizes(_indexedTable.getNumResizes());
       mergedBlock.setResizeTimeMs(_indexedTable.getResizeTimeMs());
-
       // TODO - set numGroupsLimitReached
-
       return mergedBlock;
     } catch (Exception e) {
       return new IntermediateResultsBlock(e);
     } finally {
       // Cancel all ongoing jobs
-      for (Future future : futures) {
+      for (Future future : _futures) {
         if (!future.isDone()) {
           future.cancel(true);
         }
       }
       // Deregister the main thread and wait for all threads done
-      phaser.awaitAdvance(phaser.arriveAndDeregister());
+      _phaser.awaitAdvance(_phaser.arriveAndDeregister());
     }
+  }
+
+  @Override
+  protected void mergeResultsBlocks(IntermediateResultsBlock mergedBlock, IntermediateResultsBlock blockToMerge) {
+
   }
 
   @Override


### PR DESCRIPTION
This is exactly the same as: https://github.com/apache/incubator-pinot/pull/6670, just squash multiple commits into one.

When I squash multiple commits locally and force update my branch, https://github.com/apache/incubator-pinot/pull/6670 can not get updated, so close https://github.com/apache/incubator-pinot/pull/6670 and open a new one

Sorry for the inconvenience

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
