### PR TITLE
Format large long values into string in the json query response

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
@@ -178,5 +179,21 @@ public class DataSchemaTest {
     Assert.assertEquals(fromDataType(FieldSpec.DataType.DOUBLE, false), DOUBLE_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, true), STRING);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, false), STRING_ARRAY);
+  }
+
+  @Test
+  public void testFormat() {
+    Assert.assertEquals(LONG.format(-((1L << 53) - 1)), -((1L << 53) - 1));
+    Assert.assertEquals(LONG.format(-(1L << 53)), Long.toString(-(1L << 53)));
+    Assert.assertEquals(LONG.format((1L << 53) - 1), (1L << 53) - 1);
+    Assert.assertEquals(LONG.format(1L << 53), Long.toString(1L << 53));
+
+    Serializable result = LONG_ARRAY.format(new long[]{-((1L << 53) - 1), -(1L << 53), (1L << 53) - 1, 1L << 53});
+    Assert.assertTrue(result instanceof Serializable[]);
+    Serializable[] formattedValues = (Serializable[]) result;
+    Assert.assertEquals(formattedValues[0], -((1L << 53) - 1));
+    Assert.assertEquals(formattedValues[1], Long.toString(-(1L << 53)));
+    Assert.assertEquals(formattedValues[2], (1L << 53) - 1);
+    Assert.assertEquals(formattedValues[3], Long.toString(1L << 53));
   }
 }


### PR DESCRIPTION
## Description
For issue: #5829 
JavaScript has a safe integer range that it can preserve the exact integral value. If a number is out of the range, representing it using JavaScript Number will lose precision.
This PR formats the non-safe values within the json query response into string so that the client (including the Query Console UI) can parse the values correctly.

## Release Notes
The non-safe integral numbers (not in range (-2^53 to 2^53)) will be converted to string within the json response. The client code should not assume the values are always numbers for number result types.