### PR TITLE
Added guava cache package to common relocated packages

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -313,6 +313,10 @@
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>com.google.common.cache</pattern>
+                      <shadedPattern>shaded.com.google.common.cache</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>org.apache.http</pattern>
                       <shadedPattern>shaded.org.apache.http</shadedPattern>
                     </relocation>


### PR DESCRIPTION
## Description

Our internal CI and local builds would encounter a classpath issue on `pinot-hadoop` test phase. 

```
java.lang.NoSuchMethodError: com.google.common.cache.CacheBuilder.ticker(Lcom/google/common/base/Ticker;)Lcom/google/common/cache/CacheBuilder;
        at org.apache.hadoop.security.Groups.<init>(Groups.java:99)
```

The root caused was identified using a `-verbose` surefire jvm args overwrite on the `pinot-hadoop` maven module.

```
[Loaded com.google.common.cache.CacheBuilder from file:/Users/daniellavoie/.m2/repository/org/apache/pinot/pinot-common/0.7.0-SNAPSHOT/pinot-common-0.7.0-SNAPSHOT-shaded.jar]
```

The fix involves relocating the `com.google.common.cache` package of `pinot-common` to `shaded.com.google.common.cache`.

Fixes #6757