### PR TITLE
Simplify the RealtimeJsonIndexQuickStart setup

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -243,6 +243,9 @@ public class JsonUtils {
    * </pre>
    */
   public static List<Map<String, String>> flatten(JsonNode node) {
+    if (node.isNull()) {
+      return Collections.emptyList();
+    }
     Preconditions.checkState(!node.isValueNode(), "Cannot flatten value node: %s", node);
 
     if (node.isArray()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -100,7 +100,8 @@ public class RealtimeJsonIndexQuickStart {
 
     printStatus(Color.YELLOW, "***** Realtime json-index quickstart setup complete *****");
 
-    String q1 = "select json_extract_scalar(event, '$.event_name', 'STRING') from meetupRsvp where json_match(\"group\", 'group_topics.topic_name=''Fitness''') limit 10";
+    String q1 =
+        "select json_extract_scalar(event_json, '$.event_name', 'STRING') from meetupRsvp where json_match(group_json, 'group_topics.topic_name=''Fitness''') limit 10";
     printStatus(Color.YELLOW, "Events related to fitness");
     printStatus(Color.CYAN, "Query : " + q1);
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q1)));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpJsonStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpJsonStream.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.tools.streams;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import javax.websocket.MessageHandler;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtils;
 
 
@@ -35,29 +32,9 @@ public class MeetupRsvpJsonStream extends MeetupRsvpStream {
   @Override
   protected MessageHandler.Whole<String> getMessageHandler() {
     return message -> {
-      try {
-        // Replace nested json with serialized json string
-        ObjectNode messageJson = (ObjectNode) JsonUtils.stringToJsonNode(message);
-        serializeJsonField(messageJson, "venue");
-        serializeJsonField(messageJson, "member");
-        serializeJsonField(messageJson, "event");
-        serializeJsonField(messageJson, "group");
-
-        if (_keepPublishing) {
-          _producer.produce("meetupRSVPEvents", StringUtils.encodeUtf8(messageJson.toString()));
-        }
-      } catch (Exception e) {
-        LOGGER.error("Caught exception while processing the message: {}", message, e);
+      if (_keepPublishing) {
+        _producer.produce("meetupRSVPEvents", StringUtils.encodeUtf8(message));
       }
     };
-  }
-
-  private static void serializeJsonField(ObjectNode messageJson, String fieldName) {
-    JsonNode jsonNode = messageJson.get(fieldName);
-    if (jsonNode != null && jsonNode.isObject()) {
-      messageJson.put(fieldName, jsonNode.toString());
-    } else {
-      messageJson.put(fieldName, "{}");
-    }
   }
 }

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/json_meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/json_meetupRsvp_realtime_table_config.json
@@ -10,29 +10,53 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "1"
   },
+  "ingestionConfig": {
+    "streamIngestionConfig": {
+      "streamConfigMaps": [
+        {
+          "streamType": "kafka",
+          "stream.kafka.consumer.type": "lowLevel",
+          "stream.kafka.topic.name": "meetupRSVPEvents",
+          "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+          "stream.kafka.hlc.zk.connect.string": "localhost:2191/kafka",
+          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+          "stream.kafka.zk.broker.url": "localhost:2191/kafka",
+          "stream.kafka.broker.list": "localhost:19092"
+        }
+      ]
+    },
+    "transformConfigs": [
+      {
+        "columnName": "event_json",
+        "transformFunction": "jsonFormat(event)"
+      },
+      {
+        "columnName": "group_json",
+        "transformFunction": "jsonFormat(\"group\")"
+      },
+      {
+        "columnName": "member_json",
+        "transformFunction": "jsonFormat(member)"
+      },
+      {
+        "columnName": "venue_json",
+        "transformFunction": "jsonFormat(venue)"
+      }
+    ]
+  },
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "streamConfigs": {
-      "streamType": "kafka",
-      "stream.kafka.consumer.type": "lowLevel",
-      "stream.kafka.topic.name": "meetupRSVPEvents",
-      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
-      "stream.kafka.hlc.zk.connect.string": "localhost:2191/kafka",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
-      "stream.kafka.zk.broker.url": "localhost:2191/kafka",
-      "stream.kafka.broker.list": "localhost:19092"
-    },
     "noDictionaryColumns": [
-      "venue",
-      "member",
-      "event",
-      "group"
+      "event_json",
+      "group_json",
+      "member_json",
+      "venue_json"
     ],
     "jsonIndexColumns": [
-      "venue",
-      "member",
-      "event",
-      "group"
+      "event_json",
+      "group_json",
+      "member_json",
+      "venue_json"
     ]
   },
   "metadata": {

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/json_meetupRsvp_schema.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/json_meetupRsvp_schema.json
@@ -2,36 +2,36 @@
   "schemaName": "meetupRsvp",
   "dimensionFieldSpecs": [
     {
-      "name": "venue",
+      "name": "event_json",
       "dataType": "STRING",
       "maxLength": 2147483647
     },
     {
-      "name": "visibility",
-      "dataType": "STRING"
+      "name": "group_json",
+      "dataType": "STRING",
+      "maxLength": 2147483647
+    },
+    {
+      "name": "member_json",
+      "dataType": "STRING",
+      "maxLength": 2147483647
+    },
+    {
+      "name": "venue_json",
+      "dataType": "STRING",
+      "maxLength": 2147483647
     },
     {
       "name": "response",
       "dataType": "STRING"
     },
     {
-      "name": "member",
-      "dataType": "STRING",
-      "maxLength": 2147483647
-    },
-    {
       "name": "rsvp_id",
       "dataType": "LONG"
     },
     {
-      "name": "event",
-      "dataType": "STRING",
-      "maxLength": 2147483647
-    },
-    {
-      "name": "group",
-      "dataType": "STRING",
-      "maxLength": 2147483647
+      "name": "visibility",
+      "dataType": "STRING"
     }
   ],
   "metricFieldSpecs": [


### PR DESCRIPTION
## Description
In RealtimeJsonIndexQuickStart, use transform function to generate the json string instead of modifying the kafka stream

Misc fixes:
- Support ingesting `"null"` json string