### PR TITLE
Adding a cluster wide config property to control Cluster Manager UI v…

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -138,6 +138,10 @@ public class CommonConstants {
     public static final String DEFAULT_FLAPPING_TIME_WINDOW_MS = "1";
 
     public static final String PINOT_SERVICE_ROLE = "pinot.service.role";
+
+    // Cluster wide config which controls if the Cluster manager UI should display
+    // only the Query Console (and hide everything else).
+    public static final String CONFIG_OF_QUERY_CONSOLE_ONLY_VIEW = "queryConsoleOnlyView";
   }
 
   public static class Broker {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -82,6 +82,7 @@ public class HelixSetupUtils {
         configMap.put(ENABLE_CASE_INSENSITIVE_KEY, Boolean.toString(false));
         configMap.put(DEFAULT_HYPERLOGLOG_LOG2M_KEY, Integer.toString(DEFAULT_HYPERLOGLOG_LOG2M));
         configMap.put(CommonConstants.Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, Boolean.toString(false));
+        configMap.put(CONFIG_OF_QUERY_CONSOLE_ONLY_VIEW, Boolean.toString(false));
         admin.setConfig(configScope, configMap);
         LOGGER.info("New Helix cluster: {} created", helixClusterName);
       }


### PR DESCRIPTION
…iew (QueryConsole only or everything)

## Description
Related to #6619 . This is used to configure cluster manager to only show query console for many customers that don't want to expose other things such as Zookeeper/Admin operation/Swagger to their users. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? 
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? 
Yes

## Release Notes
* Added a new cluster config: `queryConsoleOnlyView` which if set to true will result in Cluster Manager UI only displaying the query console and hiding everything else.
