### PR TITLE
Set thread cpu time in setExecutionStatistics()

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -44,7 +44,7 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
     DataTable dataTable = instanceResponseBlock.getInstanceResponseDataTable();
 
     mainThreadTimer.stop();
-    long totalThreadCpuTimeNs = intermediateResultsBlock.getThreadCpuTimeNs() + mainThreadTimer.getThreadTimeNs();
+    long totalThreadCpuTimeNs = intermediateResultsBlock.getExecutionThreadCpuTimeNs() + mainThreadTimer.getThreadTimeNs();
     dataTable.getMetadata().put(DataTable.EXECUTION_THREAD_CPU_TIME_NS_METADATA_KEY, String.valueOf(totalThreadCpuTimeNs));
 
     return instanceResponseBlock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -40,13 +40,10 @@ import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableImplV2;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.data.table.Table;
-import org.apache.pinot.core.operator.combine.GroupByCombineOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.spi.utils.ByteArray;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -69,7 +66,7 @@ public class IntermediateResultsBlock implements Block {
   private boolean _numGroupsLimitReached;
   private int _numResizes;
   private long _resizeTimeMs;
-  private long _threadCpuTimeNs;
+  private long _executionThreadCpuTimeNs;
 
   private Table _table;
 
@@ -232,12 +229,12 @@ public class IntermediateResultsBlock implements Block {
     _resizeTimeMs = resizeTimeMs;
   }
 
-  public void setThreadCpuTimeNs(long threadCpuTimeNanos) {
-    _threadCpuTimeNs = threadCpuTimeNanos;
+  public void setExecutionThreadCpuTimeNs(long executionThreadCpuTimeNs) {
+    _executionThreadCpuTimeNs = executionThreadCpuTimeNs;
   }
 
-  public long getThreadCpuTimeNs() {
-    return _threadCpuTimeNs;
+  public long getExecutionThreadCpuTimeNs() {
+    return _executionThreadCpuTimeNs;
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -127,13 +127,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       // Deregister the main thread and wait for all threads done
       phaser.awaitAdvance(phaser.arriveAndDeregister());
     }
-
-    /*
-     * TODO: setThreadTime logic can be put into CombineOperatorUtils.setExecutionStatistics(),
-     *   after we extends StreamingSelectionOnlyCombineOperator from BaseCombineOperator.
-     */
-    mergedBlock.setThreadCpuTimeNs(totalWorkerThreadCpuTimeNs.get());
-    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators);
+    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators, totalWorkerThreadCpuTimeNs.get());
     return mergedBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -47,7 +47,8 @@ public class CombineOperatorUtils {
   /**
    * Sets the execution statistics into the results block.
    */
-  public static void setExecutionStatistics(IntermediateResultsBlock resultsBlock, List<Operator> operators) {
+  public static void setExecutionStatistics(IntermediateResultsBlock resultsBlock, List<Operator> operators,
+      long threadCpuTimeNs) {
     int numSegmentsProcessed = operators.size();
     int numSegmentsMatched = 0;
     long numDocsScanned = 0;
@@ -70,5 +71,6 @@ public class CombineOperatorUtils {
     resultsBlock.setNumEntriesScannedInFilter(numEntriesScannedInFilter);
     resultsBlock.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
     resultsBlock.setNumTotalDocs(numTotalDocs);
+    resultsBlock.setThreadCpuTimeNs(threadCpuTimeNs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -71,6 +71,6 @@ public class CombineOperatorUtils {
     resultsBlock.setNumEntriesScannedInFilter(numEntriesScannedInFilter);
     resultsBlock.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
     resultsBlock.setNumTotalDocs(numTotalDocs);
-    resultsBlock.setThreadCpuTimeNs(threadCpuTimeNs);
+    resultsBlock.setExecutionThreadCpuTimeNs(threadCpuTimeNs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
@@ -60,7 +60,7 @@ public class SelectionOnlyCombineOperator extends BaseCombineOperator {
     // For LIMIT 0 query, only process one segment to get the data schema
     if (_numRowsToKeep == 0) {
       IntermediateResultsBlock resultsBlock = (IntermediateResultsBlock) _operators.get(0).nextBlock();
-      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators);
+      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators, 0);
       return resultsBlock;
     }
 


### PR DESCRIPTION
## Description

This PR remove a TODO: put thread cpu time setting logic in `setExecutionStatistics()`

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
