### PR TITLE
Clean up KafkaPartitionLevelConsumerTest

### DIFF
--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -21,6 +21,10 @@
 # Java version
 java -version
 
+# Check network
+ifconfig
+netstat -i
+
 # Only run integration tests if needed
 if [ "$RUN_INTEGRATION_TESTS" != false ]; then
   mvn test -B -P github-actions,integration-tests-only && exit 0 || exit 1

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/EmbeddedZooKeeper.java
@@ -21,49 +21,36 @@ package org.apache.pinot.plugin.stream.kafka20.utils;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.net.DatagramSocket;
-import java.net.Inet4Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.util.Enumeration;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 
 
 public class EmbeddedZooKeeper implements Closeable {
-
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "EmbeddedZooKeeper");
   private static final int TICK_TIME = 500;
-  private final NIOServerCnxnFactory factory;
-  private final ZooKeeperServer zookeeper;
-  private final File tmpDir;
-  private final int port;
+
+  private final NIOServerCnxnFactory _factory;
+  private final String _zkAddress;
 
   EmbeddedZooKeeper()
       throws IOException, InterruptedException {
-    this.tmpDir = Files.createTempDirectory(null).toFile();
-    this.factory = new NIOServerCnxnFactory();
-    this.zookeeper = new ZooKeeperServer(new File(tmpDir, "data"), new File(tmpDir, "log"), TICK_TIME);
-    InetSocketAddress addr = new InetSocketAddress(NetUtils.getHostAddress(), 0);
-    factory.configure(addr, 0);
-    factory.startup(zookeeper);
-    this.port = zookeeper.getClientPort();
+    _factory = new NIOServerCnxnFactory();
+    ZooKeeperServer zkServer = new ZooKeeperServer(new File(TEMP_DIR, "data"), new File(TEMP_DIR, "log"), TICK_TIME);
+    _factory.configure(new InetSocketAddress("localhost", 0), 0);
+    _factory.startup(zkServer);
+    _zkAddress = "localhost:" + zkServer.getClientPort();
   }
 
-  public int getPort() {
-    return port;
+  public String getZkAddress() {
+    return _zkAddress;
   }
 
   @Override
   public void close()
       throws IOException {
-    zookeeper.shutdown();
-    factory.shutdown();
-    FileUtils.deleteDirectory(tmpDir);
+    _factory.shutdown();
+    FileUtils.deleteDirectory(TEMP_DIR);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
@@ -19,67 +19,47 @@
 package org.apache.pinot.plugin.stream.kafka20.utils;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.utils.Time;
-import org.apache.pinot.spi.utils.NetUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import scala.Option;
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 
 public final class MiniKafkaCluster implements Closeable {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "MiniKafkaCluster");
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MiniKafkaCluster.class);
-  private final EmbeddedZooKeeper zkServer;
-  private final List<KafkaServer> kafkaServer;
-  private final List<Integer> kafkaPorts;
-  private final Path tempDir;
-  private final AdminClient adminClient;
-  private final String zkUrl;
+  private final EmbeddedZooKeeper _zkServer;
+  private final KafkaServer _kafkaServer;
+  private final String _kafkaServerAddress;
+  private final AdminClient _adminClient;
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private MiniKafkaCluster(List<String> brokerIds)
+  public MiniKafkaCluster(String brokerId)
       throws IOException, InterruptedException {
-    this.zkServer = new EmbeddedZooKeeper();
-    this.zkUrl = NetUtils.getHostAddress() + ":" + zkServer.getPort();
-    LOGGER.info("MiniKafkaCluster Zookeeper Url is {}", zkUrl);
-    this.tempDir = Files.createTempDirectory(Paths.get(System.getProperty("java.io.tmpdir")), "mini-kafka-cluster");
-    this.kafkaServer = new ArrayList<>();
-    this.kafkaPorts = new ArrayList<>();
-    for (String id : brokerIds) {
-      int port = getAvailablePort();
-      LOGGER.info("Generate broker id = {}, port = {}", id, port);
-      KafkaConfig c = new KafkaConfig(createBrokerConfig(id, port));
-      Seq seq =
-          scala.collection.JavaConverters.collectionAsScalaIterableConverter(Collections.emptyList()).asScala().toSeq();
-      kafkaServer.add(new KafkaServer(c, Time.SYSTEM, Option.empty(), seq));
-      kafkaPorts.add(port);
-    }
-    Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, NetUtils.getHostAddress() + ":" + getKafkaServerPort(0));
-    adminClient = AdminClient.create(props);
+    _zkServer = new EmbeddedZooKeeper();
+    int kafkaServerPort = getAvailablePort();
+    KafkaConfig kafkaBrokerConfig = new KafkaConfig(createBrokerConfig(brokerId, kafkaServerPort));
+    Seq seq = JavaConverters.collectionAsScalaIterableConverter(Collections.emptyList()).asScala().toSeq();
+    _kafkaServer = new KafkaServer(kafkaBrokerConfig, Time.SYSTEM, Option.empty(), seq);
+    _kafkaServerAddress = "localhost:" + kafkaServerPort;
+    Properties kafkaClientConfig = new Properties();
+    kafkaClientConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaServerAddress);
+    _adminClient = AdminClient.create(kafkaClientConfig);
   }
 
-  static int getAvailablePort() {
+  private static int getAvailablePort() {
     try {
       try (ServerSocket socket = new ServerSocket(0)) {
         return socket.getLocalPort();
@@ -89,17 +69,16 @@ public final class MiniKafkaCluster implements Closeable {
     }
   }
 
-  private Properties createBrokerConfig(String nodeId, int port)
-      throws IOException {
+  private Properties createBrokerConfig(String brokerId, int port) {
     Properties props = new Properties();
-    props.put("broker.id", nodeId);
+    props.put("broker.id", brokerId);
     // We need to explicitly set the network interface we want to let Kafka bind to.
     // By default, it will bind to all the network interfaces, which might not be accessible always
     // in a container based environment.
-    props.put("host.name", NetUtils.getHostAddress());
+    props.put("host.name", "localhost");
     props.put("port", Integer.toString(port));
-    props.put("log.dir", Files.createTempDirectory(tempDir, "broker-").toAbsolutePath().toString());
-    props.put("zookeeper.connect", zkUrl);
+    props.put("log.dir", new File(TEMP_DIR, "log").getPath());
+    props.put("zookeeper.connect", _zkServer.getZkAddress());
     props.put("replica.socket.timeout.ms", "1500");
     props.put("controller.socket.timeout.ms", "1500");
     props.put("controlled.shutdown.enable", "true");
@@ -112,61 +91,29 @@ public final class MiniKafkaCluster implements Closeable {
   }
 
   public void start() {
-    for (KafkaServer s : kafkaServer) {
-      s.startup();
-    }
+    _kafkaServer.startup();
   }
 
   @Override
   public void close()
       throws IOException {
-    adminClient.close();
-    for (KafkaServer s : kafkaServer) {
-      s.shutdown();
-    }
-    this.zkServer.close();
-    FileUtils.deleteDirectory(tempDir.toFile());
+    _kafkaServer.shutdown();
+    _zkServer.close();
+    FileUtils.deleteDirectory(TEMP_DIR);
   }
 
-  public int getKafkaServerPort(int index) {
-    return kafkaPorts.get(index);
+  public String getKafkaServerAddress() {
+    return _kafkaServerAddress;
   }
 
-  public boolean createTopic(String topicName, int numPartitions, int replicationFactor) {
+  public void createTopic(String topicName, int numPartitions, int replicationFactor)
+      throws ExecutionException, InterruptedException {
     NewTopic newTopic = new NewTopic(topicName, numPartitions, (short) replicationFactor);
-    CreateTopicsResult createTopicsResult = this.adminClient.createTopics(Arrays.asList(newTopic));
-    try {
-      createTopicsResult.all().get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Failed to create Kafka topic: {}, Exception: {}", newTopic.toString(), e);
-      return false;
-    }
-    return true;
+    _adminClient.createTopics(Collections.singletonList(newTopic)).all().get();
   }
 
-  public boolean deleteTopic(String topicName) {
-    final DeleteTopicsResult deleteTopicsResult = this.adminClient.deleteTopics(Collections.singletonList(topicName));
-    try {
-      deleteTopicsResult.all().get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Failed to delete Kafka topic: {}, Exception: {}", topicName, e);
-      return false;
-    }
-    return true;
-  }
-
-  public static class Builder {
-
-    private List<String> brokerIds = new ArrayList<>();
-
-    public Builder newServer(String brokerId) {
-      brokerIds.add(brokerId);
-      return this;
-    }
-
-    public MiniKafkaCluster build()
-        throws IOException, InterruptedException {
-      return new MiniKafkaCluster(brokerIds);
-    }
+  public void deleteTopic(String topicName)
+      throws ExecutionException, InterruptedException {
+    _adminClient.deleteTopics(Collections.singletonList(topicName)).all().get();
   }
 }


### PR DESCRIPTION
Simplify the logic of creating the kafka cluster in `MiniKafkaCluster`
Put `localhost` as the `host.name` to be in sync with the quick-start