### PR TITLE
Fix Kafka tests and refactor NetUtils to pinot-spi

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -52,7 +52,6 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.TableCache;
@@ -67,6 +66,7 @@ import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,8 +120,8 @@ public class HelixBrokerStarter implements ServiceStartable {
     _zkServers = zkServer.replaceAll("\\s+", "");
 
     if (brokerHost == null) {
-      brokerHost = _brokerConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtil
-          .getHostnameOrAddress() : NetUtil.getHostAddress();
+      brokerHost = _brokerConf.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils
+          .getHostnameOrAddress() : NetUtils.getHostAddress();
     }
 
     _brokerId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -53,7 +53,6 @@ import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
 import org.apache.pinot.common.metrics.ValidationMetrics;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
@@ -91,6 +90,7 @@ import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -181,7 +181,7 @@ public class ControllerStarter implements ServiceStartable {
   private void inferHostnameIfNeeded(ControllerConf config) {
     if (config.getControllerHost() == null) {
       if (config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false)) {
-        final String inferredHostname = NetUtil.getHostnameOrAddress();
+        final String inferredHostname = NetUtils.getHostnameOrAddress();
         if (inferredHostname != null) {
           config.setControllerHost(inferredHostname);
         } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerResponseFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerResponseFilter.java
@@ -25,8 +25,8 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
 import org.apache.pinot.common.Utils;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 
 
 // A class to add the controller host and version in the response headers for all APIs.
@@ -40,7 +40,7 @@ public class PinotControllerResponseFilter implements ContainerResponseFilter {
   private final String _controllerVersion;
 
   public PinotControllerResponseFilter() {
-    String controllerHost = NetUtil.getHostnameOrAddress();
+    String controllerHost = NetUtils.getHostnameOrAddress();
     if (controllerHost != null) {
       _controllerHost = controllerHost;
     } else {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentCompletionIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.pinot.common.metrics.PinotMetricUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.LLCSegmentName;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
@@ -45,6 +44,7 @@ import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -94,7 +94,7 @@ public class SegmentCompletionIntegrationTest extends BaseClusterIntegrationTest
    */
   private void startFakeServer()
       throws Exception {
-    _serverInstance = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + NetUtil.getHostAddress() + "_"
+    _serverInstance = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + NetUtils.getHostAddress() + "_"
         + CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
 
     // Create server instance with the fake server state model

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -21,11 +21,11 @@ package org.apache.pinot.integration.tests;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.server.starter.helix.HelixServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -70,7 +70,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testDefaultServerConf()
       throws Exception {
-    String expectedHost = NetUtil.getHostAddress();
+    String expectedHost = NetUtils.getHostAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
     
     verifyInstanceConfig(new PinotConfiguration(), expectedInstanceId, expectedHost, DEFAULT_SERVER_NETTY_PORT);
@@ -79,7 +79,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testSetInstanceIdToHostname()
       throws Exception {
-    String expectedHost = NetUtil.getHostnameOrAddress();
+    String expectedHost = NetUtils.getHostnameOrAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + DEFAULT_SERVER_NETTY_PORT;
     
     Map<String, Object> properties = new HashMap<>();
@@ -94,7 +94,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CONFIG_OF_INSTANCE_ID, CUSTOM_INSTANCE_ID);
     
-    verifyInstanceConfig(new PinotConfiguration(properties), CUSTOM_INSTANCE_ID, NetUtil.getHostAddress(), DEFAULT_SERVER_NETTY_PORT);
+    verifyInstanceConfig(new PinotConfiguration(properties), CUSTOM_INSTANCE_ID, NetUtils.getHostAddress(), DEFAULT_SERVER_NETTY_PORT);
   }
 
   @Test
@@ -111,7 +111,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
   @Test
   public void testCustomPort()
       throws Exception {
-    String expectedHost = NetUtil.getHostAddress();
+    String expectedHost = NetUtils.getHostAddress();
     String expectedInstanceId = PREFIX_OF_SERVER_INSTANCE + expectedHost + "_" + CUSTOM_PORT;
 
     Map<String, Object> properties = new HashMap<>();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -32,7 +32,6 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
@@ -50,6 +49,7 @@ import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,8 +73,8 @@ public class MinionStarter implements ServiceStartable {
       throws Exception {
     _config = config;
     String host = _config.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,
-        _config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtil
-            .getHostnameOrAddress() : NetUtil.getHostAddress());
+        _config.getProperty(CommonConstants.Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils
+            .getHostnameOrAddress() : NetUtils.getHostAddress());
     int port = _config.getProperty(CommonConstants.Helix.KEY_OF_MINION_PORT, CommonConstants.Minion.DEFAULT_HELIX_PORT);
     _instanceId = _config.getProperty(CommonConstants.Helix.Instance.INSTANCE_ID_KEY,
         CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE + host + "_" + port);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
@@ -18,13 +18,20 @@
  */
 package org.apache.pinot.plugin.stream.kafka20.utils;
 
-import io.netty.util.NetUtil;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
+import java.util.Enumeration;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 
@@ -42,7 +49,7 @@ public class EmbeddedZooKeeper implements Closeable {
     this.tmpDir = Files.createTempDirectory(null).toFile();
     this.factory = new NIOServerCnxnFactory();
     this.zookeeper = new ZooKeeperServer(new File(tmpDir, "data"), new File(tmpDir, "log"), TICK_TIME);
-    InetSocketAddress addr = new InetSocketAddress(NetUtil.LOCALHOST.getHostAddress(), 0);
+    InetSocketAddress addr = new InetSocketAddress(NetUtils.getHostAddress(), 0);
     factory.configure(addr, 0);
     factory.startup(zookeeper);
     this.port = zookeeper.getClientPort();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.stream.kafka20.utils;
 
-import io.netty.util.NetUtil;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -39,9 +38,8 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.network.ListenerName;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
@@ -52,26 +50,32 @@ public final class MiniKafkaCluster implements Closeable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MiniKafkaCluster.class);
   private final EmbeddedZooKeeper zkServer;
-  private final ArrayList<KafkaServer> kafkaServer;
+  private final List<KafkaServer> kafkaServer;
+  private final List<Integer> kafkaPorts;
   private final Path tempDir;
   private final AdminClient adminClient;
+  private final String zkUrl;
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private MiniKafkaCluster(List<String> brokerIds)
       throws IOException, InterruptedException {
     this.zkServer = new EmbeddedZooKeeper();
+    this.zkUrl = NetUtils.getHostAddress() + ":" + zkServer.getPort();
+    LOGGER.info("MiniKafkaCluster Zookeeper Url is {}", zkUrl);
     this.tempDir = Files.createTempDirectory(Paths.get(System.getProperty("java.io.tmpdir")), "mini-kafka-cluster");
     this.kafkaServer = new ArrayList<>();
-    int port = 0;
+    this.kafkaPorts = new ArrayList<>();
     for (String id : brokerIds) {
-      port = getAvailablePort();
+      int port = getAvailablePort();
+      LOGGER.info("Generate broker id = {}, port = {}", id, port);
       KafkaConfig c = new KafkaConfig(createBrokerConfig(id, port));
       Seq seq =
           scala.collection.JavaConverters.collectionAsScalaIterableConverter(Collections.emptyList()).asScala().toSeq();
       kafkaServer.add(new KafkaServer(c, Time.SYSTEM, Option.empty(), seq));
+      kafkaPorts.add(port);
     }
     Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, NetUtil.LOCALHOST.getHostAddress() + ":" + port);
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, NetUtils.getHostAddress() + ":" + getKafkaServerPort(0));
     adminClient = AdminClient.create(props);
   }
 
@@ -89,9 +93,13 @@ public final class MiniKafkaCluster implements Closeable {
       throws IOException {
     Properties props = new Properties();
     props.put("broker.id", nodeId);
+    // We need to explicitly set the network interface we want to let Kafka bind to.
+    // By default, it will bind to all the network interfaces, which might not be accessible always
+    // in a container based environment.
+    props.put("host.name", NetUtils.getHostAddress());
     props.put("port", Integer.toString(port));
     props.put("log.dir", Files.createTempDirectory(tempDir, "broker-").toAbsolutePath().toString());
-    props.put("zookeeper.connect", NetUtil.LOCALHOST.getHostAddress() + ":" + zkServer.getPort());
+    props.put("zookeeper.connect", zkUrl);
     props.put("replica.socket.timeout.ms", "1500");
     props.put("controller.socket.timeout.ms", "1500");
     props.put("controlled.shutdown.enable", "true");
@@ -112,6 +120,7 @@ public final class MiniKafkaCluster implements Closeable {
   @Override
   public void close()
       throws IOException {
+    adminClient.close();
     for (KafkaServer s : kafkaServer) {
       s.shutdown();
     }
@@ -119,21 +128,8 @@ public final class MiniKafkaCluster implements Closeable {
     FileUtils.deleteDirectory(tempDir.toFile());
   }
 
-  public EmbeddedZooKeeper getZkServer() {
-    return zkServer;
-  }
-
-  public List<KafkaServer> getKafkaServer() {
-    return kafkaServer;
-  }
-
   public int getKafkaServerPort(int index) {
-    return kafkaServer.get(index).socketServer()
-        .boundPort(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT));
-  }
-
-  public AdminClient getAdminClient() {
-    return adminClient;
+    return kafkaPorts.get(index);
   }
 
   public boolean createTopic(String topicName, int numPartitions, int replicationFactor) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnProviderFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnProviderFactory.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pinot.segment.local.segment.virtualcolumn;
 
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.segment.local.segment.index.column.DefaultNullValueVirtualColumnProvider;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.BuiltInVirtualColumn;
+import org.apache.pinot.spi.utils.NetUtils;
 
 
 /**
@@ -54,7 +54,7 @@ public class VirtualColumnProviderFactory {
 
     if (!schema.hasColumn(BuiltInVirtualColumn.HOSTNAME)) {
       schema.addField(new DimensionFieldSpec(BuiltInVirtualColumn.HOSTNAME, FieldSpec.DataType.STRING, true,
-          DefaultNullValueVirtualColumnProvider.class, NetUtil.getHostnameOrAddress()));
+          DefaultNullValueVirtualColumnProvider.class, NetUtils.getHostnameOrAddress()));
     }
 
     if (!schema.hasColumn(BuiltInVirtualColumn.SEGMENTNAME)) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -49,7 +49,6 @@ import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.ServiceStatus.Status;
 import org.apache.pinot.common.utils.config.TagNameUtils;
@@ -77,6 +76,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix.Instance;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.CommonConstants.Server.SegmentCompletionProtocol;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,8 +128,8 @@ public class HelixServerStarter implements ServiceStartable {
     _listenerConfigs = ListenerConfigUtil.buildServerAdminConfigs(_serverConf);
 
     _host = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_HOST,
-        _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtil.getHostnameOrAddress()
-            : NetUtil.getHostAddress());
+        _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
+            : NetUtils.getHostAddress());
     _port = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_PORT, Helix.DEFAULT_SERVER_NETTY_PORT);
 
     String instanceId = _serverConf.getProperty(Server.CONFIG_OF_INSTANCE_ID);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -26,7 +26,6 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.TlsConfig;
@@ -35,6 +34,7 @@ import org.apache.pinot.server.api.access.AccessControlFactory;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.helix.AdminApiApplication;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -65,7 +65,7 @@ public class AccessControlTest {
     _adminApiApplication.start(Collections.singletonList(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, "0.0.0.0",
         CommonConstants.Server.DEFAULT_ADMIN_API_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig())));
 
-    _webTarget = ClientBuilder.newClient().target(String.format("http://%s:%d", NetUtil.getHostAddress(),
+    _webTarget = ClientBuilder.newClient().target(String.format("http://%s:%d", NetUtils.getHostAddress(),
         CommonConstants.Server.DEFAULT_ADMIN_API_PORT));
   }
 

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -33,7 +33,6 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
@@ -51,6 +50,7 @@ import org.apache.pinot.server.api.access.AllowAllAccessFactory;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.helix.AdminApiApplication;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
@@ -128,7 +128,7 @@ public abstract class BaseResourceTest {
             CommonConstants.HTTP_PROTOCOL, new TlsConfig())));
 
     _webTarget = ClientBuilder.newClient()
-        .target(String.format("http://%s:%d", NetUtil.getHostAddress(), CommonConstants.Server.DEFAULT_ADMIN_API_PORT));
+        .target(String.format("http://%s:%d", NetUtils.getHostAddress(), CommonConstants.Server.DEFAULT_ADMIN_API_PORT));
   }
 
   @AfterClass

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.utils;
+package org.apache.pinot.spi.utils;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -24,7 +24,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 
 
-public class NetUtil {
+public class NetUtils {
   private static final String DUMMY_OUT_IP = "74.125.224.0";
 
   /**

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -22,9 +22,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -131,7 +131,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   public boolean execute()
       throws Exception {
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
 
     if (!_exec) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -23,11 +23,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.helix.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -187,7 +187,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     }
 
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
     _controllerAddress = _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.helix.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -128,7 +128,7 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
       throws Exception {
     if (_controllerAddress == null) {
       if (_controllerHost == null) {
-        _controllerHost = NetUtil.getHostAddress();
+        _controllerHost = NetUtils.getHostAddress();
       }
       _controllerAddress = _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort;
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.BootstrapTableTool;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
@@ -123,7 +123,7 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
       throws Exception {
     PluginManager.get().init();
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
     String token = makeAuthToken(_authToken, _user, _password);
     return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir, token).execute();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
@@ -22,8 +22,8 @@ import java.net.URI;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -64,7 +64,7 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
   public boolean execute()
       throws Exception {
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
 
     String stateValue = _state.toLowerCase();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -24,9 +24,9 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -137,7 +137,7 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
   public String run()
       throws Exception {
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
     LOGGER.info("Executing command: " + toString());
     if (StringUtils.isEmpty(_config) && !_operation.equalsIgnoreCase("GET")) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -19,10 +19,10 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.util.Collections;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -128,7 +128,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   public String run()
       throws Exception {
     if (_brokerHost == null) {
-      _brokerHost = NetUtil.getHostAddress();
+      _brokerHost = NetUtils.getHostAddress();
     }
     LOGGER.info("Executing command: " + toString());
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -23,11 +23,10 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 import org.kohsuke.args4j.Option;
@@ -153,7 +152,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
       properties.putAll(PinotConfigUtils.generateControllerConf(_configFileName));
     } else {
       if (_controllerHost == null) {
-        _controllerHost = NetUtil.getHostAddress();
+        _controllerHost = NetUtils.getHostAddress();
       }
       properties.putAll(PinotConfigUtils
           .generateControllerConf(_zkAddress, _clusterName, _controllerHost, _controllerPort, _dataDir, _controllerMode,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -25,9 +25,9 @@ import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -136,7 +136,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   public boolean execute()
       throws Exception {
     if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
+      _controllerHost = NetUtils.getHostAddress();
     }
 
     // Create a temporary working directory.

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/ClusterStarter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/ClusterStarter.java
@@ -27,11 +27,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.helix.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.tools.admin.command.AddTableCommand;
 import org.apache.pinot.tools.admin.command.CreateSegmentCommand;
@@ -83,7 +83,7 @@ public class ClusterStarter {
     _inputDataDir = config.getInputDataDir();
     _segmentDirName = config.getSegmentsDir();
 
-    _localhost = NetUtil.getHostAddress();
+    _localhost = NetUtils.getHostAddress();
 
     _zkAddress = config.getZookeeperAddress();
     _clusterName = config.getClusterName();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -18,14 +18,11 @@
  */
 package org.apache.pinot.tools.service;
 
-import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
-
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerStarter;
@@ -34,11 +31,12 @@ import org.apache.pinot.server.starter.helix.HelixServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.service.api.resources.PinotInstanceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
+import static org.apache.pinot.tools.utils.PinotConfigUtils.getAvailablePort;
 
 
 /**
@@ -74,7 +72,7 @@ public class PinotServiceManager {
     }
     _port = port;
     if (hostname == null || hostname.isEmpty()) {
-      hostname = NetUtil.getHostnameOrAddress();
+      hostname = NetUtils.getHostnameOrAddress();
     }
     _instanceId = String.format("ServiceManager_%s_%d", hostname, port);
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
@@ -41,12 +41,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.configuration.Configuration;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.service.PinotServiceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,7 +162,7 @@ public class PinotServiceManagerInstanceResource {
             Optional.ofNullable(properties.get(ControllerConf.CONTROLLER_HOST)).map(Object::toString).orElse(null);
         if (controllerHost == null) {
           try {
-            controllerHost = NetUtil.getHostAddress();
+            controllerHost = NetUtils.getHostAddress();
           } catch (Exception e) {
             controllerHost = "localhost";
           }
@@ -195,7 +195,7 @@ public class PinotServiceManagerInstanceResource {
         if (!properties.containsKey(CommonConstants.Broker.METRICS_CONFIG_PREFIX)) {
           String hostname;
           try {
-            hostname = NetUtil.getHostAddress();
+            hostname = NetUtils.getHostAddress();
           } catch (Exception e) {
             hostname = "localhost";
           }
@@ -208,7 +208,7 @@ public class PinotServiceManagerInstanceResource {
         if (!properties.containsKey(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST)) {
           String hostname;
           try {
-            hostname = NetUtil.getHostAddress();
+            hostname = NetUtils.getHostAddress();
           } catch (Exception e) {
             hostname = "localhost";
           }
@@ -247,7 +247,7 @@ public class PinotServiceManagerInstanceResource {
         if (!properties.containsKey(CommonConstants.Minion.CONFIG_OF_METRICS_PREFIX_KEY)) {
           String hostname;
           try {
-            hostname = NetUtil.getHostAddress();
+            hostname = NetUtils.getHostAddress();
           } catch (Exception e) {
             hostname = "localhost";
           }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -30,11 +30,11 @@ import java.util.Optional;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringUtils;
-import org.apache.pinot.common.utils.NetUtil;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerConf.ControllerPeriodicTasksConf;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public class PinotConfigUtils {
     Map<String, Object> properties = new HashMap<>();
     properties.put(ControllerConf.ZK_STR, zkAddress);
     properties.put(ControllerConf.HELIX_CLUSTER_NAME, clusterName);
-    properties.put(ControllerConf.CONTROLLER_HOST, !StringUtils.isEmpty(controllerHost) ? controllerHost : NetUtil.getHostAddress());
+    properties.put(ControllerConf.CONTROLLER_HOST, !StringUtils.isEmpty(controllerHost) ? controllerHost : NetUtils.getHostAddress());
     properties.put(ControllerConf.CONTROLLER_PORT, !StringUtils.isEmpty(controllerPort) ? controllerPort:getAvailablePort());
     properties.put(ControllerConf.DATA_DIR, !StringUtils.isEmpty(dataDir) ? dataDir : TMP_DIR + String.format("Controller_%s_%s/controller/data", controllerHost, controllerPort));
     properties.put(ControllerConf.CONTROLLER_VIP_HOST, controllerHost);
@@ -149,7 +149,7 @@ public class PinotConfigUtils {
   public static Map<String, Object> generateServerConf(String serverHost, int serverPort, int serverAdminPort,
       String serverDataDir, String serverSegmentDir) throws SocketException, UnknownHostException {
     if (serverHost == null) {
-      serverHost = NetUtil.getHostAddress();
+      serverHost = NetUtils.getHostAddress();
     }
     if (serverPort == 0) {
       serverPort = getAvailablePort();
@@ -176,7 +176,7 @@ public class PinotConfigUtils {
   public static Map<String, Object> generateMinionConf(String minionHost, int minionPort)
       throws SocketException, UnknownHostException {
     if (minionHost == null) {
-      minionHost = NetUtil.getHostAddress();
+      minionHost = NetUtils.getHostAddress();
     }
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.KEY_OF_MINION_HOST, minionHost);


### PR DESCRIPTION
## Description
- Fix Kafka tests by explicitly set the hostname Kafka broker to bind to.
- Refactor NetUtil from pinot-common to pinot-spi.
- Replace the usage of netty NetUtils with internal NetUtils for getting the local IP address.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
