### PR TITLE
Add more logging for segment reloading status.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -106,7 +106,7 @@ public class SegmentPreProcessor implements AutoCloseable {
         _segmentMetadata = new SegmentMetadataImpl(_indexDir);
         _segmentDirectory.reloadMetadata();
       } else {
-        LOGGER.warn("The table schema is null for the segment {}.", _segmentMetadata.getName());
+        LOGGER.warn("Skip creating default columns for segment: {} without schema", _segmentMetadata.getName());
       }
 
       // Create column inverted indices according to the index config.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -81,7 +81,7 @@ public class SegmentPreProcessor implements AutoCloseable {
   public void process()
       throws Exception {
     if (_segmentMetadata.getTotalDocs() == 0) {
-      LOGGER.info("Skip preprocessing because the segment {} has 0 doc.", _segmentMetadata.getName());
+      LOGGER.info("Skip preprocessing empty segment: {}", _segmentMetadata.getName());
       return;
     }
     // Remove all the existing inverted index temp files before loading segments.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/SegmentPreProcessor.java
@@ -81,6 +81,7 @@ public class SegmentPreProcessor implements AutoCloseable {
   public void process()
       throws Exception {
     if (_segmentMetadata.getTotalDocs() == 0) {
+      LOGGER.info("Skip preprocessing because the segment {} has 0 doc.", _segmentMetadata.getName());
       return;
     }
     // Remove all the existing inverted index temp files before loading segments.
@@ -104,6 +105,8 @@ public class SegmentPreProcessor implements AutoCloseable {
         defaultColumnHandler.updateDefaultColumns();
         _segmentMetadata = new SegmentMetadataImpl(_indexDir);
         _segmentDirectory.reloadMetadata();
+      } else {
+        LOGGER.warn("The table schema is null for the segment {}.", _segmentMetadata.getName());
       }
 
       // Create column inverted indices according to the index config.

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -133,6 +133,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     // Compute the action needed for each column.
     Map<String, DefaultColumnAction> defaultColumnActionMap = computeDefaultColumnActionMap();
     if (defaultColumnActionMap.isEmpty()) {
+      LOGGER.info("No default column action needed for the segment {}.", _segmentMetadata.getName());
       return;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -133,7 +133,6 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     // Compute the action needed for each column.
     Map<String, DefaultColumnAction> defaultColumnActionMap = computeDefaultColumnActionMap();
     if (defaultColumnActionMap.isEmpty()) {
-      LOGGER.info("No default column action needed for the segment {}.", _segmentMetadata.getName());
       return;
     }
 


### PR DESCRIPTION
## Description

Add more logging to indicate the status of segment reloading. The segment reload involves multiple steps and conditions. We found it is hard to track the status for operation like segment reloading to populate derived columns.


A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
