### PR TITLE
Support IN predicate in ColumnValue SegmentPruner

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -74,7 +74,6 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
   @Override
   public boolean prune(IndexSegment segment, QueryContext query) {
     FilterContext filter = query.getFilter();
-
     if (filter == null) {
       return false;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.query.pruner;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.pinot.core.common.DataSource;
 import org.apache.pinot.core.common.DataSourceMetadata;
 import org.apache.pinot.core.data.partition.PartitionFunctionFactory;
@@ -26,6 +28,7 @@ import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertFalse;
@@ -36,9 +39,16 @@ import static org.mockito.Mockito.when;
 
 public class ColumnValueSegmentPrunerTest {
   private static final ColumnValueSegmentPruner PRUNER = new ColumnValueSegmentPruner();
+  private static final int MAX_DEFAULT_THRESHOLD_FOR_IN_PREDICATE = 10;
+  private static final String CONFIG_VALUE_FOR_IN_PREDICATE = "pinot.segment.pruner.columnvalue.in.threshold";
 
   @Test
   public void testMinMaxValuePruning() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_VALUE_FOR_IN_PREDICATE, MAX_DEFAULT_THRESHOLD_FOR_IN_PREDICATE);
+    PinotConfiguration configuration = new PinotConfiguration(properties);
+    PRUNER.init(configuration);
+
     IndexSegment indexSegment = mock(IndexSegment.class);
 
     DataSource dataSource = mock(DataSource.class);
@@ -67,6 +77,14 @@ public class ColumnValueSegmentPrunerTest {
     // Invalid range predicate
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 20 AND 10"));
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 30 AND 20"));
+    // In Predicate
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 5, 8)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (21, 30)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (10)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (5, 10, 15)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)"));
     // AND operator
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 AND column > 10"));
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 0 AND column < 10"));


### PR DESCRIPTION
Server side segment pruning is currently supported for =, RANGE filter operators using min-max value stats (segment metadata). Similarly, bloom filter is also used for = filter.

For IN filter operator, we should add support for min-max value based pruning if the number of values in the IN clause are below a certain threshold.

Adding this support for large number of values in IN clause won't be helpful as the pruning may not happen (since values are likely to be spread across several segments) and the time to prune itself may negate the benefits. So, let's start with a configurable value with default being less than 10.