### PR TITLE
Add the refreshed text index segment back into queue(#6796)

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LuceneRealtimeClusterIntegrationTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 
 /**
@@ -197,15 +198,15 @@ public class LuceneRealtimeClusterIntegrationTest extends BaseClusterIntegration
       Thread.sleep(100);
     }
 
-    // TODO: Fix Lucene index on consuming segments to update the latest records, then uncomment the following part
-//    TestUtils.waitForCondition(aVoid -> {
-//      try {
-//        return getTextColumnQueryResult() == NUM_MATCHING_RECORDS;
-//      } catch (Exception e) {
-//        fail("Caught exception while getting text column query result");
-//        return false;
-//      }
-//    }, 10_000L, "Failed to reach expected number of matching records");
+    //Lucene index on consuming segments to update the latest records
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return getTextColumnQueryResult() == NUM_MATCHING_RECORDS;
+      } catch (Exception e) {
+        fail("Caught exception while getting text column query result");
+        return false;
+      }
+    }, 10_000L, "Failed to reach expected number of matching records");
   }
 
   private long getTextColumnQueryResult()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneIndexReaderRefreshThread.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneIndexReaderRefreshThread.java
@@ -134,6 +134,7 @@ public class RealtimeLuceneIndexReaderRefreshThread implements Runnable {
             }
           }
         } finally {
+          _luceneRealtimeReaders.offer(realtimeReadersForSegment);
           realtimeReadersForSegment.getLock().unlock();
         }
       }


### PR DESCRIPTION
The refresh thread maintains a single global queue of realtime text index readers across all consuming segments across all tables.

A reader is polled, refreshed and supposed to be added back to the queue so that it can be refreshed again in the next cycle. There is a bug in the refresh thread code as it somewhere fails to add the polled reader back to the queue.

This will introduce the lag between documents being added to realtime text index and appearing in search results by the reader since the reader snapshot will be refreshed exactly once. The problem was recently reported in open source as the client was ingesting documents at time T, they appeared in search results at time T and T + X, but any documents added after T + X were not being reported in search results until long time when the consuming segment finally committed and converted to offline at which point obviously everything became available.

Issue #6796 