### PR TITLE
UI integration with Authentication API and added login page

### DIFF
--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -69,6 +69,8 @@ const App = () => {
     // it doesn't require authentication.
     if(authInfoResponse?.workflow !== 'BASIC'){
       setIsAuthenticated(true);
+    } else {
+      setLoading(false);
     }
   }
 

--- a/pinot-controller/src/main/resources/app/app_state.ts
+++ b/pinot-controller/src/main/resources/app/app_state.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 class app_state {
-  queryConsoleOnlyView: boolean
+  queryConsoleOnlyView: boolean;
+  authToken: string | null;
 }
 export default new app_state();

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -76,6 +76,8 @@ declare module 'Models' {
   export type IdealState = {
     OFFLINE: Object | null;
     REALTIME: Object | null;
+    code?: number;
+    error?: string;
   };
 
   export type QueryTables = {

--- a/pinot-controller/src/main/resources/app/pages/LoginPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/LoginPage.tsx
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { Box, Button, createStyles, makeStyles, TextField, Theme } from '@material-ui/core';
+import Logo from '../components/SvgIcons/Logo';
+import { useForm } from 'react-hook-form';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import app_state from '../app_state';
+
+interface FormData {
+  username: string;
+  password: string;
+}
+
+const useStyles = makeStyles((theme: Theme) => {
+  return createStyles({
+    container: {
+      height: "100vh",
+      width: "100vw",
+      backgroundColor: "#ebebeb",
+      boxSizing: "border-box",
+      paddingTop: "5%",
+      margin: -8,
+    },
+    loginForm: {
+      width: 420,
+      margin: "0 auto",
+      zIndex: 99,
+      display: "block",
+      background: "#fff",
+      borderRadius: ".25rem",
+      textAlign: "center",
+      boxShadow: "0 0 20px rgba(0, 0, 0, 0.2)",
+      color: theme.palette.common.white,
+    },
+    logoContainer: {
+      textAlign: "center",
+      opacity: 0.7,
+      padding: "30px",
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.common.white,
+      borderRadius: "0.25rem 0.25rem 0 0",
+    },
+    marginTop1: {
+      marginTop: theme.spacing(1),
+    },
+    paddingBottom3: {
+      paddingBottom: theme.spacing(3),
+    },
+  });
+});
+
+const LoginPage = (props) => {
+  const { handleSubmit, register } = useForm<FormData>();
+  const [invalidToken, setInvalidToken] = React.useState(null);
+
+  const onSubmit = handleSubmit(async (data) => {
+    const authToken = "Basic "+btoa(data.username+":"+data.password);
+    const isUserAuthenticated = await PinotMethodUtils.verifyAuth(authToken);
+    if(isUserAuthenticated){
+      setInvalidToken(false);
+      props.setIsAuthenticated(true);
+      app_state.authToken = authToken;
+      props.history.push(app_state.queryConsoleOnlyView ? '/query' : '/');
+    } else {
+      setInvalidToken(true);
+    }
+  });
+
+  const classes = useStyles();
+  return (
+    <div className={classes.container}>
+      <div className={classes.loginForm}>
+        <div className={classes.logoContainer}>
+          <Logo fulllogo="true" />
+        </div>
+        <form onSubmit={onSubmit}>
+          <TextField
+            inputRef={register}
+            className={classes.marginTop1}
+            label="Username"
+            name="username"
+            required
+          />
+          <TextField
+            inputRef={register}
+            className={classes.marginTop1}
+            name="password"
+            label="Password"
+            type="password"
+            required
+          />
+          {invalidToken &&
+            <Box mt={3}>
+              <span style={{color: "red"}}>Invalid Username/Password</span>
+            </Box>
+          }
+          <Box paddingY={3}>
+            <Button type="submit" variant="contained" color="primary">
+              Login
+            </Button>
+          </Box>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -192,10 +192,15 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
 
   const fetchTableJSON = async () => {
     const result = await PinotMethodUtils.getTableDetails(tableName);
-    const tableObj:any = result.OFFLINE || result.REALTIME;
-    setTableType(tableObj.tableType);
-    setTableConfig(JSON.stringify(result, null, 2));
-    fetchTableState(tableObj.tableType);
+    if(result.error){
+      setFetching(false);
+      dispatch({type: 'error', message: result.error, show: true});
+    } else {
+      const tableObj:any = result.OFFLINE || result.REALTIME;
+      setTableType(tableObj.tableType);
+      setTableConfig(JSON.stringify(result, null, 2));
+      fetchTableState(tableObj.tableType);
+    }
   };
 
   const fetchTableState = async (type) => {
@@ -219,7 +224,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
 
   const toggleTableState = async () => {
     const result = await PinotMethodUtils.toggleTableState(tableName, state.enabled ? 'disable' : 'enable', tableType.toLowerCase());
-    if(result[0].state){
+    if(!result.error && result[0].state){
       if(result[0].state.successful){
         dispatch({type: 'success', message: result[0].state.message, show: true});
         setState({ enabled: !state.enabled });

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -164,3 +164,9 @@ export const saveTable = (tableObject: string): Promise<AxiosResponse<OperationR
 
 export const getState = (tableName: string, tableType: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/tables/${tableName}/state?type=${tableType}`);
+
+export const getInfo = (): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.get(`/auth/info`);
+
+export const authenticateUser = (authToken): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.get(`/auth/verify`, {headers:{"Authorization": authToken}});

--- a/pinot-controller/src/main/resources/app/router.tsx
+++ b/pinot-controller/src/main/resources/app/router.tsx
@@ -28,6 +28,7 @@ import SegmentDetails from './pages/SegmentDetails';
 import InstanceDetails from './pages/InstanceDetails';
 import ZookeeperPage from './pages/ZookeeperPage';
 import SchemaPageDetails from './pages/SchemaPageDetails';
+import LoginPage from './pages/LoginPage';
 
 export default [
   { path: '/', Component: HomePage },
@@ -47,4 +48,5 @@ export default [
   { path: '/instance/:instanceName/table/:tableName', Component: TenantPageDetails },
   { path: '/instance/:instanceName/table/:tableName/:segmentName', Component: SegmentDetails },
   { path: '/zookeeper', Component: ZookeeperPage },
+  { path: '/login', Component: LoginPage },
 ];

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -64,7 +64,9 @@ import {
   saveTable,
   getSchema,
   getSchemaList,
-  getState
+  getState,
+  getInfo,
+  authenticateUser
 } from '../requests';
 import Utils from './Utils';
 
@@ -745,6 +747,18 @@ const getTableState = (tableName, tableType) => {
   });
 };
 
+const getAuthInfo = () => {
+  return getInfo().then((response)=>{
+    return response.data;
+  });
+};
+
+const verifyAuth = (authToken) => {
+  return authenticateUser(authToken).then((response)=>{
+    return response.data;
+  });
+};
+
 export default {
   getTenantsData,
   getAllInstances,
@@ -792,5 +806,7 @@ export default {
   saveTableAction,
   getSchemaData,
   getAllSchemaDetails,
-  getTableState
+  getTableState,
+  getAuthInfo,
+  verifyAuth
 };

--- a/pinot-controller/src/main/resources/app/utils/axios-config.ts
+++ b/pinot-controller/src/main/resources/app/utils/axios-config.ts
@@ -20,6 +20,7 @@
 /* eslint-disable no-console */
 
 import axios from 'axios';
+import app_state from '../app_state';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -38,6 +39,9 @@ const handleResponse = (response: any) => {
 };
 
 const handleConfig = (config: any) => {
+  if(app_state.authToken){
+    Object.assign(config.headers, {"Authorization": app_state.authToken});
+  }
   if (isDev) {
     console.log(config);
   }

--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -78,6 +78,7 @@
     "react": "16.13.1",
     "react-codemirror2": "^7.2.1",
     "react-dom": "16.13.1",
+    "react-hook-form": "^6.15.4",
     "react-router-dom": "^5.2.0",
     "react-spring": "^8.0.27",
     "system": "^2.0.1",


### PR DESCRIPTION
## Description
This PR is for https://github.com/apache/incubator-pinot/issues/6313

Added Login Page:
![image](https://user-images.githubusercontent.com/6761317/111385704-332ff580-86d1-11eb-9c76-8700a4f66b76.png)

Additionally, if `auth/info` API returns workflow which is anything but "BASIC" we do not show any login page. Only for "BASIC" auth, a login page will be displayed on every reload of the app and the generated authentication token will be passed to every API post login.