### PR TITLE
Fixing the issue that multi-get doesn't release the http connection

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/http/MultiGetRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/MultiGetRequest.java
@@ -100,8 +100,8 @@ public class MultiGetRequest {
     CompletionService<GetMethod> completionService = new ExecutorCompletionService<>(_executor);
     for (String url : urls) {
       completionService.submit(() -> {
+        GetMethod getMethod = new GetMethod(url);
         try {
-          GetMethod getMethod = new GetMethod(url);
           getMethod.getParams().setSoTimeout(timeoutMs);
           client.executeMethod(getMethod);
           return getMethod;
@@ -109,6 +109,8 @@ public class MultiGetRequest {
           // Log only exception type and message instead of the whole stack trace
           LOGGER.warn("Caught '{}' while executing GET on URL: {}", e.toString(), url);
           throw e;
+        } finally {
+          getMethod.releaseConnection();
         }
       });
     }


### PR DESCRIPTION
## Description
Per: https://hc.apache.org/httpclient-legacy/threading.html, we need to release the connection for get method.

This sometimes failed the tests in JDK 11.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
