### PR TITLE
Fix SegmentCreationSparkTest

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerBackwardCompatibilityTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerBackwardCompatibilityTest.java
@@ -18,30 +18,6 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeoutException;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
-import org.apache.pinot.plugin.stream.kafka20.utils.MiniKafkaCluster;
-import org.apache.pinot.spi.stream.MessageBatch;
-import org.apache.pinot.spi.stream.OffsetCriteria;
-import org.apache.pinot.spi.stream.PartitionLevelConsumer;
-import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.stream.StreamConsumerFactory;
-import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-
 /**
  * Tests for the KafkaPartitionLevelConsumer with old kafka consumer factory name.
  */
@@ -51,5 +27,4 @@ public class KafkaPartitionLevelConsumerBackwardCompatibilityTest extends KafkaP
   protected String getKafkaConsumerFactoryName() {
     return "org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory";
   }
-
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -63,7 +63,7 @@ public class KafkaPartitionLevelConsumerTest {
     kafkaCluster = new MiniKafkaCluster.Builder().newServer("0").build();
     LOGGER.info("Trying to start MiniKafkaCluster");
     kafkaCluster.start();
-    brokerAddress = getKakfaBroker();
+    brokerAddress = getKafkaBroker();
     kafkaCluster.createTopic(TEST_TOPIC_1, 1, 1);
     kafkaCluster.createTopic(TEST_TOPIC_2, 2, 1);
     Thread.sleep(STABILIZE_SLEEP_DELAYS);
@@ -73,7 +73,7 @@ public class KafkaPartitionLevelConsumerTest {
 
   private static void produceMsgToKafka() {
     Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKakfaBroker());
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
     props.put(ProducerConfig.CLIENT_ID_CONFIG, "clientId");
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
@@ -86,8 +86,8 @@ public class KafkaPartitionLevelConsumerTest {
     }
   }
 
-  private static String getKakfaBroker() {
-    return "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+  private static String getKafkaBroker() {
+    return "localhost:" + kafkaCluster.getKafkaServerPort(0);
   }
 
   @AfterClass
@@ -103,7 +103,7 @@ public class KafkaPartitionLevelConsumerTest {
       throws Exception {
     String streamType = "kafka";
     String streamKafkaTopicName = "theTopic";
-    String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+    String streamKafkaBrokerList = brokerAddress;
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
     String tableNameWithType = "tableName_REALTIME";
@@ -119,12 +119,8 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.fetcher.minBytes", "20000");
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
-    KafkaStreamMetadataProvider streamMetadataProvider =
-        new KafkaStreamMetadataProvider(clientId, streamConfig);
-
     // test default value
-    KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer =
-        new KafkaPartitionLevelConsumer(clientId, streamConfig, 0);
+    KafkaPartitionLevelConsumer kafkaSimpleStreamConsumer = new KafkaPartitionLevelConsumer(clientId, streamConfig, 0);
     kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), new LongMsgOffset(23456L), 10000);
 
     Assert.assertEquals(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BUFFER_SIZE_DEFAULT,
@@ -133,8 +129,8 @@ public class KafkaPartitionLevelConsumerTest {
         kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaSocketTimeout());
 
     // test parsing values
-    Assert.assertEquals(10000,
-        kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaFetcherSizeBytes());
+    Assert
+        .assertEquals(10000, kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaFetcherSizeBytes());
     Assert
         .assertEquals(20000, kafkaSimpleStreamConsumer.getKafkaPartitionLevelStreamConfig().getKafkaFetcherMinBytes());
 
@@ -151,7 +147,7 @@ public class KafkaPartitionLevelConsumerTest {
   @Test
   public void testGetPartitionCount() {
     String streamType = "kafka";
-    String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+    String streamKafkaBrokerList = brokerAddress;
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
     String tableNameWithType = "tableName_REALTIME";
@@ -165,8 +161,7 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
-    KafkaStreamMetadataProvider streamMetadataProvider =
-        new KafkaStreamMetadataProvider(clientId, streamConfig);
+    KafkaStreamMetadataProvider streamMetadataProvider = new KafkaStreamMetadataProvider(clientId, streamConfig);
     Assert.assertEquals(streamMetadataProvider.fetchPartitionCount(10000L), 1);
 
     streamConfigMap = new HashMap<>();
@@ -187,7 +182,7 @@ public class KafkaPartitionLevelConsumerTest {
       throws Exception {
     String streamType = "kafka";
     String streamKafkaTopicName = "theTopic";
-    String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+    String streamKafkaBrokerList = brokerAddress;
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
     String tableNameWithType = "tableName_REALTIME";
@@ -217,7 +212,7 @@ public class KafkaPartitionLevelConsumerTest {
   private void testFetchOffsets(String topic)
       throws Exception {
     String streamType = "kafka";
-    String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+    String streamKafkaBrokerList = brokerAddress;
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
     String tableNameWithType = "tableName_REALTIME";
@@ -231,17 +226,14 @@ public class KafkaPartitionLevelConsumerTest {
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
-    int numPartitions =
-        new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
+    int numPartitions = new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
     for (int partition = 0; partition < numPartitions; partition++) {
       KafkaStreamMetadataProvider kafkaStreamMetadataProvider =
           new KafkaStreamMetadataProvider(clientId, streamConfig, partition);
       Assert.assertEquals(new LongMsgOffset(0).compareTo(kafkaStreamMetadataProvider
-          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000)),
-          0);
+          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest(), 10000)), 0);
       Assert.assertEquals(new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION).compareTo(kafkaStreamMetadataProvider
-          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest(), 10000)),
-          0);
+          .fetchStreamPartitionOffset(new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest(), 10000)), 0);
     }
   }
 
@@ -255,7 +247,7 @@ public class KafkaPartitionLevelConsumerTest {
   private void testConsumer(String topic)
       throws TimeoutException {
     String streamType = "kafka";
-    String streamKafkaBrokerList = "127.0.0.1:" + kafkaCluster.getKafkaServerPort(0);
+    String streamKafkaBrokerList = brokerAddress;
     String streamKafkaConsumerType = "simple";
     String clientId = "clientId";
     String tableNameWithType = "tableName_REALTIME";
@@ -270,30 +262,28 @@ public class KafkaPartitionLevelConsumerTest {
     StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
 
     final StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
-    int numPartitions =
-        new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
+    int numPartitions = new KafkaStreamMetadataProvider(clientId, streamConfig).fetchPartitionCount(10000);
     for (int partition = 0; partition < numPartitions; partition++) {
       final PartitionLevelConsumer consumer = streamConsumerFactory.createPartitionLevelConsumer(clientId, partition);
 
       // Test consume a large batch, only 500 records will be returned.
-      final MessageBatch batch1 = consumer.fetchMessages(new LongMsgOffset(0),
-          new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
+      final MessageBatch batch1 =
+          consumer.fetchMessages(new LongMsgOffset(0), new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch1.getMessageCount(), 500);
       for (int i = 0; i < batch1.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch1.getMessageAtIndex(i);
         Assert.assertEquals(new String(msg), "sample_msg_" + i);
       }
       // Test second half batch
-      final MessageBatch batch2 = consumer.fetchMessages(new LongMsgOffset(500),
-          new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
+      final MessageBatch batch2 =
+          consumer.fetchMessages(new LongMsgOffset(500), new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch2.getMessageCount(), 500);
       for (int i = 0; i < batch2.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch2.getMessageAtIndex(i);
         Assert.assertEquals(new String(msg), "sample_msg_" + (500 + i));
       }
       // Some random range
-      final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10),
-          new LongMsgOffset(35), 10000);
+      final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(35), 10000);
       Assert.assertEquals(batch3.getMessageCount(), 25);
       for (int i = 0; i < batch3.getMessageCount(); i++) {
         final byte[] msg = (byte[]) batch3.getMessageAtIndex(i);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
@@ -36,12 +36,12 @@ public class EmbeddedZooKeeper implements Closeable {
   private final File tmpDir;
   private final int port;
 
-  EmbeddedZooKeeper() throws IOException, InterruptedException {
+  EmbeddedZooKeeper()
+      throws IOException, InterruptedException {
     this.tmpDir = Files.createTempDirectory(null).toFile();
     this.factory = new NIOServerCnxnFactory();
-    this.zookeeper = new ZooKeeperServer(new File(tmpDir, "data"), new File(tmpDir, "log"),
-        TICK_TIME);
-    InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 0);
+    this.zookeeper = new ZooKeeperServer(new File(tmpDir, "data"), new File(tmpDir, "log"), TICK_TIME);
+    InetSocketAddress addr = new InetSocketAddress("localhost", 0);
     factory.configure(addr, 0);
     factory.startup(zookeeper);
     this.port = zookeeper.getClientPort();
@@ -52,7 +52,8 @@ public class EmbeddedZooKeeper implements Closeable {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close()
+      throws IOException {
     zookeeper.shutdown();
     factory.shutdown();
     FileUtils.deleteDirectory(tmpDir);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
@@ -70,7 +70,7 @@ public final class MiniKafkaCluster implements Closeable {
       kafkaServer.add(new KafkaServer(c, Time.SYSTEM, Option.empty(), seq));
     }
     Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:" + port);
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + port);
     adminClient = AdminClient.create(props);
   }
 
@@ -90,7 +90,7 @@ public final class MiniKafkaCluster implements Closeable {
     props.put("broker.id", nodeId);
     props.put("port", Integer.toString(port));
     props.put("log.dir", Files.createTempDirectory(tempDir, "broker-").toAbsolutePath().toString());
-    props.put("zookeeper.connect", "127.0.0.1:" + zkServer.getPort());
+    props.put("zookeeper.connect", "localhost:" + zkServer.getPort());
     props.put("replica.socket.timeout.ms", "1500");
     props.put("controller.socket.timeout.ms", "1500");
     props.put("controlled.shutdown.enable", "true");


### PR DESCRIPTION
## Description
Fix the following exception:
```
ERROR org.apache.spark.SparkContext - Error initializing SparkContext.
java.net.BindException: Cannot assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.
	at sun.nio.ch.Net.bind0(Native Method) ~[?:1.8.0_282]
	at sun.nio.ch.Net.bind(Net.java:461) ~[?:1.8.0_282]
	at sun.nio.ch.Net.bind(Net.java:453) ~[?:1.8.0_282]
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:222) ~[?:1.8.0_282]
	at io.netty.channel.socket.nio.NioServerSocketChannel.doBind(NioServerSocketChannel.java:134) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:550) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1334) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:506) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:491) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:973) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.AbstractChannel.bind(AbstractChannel.java:248) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:356) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-all-4.1.54.Final.jar:4.1.54.Final]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_282]
```