### PR TITLE
Explicitly enable lead controller resource

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -205,11 +205,10 @@ public class HelixSetupUtils {
     if (resourceConfig == null) {
       resourceConfig = new ResourceConfig(LEAD_CONTROLLER_RESOURCE_NAME);
     }
-    // Explicitly set RESOURCE_ENABLED to true
-    String leadControllerResourceEnabled = resourceConfig.getSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
-    if (!Boolean.parseBoolean(leadControllerResourceEnabled)) {
-      resourceConfig.putSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY, Boolean.TRUE.toString());
-    }
+    // Explicitly set RESOURCE_ENABLED to true, so that the lead controller resource is always enabled.
+    // This is to help keep the behavior consistent in all clusters for better maintenance.
+    // TODO: remove the logic of handling this config in both controller and server in the next official release.
+    resourceConfig.putSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY, Boolean.TRUE.toString());
     configAccessor.setResourceConfig(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME, resourceConfig);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -205,9 +205,10 @@ public class HelixSetupUtils {
     if (resourceConfig == null) {
       resourceConfig = new ResourceConfig(LEAD_CONTROLLER_RESOURCE_NAME);
     }
-    // Set RESOURCE_ENABLED to false if it's absent in resource config
-    if (resourceConfig.getSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY) == null) {
-      resourceConfig.putSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY, Boolean.FALSE.toString());
+    // Explicitly set RESOURCE_ENABLED to true
+    String leadControllerResourceEnabled = resourceConfig.getSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY);
+    if (!Boolean.parseBoolean(leadControllerResourceEnabled)) {
+      resourceConfig.putSimpleConfig(LEAD_CONTROLLER_RESOURCE_ENABLED_KEY, Boolean.TRUE.toString());
     }
     configAccessor.setResourceConfig(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME, resourceConfig);
   }


### PR DESCRIPTION
## Description
This PR explicitly enables lead controller resource.
The purpose of this feature is to logically separate per-table functionality in all clusters. 

After enabling lead controller resource, the controller host listed under `CONTROLLER/LEADER` ZNode only denotes the helix lead controller in the cluster.

The lead Pinot controller for each of the tables can be found by the following APIs:
Get the leaders for all the tables in the cluster 
GET /leader/tables 

Given a table name, return the partition id and lead controller instance id 
GET /leader/tables/{tableName} 

The `RESOURCE_ENABLED` config is to be removed whenever we release 0.8 or later version of Pinot.

Details can be found in doc: https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
This PR explicitly enabled lead controller resource. The controller host listed in `CONTROLLER/LEADER` ZNode only denotes the helix lead controller in the cluster. The actual logic (like controller periodic tasks, realtime segment completion) of Pinot lead controller is distributed to each of the Pinot only controllers.
After enabling this feature, Helix controller and Pinot controller don't have to be run in the same hardware.

## Documentation
See https://cwiki.apache.org/confluence/display/PINOT/Controller+Separation+between+Helix+and+Pinot
