### PR TITLE
Fixing minion SegmentGenerationAndPushTask to for task spec generator using created PinotFS

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskGenerator.java
@@ -45,9 +45,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -268,14 +266,9 @@ public class SegmentGenerationAndPushTaskGenerator implements PinotTaskGenerator
   }
 
   private List<URI> getInputFilesFromDirectory(Map<String, String> batchConfigMap, URI inputDirURI,
-      Set<String> existingSegmentInputFileURIs) {
-    String inputDirURIScheme = inputDirURI.getScheme();
-    if (!PinotFSFactory.isSchemeSupported(inputDirURIScheme)) {
-      String fsClass = batchConfigMap.get(BatchConfigProperties.INPUT_FS_CLASS);
-      PinotConfiguration fsProps = IngestionConfigUtils.getInputFsProps(batchConfigMap);
-      PinotFSFactory.register(inputDirURIScheme, fsClass, fsProps);
-    }
-    PinotFS inputDirFS = PinotFSFactory.create(inputDirURIScheme);
+      Set<String> existingSegmentInputFileURIs)
+      throws Exception {
+    PinotFS inputDirFS = SegmentGenerationAndPushTaskUtils.getInputPinotFS(batchConfigMap, inputDirURI);
 
     String includeFileNamePattern = batchConfigMap.get(BatchConfigProperties.INCLUDE_FILE_NAME_PATTERN);
     String excludeFileNamePattern = batchConfigMap.get(BatchConfigProperties.EXCLUDE_FILE_NAME_PATTERN);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segment_generation_and_push/SegmentGenerationAndPushTaskUtils.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segment_generation_and_push;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+
+
+public class SegmentGenerationAndPushTaskUtils {
+
+  private static final PinotFS LOCAL_PINOT_FS = new LocalPinotFS();
+
+  static PinotFS getInputPinotFS(Map<String, String> taskConfigs, URI fileURI)
+      throws Exception {
+    String fileURIScheme = fileURI.getScheme();
+    if (fileURIScheme == null) {
+      return LOCAL_PINOT_FS;
+    }
+    // Try to create PinotFS using given Input FileSystem config always
+    String fsClass = taskConfigs.get(BatchConfigProperties.INPUT_FS_CLASS);
+    if (fsClass != null) {
+      PinotFS pinotFS = PluginManager.get().createInstance(fsClass);
+      PinotConfiguration fsProps = IngestionConfigUtils.getInputFsProps(taskConfigs);
+      pinotFS.init(fsProps);
+      return pinotFS;
+    }
+    // Fallback to use the PinotFS created by Minion Server configs
+    return PinotFSFactory.create(fileURIScheme);
+  }
+
+  static PinotFS getOutputPinotFS(Map<String, String> taskConfigs, URI fileURI)
+      throws Exception {
+    String fileURIScheme = (fileURI == null) ? null : fileURI.getScheme();
+    if (fileURIScheme == null) {
+      return LOCAL_PINOT_FS;
+    }
+    // Try to create PinotFS using given Input FileSystem config always
+    String fsClass = taskConfigs.get(BatchConfigProperties.OUTPUT_FS_CLASS);
+    if (fsClass != null) {
+      PinotFS pinotFS = PluginManager.get().createInstance(fsClass);
+      PinotConfiguration fsProps = IngestionConfigUtils.getOutputFsProps(taskConfigs);
+      pinotFS.init(fsProps);
+      return pinotFS;
+    }
+    // Fallback to use the PinotFS created by Minion Server configs
+    return PinotFSFactory.create(fileURIScheme);
+  }
+
+  static PinotFS getLocalPinotFs() {
+    return LOCAL_PINOT_FS;
+  }
+}


### PR DESCRIPTION
## Description
Follow up on https://github.com/apache/incubator-pinot/pull/6744, which missed the part to use override PinotFS to scan the input directory.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
