### PR TITLE
Fix the issue that PinotFs doesn't init before the first get in SegmentGenerationJobRunner

### DIFF
--- a/.github/workflows/scripts/.pinot_quickstart.sh
+++ b/.github/workflows/scripts/.pinot_quickstart.sh
@@ -21,6 +21,10 @@
 # Print environment variables
 printenv
 
+# Check network
+ifconfig
+netstat -i
+
 # Java version
 java -version
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
+import io.netty.util.NetUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -54,11 +55,11 @@ public class KafkaPartitionLevelConsumerTest {
   private static final String TEST_TOPIC_2 = "bar";
   private static final int NUM_MSG_PRODUCED_PER_PARTITION = 1000;
 
-  private static MiniKafkaCluster kafkaCluster;
-  private static String brokerAddress;
+  private MiniKafkaCluster kafkaCluster;
+  private String brokerAddress;
 
   @BeforeClass
-  public static void setup()
+  public void setup()
       throws Exception {
     kafkaCluster = new MiniKafkaCluster.Builder().newServer("0").build();
     LOGGER.info("Trying to start MiniKafkaCluster");
@@ -71,7 +72,7 @@ public class KafkaPartitionLevelConsumerTest {
     Thread.sleep(STABILIZE_SLEEP_DELAYS);
   }
 
-  private static void produceMsgToKafka() {
+  private void produceMsgToKafka() {
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
     props.put(ProducerConfig.CLIENT_ID_CONFIG, "clientId");
@@ -86,12 +87,12 @@ public class KafkaPartitionLevelConsumerTest {
     }
   }
 
-  private static String getKafkaBroker() {
-    return "localhost:" + kafkaCluster.getKafkaServerPort(0);
+  private String getKafkaBroker() {
+    return NetUtil.LOCALHOST.getHostAddress() + ":" + kafkaCluster.getKafkaServerPort(0);
   }
 
   @AfterClass
-  public static void shutDown()
+  public void shutDown()
       throws Exception {
     kafkaCluster.deleteTopic(TEST_TOPIC_1);
     kafkaCluster.deleteTopic(TEST_TOPIC_2);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.stream.kafka20.utils;
 
+import io.netty.util.NetUtil;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class EmbeddedZooKeeper implements Closeable {
     this.tmpDir = Files.createTempDirectory(null).toFile();
     this.factory = new NIOServerCnxnFactory();
     this.zookeeper = new ZooKeeperServer(new File(tmpDir, "data"), new File(tmpDir, "log"), TICK_TIME);
-    InetSocketAddress addr = new InetSocketAddress("localhost", 0);
+    InetSocketAddress addr = new InetSocketAddress(NetUtil.LOCALHOST.getHostAddress(), 0);
     factory.configure(addr, 0);
     factory.startup(zookeeper);
     this.port = zookeeper.getClientPort();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.stream.kafka20.utils;
 
+import io.netty.util.NetUtil;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -70,7 +71,7 @@ public final class MiniKafkaCluster implements Closeable {
       kafkaServer.add(new KafkaServer(c, Time.SYSTEM, Option.empty(), seq));
     }
     Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + port);
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, NetUtil.LOCALHOST.getHostAddress() + ":" + port);
     adminClient = AdminClient.create(props);
   }
 
@@ -90,7 +91,7 @@ public final class MiniKafkaCluster implements Closeable {
     props.put("broker.id", nodeId);
     props.put("port", Integer.toString(port));
     props.put("log.dir", Files.createTempDirectory(tempDir, "broker-").toAbsolutePath().toString());
-    props.put("zookeeper.connect", "localhost:" + zkServer.getPort());
+    props.put("zookeeper.connect", NetUtil.LOCALHOST.getHostAddress() + ":" + zkServer.getPort());
     props.put("replica.socket.timeout.ms", "1500");
     props.put("controller.socket.timeout.ms", "1500");
     props.put("controlled.shutdown.enable", "true");


### PR DESCRIPTION
## Description
Fix the issue that PinotFs doesn't init before the first get in SegmentGenerationJobRunner

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
