### PR TITLE
Close partitionMetadataProvider after use in computePartitionGroupMetadata()

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -82,11 +82,12 @@ public interface StreamMetadataProvider extends Closeable {
     // Use offset criteria from stream config
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     for (int i = partitionGroupConsumptionStatuses.size(); i < partitionCount; i++) {
-      StreamMetadataProvider partitionMetadataProvider =
-          streamConsumerFactory.createPartitionMetadataProvider(clientId, i);
-      StreamPartitionMsgOffset streamPartitionMsgOffset =
-          partitionMetadataProvider.fetchStreamPartitionOffset(streamConfig.getOffsetCriteria(), timeoutMillis);
-      newPartitionGroupMetadataList.add(new PartitionGroupMetadata(i, streamPartitionMsgOffset));
+      try (StreamMetadataProvider partitionMetadataProvider =
+          streamConsumerFactory.createPartitionMetadataProvider(clientId, i)) {
+        StreamPartitionMsgOffset streamPartitionMsgOffset =
+            partitionMetadataProvider.fetchStreamPartitionOffset(streamConfig.getOffsetCriteria(), timeoutMillis);
+        newPartitionGroupMetadataList.add(new PartitionGroupMetadata(i, streamPartitionMsgOffset));
+      }
     }
     return newPartitionGroupMetadataList;
   }


### PR DESCRIPTION
One line fix for the change in #6667 