### PR TITLE
Remove unused variable in ServerQueryExecutorV1Impl and unnecessary check in ThreadTimer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -77,7 +77,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   private PlanMaker _planMaker;
   private long _defaultTimeOutMs = CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS;
   private ServerMetrics _serverMetrics;
-  boolean _enableThreadCpuTimeInstrument;
 
   @Override
   public synchronized void init(PinotConfiguration config, InstanceDataManager instanceDataManager,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
@@ -55,7 +55,7 @@ public class ThreadTimer {
   }
 
   public long getThreadTimeNs() {
-    if (_startTimeNs == -1 || _endTimeNs == -1) {
+    if (!IS_THREAD_CPU_TIME_MEASUREMENT_ENABLED) {
       return 0;
     }
     return _endTimeNs - _startTimeNs;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
@@ -55,9 +55,6 @@ public class ThreadTimer {
   }
 
   public long getThreadTimeNs() {
-    if (!IS_THREAD_CPU_TIME_MEASUREMENT_ENABLED) {
-      return 0;
-    }
     return _endTimeNs - _startTimeNs;
   }
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/apache/incubator-pinot/pull/6680, this PR to some code cleanup:
* remove unused variable in ServerQueryExecutorV1Impl
* remove unnecessary check in ThreadTimer. Instead, if thread cpu timing is not enabled, return 0.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
