### PR TITLE
Block backward incompatible schema change

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/SchemaBackwardIncompatibleException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/SchemaBackwardIncompatibleException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.exception;
+
+public class SchemaBackwardIncompatibleException extends Exception {
+
+  public SchemaBackwardIncompatibleException(String message) {
+    super(message);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -243,9 +244,8 @@ public class PinotSchemaRestletResource {
       return new SuccessResponse(schemaName + " successfully added");
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Failed to add new schema %s.", schemaName), Response.Status.INTERNAL_SERVER_ERROR,
-          e);
+      throw new ControllerApplicationException(LOGGER, String.format("Failed to add new schema %s.", schemaName),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 
@@ -262,16 +262,15 @@ public class PinotSchemaRestletResource {
       SchemaUtils.validate(schema, tableConfigs);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          "Cannot add invalid schema: " + schemaName + ". Reason: " + e.getMessage(),
+          String.format("Cannot add invalid schema: %s. Reason: %s", schemaName, e.getMessage()),
           Response.Status.BAD_REQUEST, e);
     }
 
     if (schemaName != null && !schema.getSchemaName().equals(schemaName)) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
-      final String message =
-          "Schema name mismatch for uploaded schema, tried to add schema with name " + schema.getSchemaName() + " as "
-              + schemaName;
-      throw new ControllerApplicationException(LOGGER, message, Response.Status.BAD_REQUEST);
+      throw new ControllerApplicationException(LOGGER, String
+          .format("Schema name mismatch for uploaded schema, tried to add schema with name %s as %s",
+              schema.getSchemaName(), schema), Response.Status.BAD_REQUEST);
     }
 
     try {
@@ -284,6 +283,11 @@ public class PinotSchemaRestletResource {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER, String.format("Failed to find schema %s", schemaName),
           Response.Status.NOT_FOUND, e);
+    } catch (SchemaBackwardIncompatibleException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Backward incompatible schema %s. Only allow adding new columns", schemaName),
+          Response.Status.BAD_REQUEST, e);
     } catch (TableNotFoundException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER, String.format("Failed to find table %s to reload", schemaName),


### PR DESCRIPTION
## Description
Currently when uploading a backward incompatible schema, we only log a warning instead of blocking the schema update.
This PR changes the behavior to block the backward incompatible schema change.

## Release Notes
Backward incompatible schema change through controller rest API `PUT /schemas/{schemaName}` will be blocked.