### PR TITLE
[PQL Deprecation] Remove the usage of PQL compiler

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -124,6 +124,44 @@ public class StringFunctions {
   }
 
   /**
+   * Standard SQL trim function.
+   *
+   * @param end BOTH|LEADING|TRAILING
+   * @param characters characters to be trimmed off
+   * @param value value to trim
+   * @return trim the characters from both/leading/trailing end of the string
+   */
+  @ScalarFunction
+  public static String trim(String end, String characters, String value) {
+    int length = value.length();
+    int startIndex = 0;
+    int endIndex = length;
+    if (end.equals("BOTH") || end.equals("LEADING")) {
+      while (startIndex < endIndex) {
+        if (characters.indexOf(value.charAt(startIndex)) >= 0) {
+          startIndex++;
+        } else {
+          break;
+        }
+      }
+    }
+    if (end.equals("BOTH") || end.equals("TRAILING")) {
+      while (startIndex < endIndex) {
+        if (characters.indexOf(value.charAt(endIndex - 1)) >= 0) {
+          endIndex--;
+        } else {
+          break;
+        }
+      }
+    }
+    if (startIndex > 0 || endIndex < length) {
+      return value.substring(startIndex, endIndex);
+    } else {
+      return value;
+    }
+  }
+
+  /**
    * @param input
    * @return trim spaces from left side of the string
    */

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -248,12 +248,16 @@ public class CalciteSqlParser {
    * @param expression String expression.
    * @return {@link Expression} equivalent of the string.
    *
-   * @throws SqlParseException Throws parse exception if String is not a valid expression.
+   * @throws SqlCompilationException if String is not a valid expression.
    */
-  public static Expression compileToExpression(String expression)
-      throws SqlParseException {
+  public static Expression compileToExpression(String expression) {
     SqlParser sqlParser = SqlParser.create(expression, PARSER_CONFIG);
-    SqlNode sqlNode = sqlParser.parseExpression();
+    SqlNode sqlNode;
+    try {
+      sqlNode = sqlParser.parseExpression();
+    } catch (SqlParseException e) {
+      throw new SqlCompilationException("Caught exception while parsing expression: " + expression, e);
+    }
     return toExpression(sqlNode);
   }
 
@@ -280,7 +284,7 @@ public class CalciteSqlParser {
     try {
       sqlNode = sqlParser.parseQuery();
     } catch (SqlParseException e) {
-      throw new SqlCompilationException(e);
+      throw new SqlCompilationException("Caught exception while parsing query: " + sql, e);
     }
 
     SqlSelect selectNode;
@@ -1012,9 +1016,9 @@ public class CalciteSqlParser {
           Object result = invoker.invoke(arguments);
           return RequestUtils.getLiteralExpression(result);
         } catch (Exception e) {
-          throw new SqlCompilationException(new RuntimeException(
+          throw new SqlCompilationException(
               "Caught exception while invoking method: " + functionInfo.getMethod() + " with arguments: " + Arrays
-                  .toString(arguments), e));
+                  .toString(arguments), e);
         }
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlCompilationException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlCompilationException.java
@@ -30,4 +30,8 @@ public class SqlCompilationException extends RuntimeException {
   public SqlCompilationException(Throwable throwable) {
     super(throwable);
   }
+
+  public SqlCompilationException(String msg, Throwable throwable) {
+    super(msg, throwable);
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -509,9 +509,10 @@ public class CalciteSqlCompilerTest {
 
     // nested functions in group by
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery("select concat(upper(playerName), lower(teamID), '-') playerTeam, "
-          + "upper(league) leagueUpper, count(playerName) cnt from baseballStats group by playerTeam, lower(teamID), leagueUpper "
-          + "having cnt > 1 order by cnt desc limit 10");
+      pinotQuery = CalciteSqlParser.compileToPinotQuery(
+          "select concat(upper(playerName), lower(teamID), '-') playerTeam, "
+              + "upper(league) leagueUpper, count(playerName) cnt from baseballStats group by playerTeam, lower(teamID), leagueUpper "
+              + "having cnt > 1 order by cnt desc limit 10");
     } catch (SqlCompilationException e) {
       throw e;
     }
@@ -574,7 +575,7 @@ public class CalciteSqlCompilerTest {
       CalciteSqlParser.compileToPinotQuery(query);
     } catch (SqlCompilationException e) {
       // Expected
-      Assert.assertTrue(e.getMessage().contains("at line 1, column 31."),
+      Assert.assertTrue(e.getCause().getMessage().contains("at line 1, column 31."),
           "Compilation exception should contain line and character for error message. Error message is " + e
               .getMessage());
       return;
@@ -1409,7 +1410,8 @@ public class CalciteSqlCompilerTest {
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getCause() instanceof SqlParseException);
-      Assert.assertTrue(e.getMessage().contains("Encountered") && e.getMessage().contains("table"));
+      String message = e.getCause().getMessage();
+      Assert.assertTrue(message.startsWith("Encountered") && message.contains("table"));
     }
     // date - need to escape
     try {
@@ -1418,7 +1420,8 @@ public class CalciteSqlCompilerTest {
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getCause() instanceof SqlParseException);
-      Assert.assertTrue(e.getMessage().contains("Encountered") && e.getMessage().contains("Date"));
+      String message = e.getCause().getMessage();
+      Assert.assertTrue(message.startsWith("Encountered") && message.contains("Date"));
     }
 
     // timestamp - need to escape
@@ -1428,7 +1431,8 @@ public class CalciteSqlCompilerTest {
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getCause() instanceof SqlParseException);
-      Assert.assertTrue(e.getMessage().contains("Encountered") && e.getMessage().contains("timestamp"));
+      String message = e.getCause().getMessage();
+      Assert.assertTrue(message.startsWith("Encountered") && message.contains("timestamp"));
     }
 
     // time - need to escape
@@ -1438,7 +1442,8 @@ public class CalciteSqlCompilerTest {
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getCause() instanceof SqlParseException);
-      Assert.assertTrue(e.getMessage().contains("Encountered") && e.getMessage().contains("time"));
+      String message = e.getCause().getMessage();
+      Assert.assertTrue(message.startsWith("Encountered") && message.contains("time"));
     }
 
     // group - need to escape
@@ -1448,7 +1453,8 @@ public class CalciteSqlCompilerTest {
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
       Assert.assertTrue(e.getCause() instanceof SqlParseException);
-      Assert.assertTrue(e.getMessage().contains("Encountered") && e.getMessage().contains("group"));
+      String message = e.getCause().getMessage();
+      Assert.assertTrue(message.startsWith("Encountered") && message.contains("group"));
     }
 
     // escaping the above works
@@ -1631,11 +1637,16 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testOrdinalsQueryRewriteWithDistinctOrderby() {
-    String query = "SELECT baseballStats.playerName AS playerName FROM baseballStats GROUP BY baseballStats.playerName ORDER BY 1 ASC";
+    String query =
+        "SELECT baseballStats.playerName AS playerName FROM baseballStats GROUP BY baseballStats.playerName ORDER BY 1 ASC";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "baseballStats.playerName");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "baseballStats.playerName");
     Assert.assertTrue(pinotQuery.getGroupByList().isEmpty());
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "baseballStats.playerName");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "baseballStats.playerName");
   }
 
   @Test
@@ -1693,8 +1704,7 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testCompileTimeExpression()
-      throws SqlParseException {
+  public void testCompileTimeExpression() {
     long lowerBound = System.currentTimeMillis();
     Expression expression = CalciteSqlParser.compileToExpression("now()");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -1749,8 +1759,7 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
-  public void testLiteralExpressionCheck()
-      throws SqlParseException {
+  public void testLiteralExpressionCheck() {
     Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("1123")));
     Assert.assertTrue(CalciteSqlParser.isLiteralOnlyExpression(CalciteSqlParser.compileToExpression("'ab'")));
     Assert.assertTrue(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.datasketches.Util;
 import org.apache.datasketches.memory.Memory;
@@ -128,13 +127,8 @@ public class DistinctCountThetaSketchAggregationFunction extends BaseSingleInput
         ExpressionContext filterExpression = arguments.get(i);
         Preconditions.checkArgument(filterExpression.getType() == ExpressionContext.Type.LITERAL,
             "Third to second last argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal (filter expression)");
-        FilterContext filter;
-        try {
-          filter =
-              RequestContextUtils.getFilter(CalciteSqlParser.compileToExpression(filterExpression.getLiteral()));
-        } catch (SqlParseException e) {
-          throw new IllegalArgumentException("Invalid filter expression: " + filterExpression.getLiteral());
-        }
+        FilterContext filter =
+            RequestContextUtils.getFilter(CalciteSqlParser.compileToExpression(filterExpression.getLiteral()));
         // NOTE: Collect expressions before constructing the FilterInfo so that expressionIndexMap always include the
         //       expressions in the filter.
         collectExpressions(filter, _inputExpressions, expressionIndexMap);
@@ -145,13 +139,8 @@ public class DistinctCountThetaSketchAggregationFunction extends BaseSingleInput
       ExpressionContext postAggregationExpression = arguments.get(numArguments - 1);
       Preconditions.checkArgument(postAggregationExpression.getType() == ExpressionContext.Type.LITERAL,
           "Last argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal (post-aggregation expression)");
-      try {
-        _postAggregationExpression = RequestContextUtils
-            .getExpression(CalciteSqlParser.compileToExpression(postAggregationExpression.getLiteral()));
-      } catch (SqlParseException e) {
-        throw new IllegalArgumentException(
-            "Invalid post-aggregation expression: " + postAggregationExpression.getLiteral());
-      }
+      _postAggregationExpression = RequestContextUtils
+          .getExpression(CalciteSqlParser.compileToExpression(postAggregationExpression.getLiteral()));
 
       // Validate the post-aggregation expression
       _includeDefaultSketch = validatePostAggregationExpression(_postAggregationExpression, _filterEvaluators.size());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -70,8 +70,7 @@ public class SelectionDataTableReducer implements DataTableReducer {
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
     if (dataTableMap.isEmpty()) {
       // For empty data table map, construct empty result using the cached data schema for selection query
-      List<String> selectionColumns =
-          SelectionOperatorUtils.getSelectionColumns(_queryContext.getSelectExpressions(), dataSchema);
+      List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(_queryContext, dataSchema);
       if (_responseFormatSql) {
         DataSchema selectionDataSchema = SelectionOperatorUtils.getResultTableDataSchema(dataSchema, selectionColumns);
         brokerResponseNative.setResultTable(new ResultTable(selectionDataSchema, Collections.emptyList()));
@@ -107,8 +106,7 @@ public class SelectionDataTableReducer implements DataTableReducer {
         }
       } else {
         // Selection only
-        List<String> selectionColumns =
-            SelectionOperatorUtils.getSelectionColumns(_queryContext.getSelectExpressions(), dataSchema);
+        List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(_queryContext, dataSchema);
         List<Object[]> reducedRows = SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), limit);
         if (_responseFormatSql) {
           brokerResponseNative

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverter.java
@@ -141,7 +141,7 @@ public class BrokerRequestToQueryContextConverter {
       List<String> selectionColumns = selections.getSelectionColumns();
       selectExpressions = new ArrayList<>(selectionColumns.size());
       for (String expression : selectionColumns) {
-        selectExpressions.add(RequestContextUtils.getExpression(expression));
+        selectExpressions.add(RequestContextUtils.getExpressionFromPQL(expression));
       }
 
       // NOTE: Some old Pinot clients (E.g. Presto segment level query) set LIMIT in Selection object.
@@ -162,13 +162,13 @@ public class BrokerRequestToQueryContextConverter {
         if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
           // For DISTINCT query, all arguments are expressions
           for (String expression : stringExpressions) {
-            arguments.add(RequestContextUtils.getExpression(expression));
+            arguments.add(RequestContextUtils.getExpressionFromPQL(expression));
           }
         } else {
           // For non-DISTINCT query, only the first argument is expression, others are literals
           // NOTE: We directly use the string as the literal value because of the legacy behavior of PQL compiler
           //       treating string literal as identifier in the aggregation function.
-          arguments.add(RequestContextUtils.getExpression(stringExpressions.get(0)));
+          arguments.add(RequestContextUtils.getExpressionFromPQL(stringExpressions.get(0)));
           for (int i = 1; i < numArguments; i++) {
             arguments.add(ExpressionContext.forLiteral(stringExpressions.get(i)));
           }
@@ -183,7 +183,7 @@ public class BrokerRequestToQueryContextConverter {
         List<String> stringExpressions = groupBy.getExpressions();
         groupByExpressions = new ArrayList<>(stringExpressions.size());
         for (String stringExpression : stringExpressions) {
-          groupByExpressions.add(RequestContextUtils.getExpression(stringExpression));
+          groupByExpressions.add(RequestContextUtils.getExpressionFromPQL(stringExpression));
         }
 
         // NOTE: Use TOP in GROUP-BY clause as LIMIT for backward-compatibility.
@@ -204,7 +204,7 @@ public class BrokerRequestToQueryContextConverter {
       orderByExpressions = new ArrayList<>(orderBy.size());
       Set<ExpressionContext> expressionSet = new HashSet<>();
       for (SelectionSort selectionSort : orderBy) {
-        ExpressionContext expression = RequestContextUtils.getExpression(selectionSort.getColumn());
+        ExpressionContext expression = RequestContextUtils.getExpressionFromPQL(selectionSort.getColumn());
         if (expressionSet.add(expression)) {
           orderByExpressions.add(new OrderByExpressionContext(expression, selectionSort.isIsAsc()));
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -74,7 +74,7 @@ public class SelectionOperatorService {
    * @param dataSchema data schema.
    */
   public SelectionOperatorService(QueryContext queryContext, DataSchema dataSchema) {
-    _selectionColumns = SelectionOperatorUtils.getSelectionColumns(queryContext.getSelectExpressions(), dataSchema);
+    _selectionColumns = SelectionOperatorUtils.getSelectionColumns(queryContext, dataSchema);
     _dataSchema = dataSchema;
     // Select rows from offset to offset + limit.
     _offset = queryContext.getOffset();

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableUtilsTest.java
@@ -39,7 +39,7 @@ public class DataTableUtilsTest {
       throws IOException {
     // Selection
     QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM table WHERE foo = 'bar'");
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable WHERE foo = 'bar'");
     DataTable dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
     DataSchema dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"*"});
@@ -48,7 +48,7 @@ public class DataTableUtilsTest {
 
     // Aggregation
     queryContext = QueryContextConverterUtils
-        .getQueryContextFromPQL("SELECT COUNT(*), SUM(a), MAX(b) FROM table WHERE foo = 'bar'");
+        .getQueryContextFromSQL("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar'");
     dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"count_star", "sum_a", "max_b"});
@@ -61,7 +61,7 @@ public class DataTableUtilsTest {
 
     // PQL group-by
     queryContext = QueryContextConverterUtils
-        .getQueryContextFromPQL("SELECT COUNT(*), SUM(a), MAX(b) FROM table WHERE foo = 'bar' GROUP BY c, d");
+        .getQueryContextFromPQL("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar' GROUP BY c, d");
     dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"functionName", "GroupByResultMap"});
@@ -75,8 +75,8 @@ public class DataTableUtilsTest {
     assertEquals(dataTable.getObject(2, 1), Collections.emptyMap());
 
     // SQL group-by
-    queryContext = QueryContextConverterUtils.getQueryContextFromPQL(
-        "SELECT c, d, COUNT(*), SUM(a), MAX(b) FROM table WHERE foo = 'bar' GROUP BY c, d OPTION(groupByMode=sql)");
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT c, d, COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar' GROUP BY c, d OPTION(groupByMode=sql)");
     dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"c", "d", "count(*)", "sum(a)", "max(b)"});
@@ -86,7 +86,7 @@ public class DataTableUtilsTest {
 
     // Distinct
     queryContext =
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT DISTINCT(a, b) FROM table WHERE foo = 'bar'");
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT DISTINCT a, b FROM testTable WHERE foo = 'bar'");
     dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"distinct_a:b"});

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -53,22 +53,27 @@ public class ArithmeticFunctionsTest {
     GenericRow row0 = new GenericRow();
     row0.putValue("a", (byte) 1);
     row0.putValue("b", (char) 2);
-    inputs.add(new Object[]{"plus(a, b)", Lists.newArrayList("a", "b"), row0, 3.0});
+    inputs.add(new Object[]{"a + b", Lists.newArrayList("a", "b"), row0, 3.0});
 
     GenericRow row1 = new GenericRow();
     row1.putValue("a", (short) 3);
     row1.putValue("b", 4);
-    inputs.add(new Object[]{"minus(a, b)", Lists.newArrayList("a", "b"), row1, -1.0});
+    inputs.add(new Object[]{"a - b", Lists.newArrayList("a", "b"), row1, -1.0});
 
     GenericRow row2 = new GenericRow();
     row2.putValue("a", 5L);
     row2.putValue("b", 6f);
-    inputs.add(new Object[]{"times(a, b)", Lists.newArrayList("a", "b"), row2, 30.0});
+    inputs.add(new Object[]{"a * b", Lists.newArrayList("a", "b"), row2, 30.0});
 
     GenericRow row3 = new GenericRow();
     row3.putValue("a", 7.0);
     row3.putValue("b", "8");
-    inputs.add(new Object[]{"divide(a, b)", Lists.newArrayList("a", "b"), row3, 0.875});
+    inputs.add(new Object[]{"a / b", Lists.newArrayList("a", "b"), row3, 0.875});
+
+    GenericRow row4 = new GenericRow();
+    row4.putValue("a", 9);
+    row4.putValue("b", 5);
+    inputs.add(new Object[]{"a % b", Lists.newArrayList("a", "b"), row4, 4.0});
 
     return inputs.toArray(new Object[0][]);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -65,70 +65,71 @@ public class DateTimeFunctionsTest {
     GenericRow row0_0 = new GenericRow();
     row0_0.putValue("timestamp", 1578685189000L);
     // round to 15 minutes, but keep in milliseconds: Fri Jan 10 2020 19:39:49 becomes Fri Jan 10 2020 19:30:00
-    inputs.add(new Object[]{"round(timestamp, 900000)", Lists.newArrayList("timestamp"), row0_0, 1578684600000L});
+    inputs.add(new Object[]{"round(\"timestamp\", 900000)", Lists.newArrayList("timestamp"), row0_0, 1578684600000L});
 
     // toEpochSeconds (with type conversion)
     GenericRow row1_0 = new GenericRow();
     row1_0.putValue("timestamp", 1578685189000.0);
-    inputs.add(new Object[]{"toEpochSeconds(timestamp)", Lists.newArrayList("timestamp"), row1_0, 1578685189L});
+    inputs.add(new Object[]{"toEpochSeconds(\"timestamp\")", Lists.newArrayList("timestamp"), row1_0, 1578685189L});
 
     // toEpochSeconds w/ rounding (with type conversion)
     GenericRow row1_1 = new GenericRow();
     row1_1.putValue("timestamp", "1578685189000");
     inputs.add(
-        new Object[]{"toEpochSecondsRounded(timestamp, 10)", Lists.newArrayList("timestamp"), row1_1, 1578685180L});
+        new Object[]{"toEpochSecondsRounded(\"timestamp\", 10)", Lists.newArrayList("timestamp"), row1_1, 1578685180L});
 
     // toEpochSeconds w/ bucketing (with underscore in function name)
     GenericRow row1_2 = new GenericRow();
     row1_2.putValue("timestamp", 1578685189000L);
-    inputs.add(
-        new Object[]{"to_epoch_seconds_bucket(timestamp, 10)", Lists.newArrayList("timestamp"), row1_2, 157868518L});
+    inputs.add(new Object[]{"to_epoch_seconds_bucket(\"timestamp\", 10)", Lists.newArrayList(
+        "timestamp"), row1_2, 157868518L});
 
     // toEpochMinutes
     GenericRow row2_0 = new GenericRow();
     row2_0.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochMinutes(timestamp)", Lists.newArrayList("timestamp"), row2_0, 26311419L});
+    inputs.add(new Object[]{"toEpochMinutes(\"timestamp\")", Lists.newArrayList("timestamp"), row2_0, 26311419L});
 
     // toEpochMinutes w/ rounding
     GenericRow row2_1 = new GenericRow();
     row2_1.putValue("timestamp", 1578685189000L);
-    inputs
-        .add(new Object[]{"toEpochMinutesRounded(timestamp, 15)", Lists.newArrayList("timestamp"), row2_1, 26311410L});
+    inputs.add(
+        new Object[]{"toEpochMinutesRounded(\"timestamp\", 15)", Lists.newArrayList("timestamp"), row2_1, 26311410L});
 
     // toEpochMinutes w/ bucketing
     GenericRow row2_2 = new GenericRow();
     row2_2.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochMinutesBucket(timestamp, 15)", Lists.newArrayList("timestamp"), row2_2, 1754094L});
+    inputs.add(
+        new Object[]{"toEpochMinutesBucket(\"timestamp\", 15)", Lists.newArrayList("timestamp"), row2_2, 1754094L});
 
     // toEpochHours
     GenericRow row3_0 = new GenericRow();
     row3_0.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochHours(timestamp)", Lists.newArrayList("timestamp"), row3_0, 438523L});
+    inputs.add(new Object[]{"toEpochHours(\"timestamp\")", Lists.newArrayList("timestamp"), row3_0, 438523L});
 
     // toEpochHours w/ rounding
     GenericRow row3_1 = new GenericRow();
     row3_1.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochHoursRounded(timestamp, 2)", Lists.newArrayList("timestamp"), row3_1, 438522L});
+    inputs.add(new Object[]{"toEpochHoursRounded(\"timestamp\", 2)", Lists.newArrayList("timestamp"), row3_1, 438522L});
 
     // toEpochHours w/ bucketing
     GenericRow row3_2 = new GenericRow();
     row3_2.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochHoursBucket(timestamp, 2)", Lists.newArrayList("timestamp"), row3_2, 219261L});
+    inputs.add(new Object[]{"toEpochHoursBucket(\"timestamp\", 2)", Lists.newArrayList("timestamp"), row3_2, 219261L});
 
     // toEpochDays
     GenericRow row4_0 = new GenericRow();
     row4_0.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochDays(timestamp)", Lists.newArrayList("timestamp"), row4_0, 18271L});
+    inputs.add(new Object[]{"toEpochDays(\"timestamp\")", Lists.newArrayList("timestamp"), row4_0, 18271L});
 
     // toEpochDays w/ rounding
     GenericRow row4_1 = new GenericRow();
     row4_1.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochDaysRounded(timestamp, 7)", Lists.newArrayList("timestamp"), row4_1, 18270L});
+    inputs.add(new Object[]{"toEpochDaysRounded(\"timestamp\", 7)", Lists.newArrayList("timestamp"), row4_1, 18270L});
 
     // toEpochDays w/ bucketing
     GenericRow row4_2 = new GenericRow();
     row4_2.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{"toEpochDaysBucket(timestamp, 7)", Lists.newArrayList("timestamp"), row4_2, 2610L});
+    inputs.add(new Object[]{"toEpochDaysBucket(\"timestamp\", 7)", Lists.newArrayList("timestamp"), row4_2, 2610L});
 
     // fromEpochDays
     GenericRow row5_0 = new GenericRow();
@@ -222,7 +223,7 @@ public class DateTimeFunctionsTest {
     // fromDateTime with timezone
     GenericRow row11_2 = new GenericRow();
     row11_2.putValue("dateTime", "Mon Aug 24 12:36:46 America/Los_Angeles 2009");
-    inputs.add(new Object[]{"fromDateTime(dateTime, \"EEE MMM dd HH:mm:ss ZZZ yyyy\")", Lists.newArrayList(
+    inputs.add(new Object[]{"fromDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList(
         "dateTime"), row11_2, 1251142606000L});
 
     // timezone_hour and timezone_minute

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
@@ -155,7 +155,7 @@ public class GeoFunctionTest {
     ProjectionBlock projectionBlock = new ProjectionOperator(dataSourceMap,
         new DocIdSetOperator(new MatchAllFilterOperator(length), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
 
-    ExpressionContext expression = RequestContextUtils.getExpression(function);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(function);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, dataSourceMap);
     evaluator.accept(transformFunction, projectionBlock);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StGeometryTypeFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StGeometryTypeFunctionTest.java
@@ -18,12 +18,13 @@
  */
 package org.apache.pinot.core.geospatial.transform;
 
-import java.util.Arrays;
-import org.apache.pinot.spi.data.FieldSpec;
+import java.util.Collections;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.Test;
 
 
 public class StGeometryTypeFunctionTest extends GeoFunctionTest {
+
   @Test
   public void testGeometryType()
       throws Exception {
@@ -39,10 +40,10 @@ public class StGeometryTypeFunctionTest extends GeoFunctionTest {
   private void assertType(String wkt, String type)
       throws Exception {
     // assert geometry
-    assertStringFunction(String.format("ST_GeometryType(ST_GeomFromText(%s))))", STRING_SV_COLUMN), new String[]{type},
-        Arrays.asList(new GeoFunctionTest.Column(STRING_SV_COLUMN, FieldSpec.DataType.STRING, new String[]{wkt})));
+    assertStringFunction(String.format("ST_GeometryType(ST_GeomFromText(%s))", STRING_SV_COLUMN), new String[]{type},
+        Collections.singletonList(new Column(STRING_SV_COLUMN, DataType.STRING, new String[]{wkt})));
     // assert geography
-    assertStringFunction(String.format("ST_GeometryType(ST_GeogFromText(%s))))", STRING_SV_COLUMN), new String[]{type},
-        Arrays.asList(new GeoFunctionTest.Column(STRING_SV_COLUMN, FieldSpec.DataType.STRING, new String[]{wkt})));
+    assertStringFunction(String.format("ST_GeometryType(ST_GeogFromText(%s))", STRING_SV_COLUMN), new String[]{type},
+        Collections.singletonList(new Column(STRING_SV_COLUMN, DataType.STRING, new String[]{wkt})));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StPointFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/StPointFunctionTest.java
@@ -43,7 +43,7 @@ public class StPointFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testStPointLiteralFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("ST_Point(20,10, 1)"));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL("ST_Point(20,10, 1)");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     byte[][] expectedValues = new byte[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -56,7 +56,7 @@ public class StPointFunctionTest extends BaseTransformFunctionTest {
 
   private void testStPointFunction(int isGeography) {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("ST_Point(%s,%s, %d)", DOUBLE_SV_COLUMN, DOUBLE_SV_COLUMN, isGeography));
+        .getExpressionFromSQL(String.format("ST_Point(%s,%s, %d)", DOUBLE_SV_COLUMN, DOUBLE_SV_COLUMN, isGeography));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof StPointFunction);
     Assert.assertEquals(transformFunction.getName(), StPointFunction.FUNCTION_NAME);
@@ -73,7 +73,7 @@ public class StPointFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -65,8 +65,7 @@ public class CombineSlowOperatorsTest {
   public void testSelectionOnlyCombineOperator() {
     List<Operator> operators = getOperators();
     SelectionOnlyCombineOperator combineOperator = new SelectionOnlyCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM table"),
-        _executorService, TIMEOUT_MS);
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable"), _executorService, TIMEOUT_MS);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -77,7 +76,7 @@ public class CombineSlowOperatorsTest {
   public void testAggregationOnlyCombineOperator() {
     List<Operator> operators = getOperators();
     AggregationOnlyCombineOperator combineOperator = new AggregationOnlyCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT COUNT(*) FROM table"), _executorService,
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable"), _executorService,
         TIMEOUT_MS);
     testCombineOperator(operators, combineOperator);
   }
@@ -86,7 +85,7 @@ public class CombineSlowOperatorsTest {
   public void testGroupByCombineOperator() {
     List<Operator> operators = getOperators();
     GroupByCombineOperator combineOperator = new GroupByCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT COUNT(*) FROM table GROUP BY column"),
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
         _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
     testCombineOperator(operators, combineOperator);
   }
@@ -95,7 +94,7 @@ public class CombineSlowOperatorsTest {
   public void testGroupByOrderByCombineOperator() {
     List<Operator> operators = getOperators();
     GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT COUNT(*) FROM table GROUP BY column"),
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
         _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     testCombineOperator(operators, combineOperator);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -60,7 +60,7 @@ import static org.testng.Assert.assertTrue;
  * Test for {@link SelectionOnlyCombineOperator} and {@link SelectionOrderByCombineOperator}.
  */
 public class SelectionCombineOperatorTest {
-  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "SelectionCombineEarlyTerminationTest");
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "SelectionCombineOperatorTest");
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME_PREFIX = "testSegment_";
 
@@ -223,15 +223,14 @@ public class SelectionCombineOperatorTest {
   }
 
   private IntermediateResultsBlock getCombineResult(String query) {
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
     List<PlanNode> planNodes = new ArrayList<>(NUM_SEGMENTS);
     for (IndexSegment indexSegment : _indexSegments) {
       planNodes.add(PLAN_MAKER.makeSegmentPlanNode(indexSegment, queryContext));
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     return combinePlanNode.run().nextBlock();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
@@ -30,7 +30,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testAdditionTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String
         .format("add(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
             STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -44,7 +44,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String
+    expression = RequestContextUtils.getExpressionFromSQL(String
         .format("add(add(12,%s),%s,add(add(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN,
             LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -58,7 +58,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayBaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayBaseTransformFunctionTest.java
@@ -32,7 +32,7 @@ public abstract class ArrayBaseTransformFunctionTest extends BaseTransformFuncti
   @Test
   public void testArrayTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("%s(%s)", getFunctionName(), INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", getFunctionName(), INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertEquals(transformFunction.getClass().getName(), getArrayFunctionClass().getName());
     Assert.assertEquals(transformFunction.getName(), getFunctionName());
@@ -76,7 +76,7 @@ public abstract class ArrayBaseTransformFunctionTest extends BaseTransformFuncti
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -78,7 +78,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String DOUBLE_MV_COLUMN = "doubleMV";
   protected static final String STRING_MV_COLUMN = "stringMV";
   protected static final String STRING_ALPHANUM_MV_COLUMN = "stringAlphaNumMV";
-  protected static final String TIME_COLUMN = "time";
+  protected static final String TIME_COLUMN = "timeColumn";
   protected static final String JSON_COLUMN = "json";
   protected final int[] _intSVValues = new int[NUM_ROWS];
   protected final long[] _longSVValues = new long[NUM_ROWS];

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -49,7 +49,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
   @Test
   public void testBinaryOperatorTransformFunction() {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("%s(%s, %d)", getFuncName(), INT_SV_COLUMN, _intSVValues[0]));
+        .getExpressionFromSQL(String.format("%s(%s, %d)", getFuncName(), INT_SV_COLUMN, _intSVValues[0]));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertEquals(transformFunction.getName(), getFuncName().toLowerCase());
     int[] expectedIntValues = new int[NUM_ROWS];
@@ -59,7 +59,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     testTransformFunction(transformFunction, expectedIntValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("%s(%s, %d)", getFuncName(), LONG_SV_COLUMN, _longSVValues[0]));
+        .getExpressionFromSQL(String.format("%s(%s, %d)", getFuncName(), LONG_SV_COLUMN, _longSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedLongValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -68,7 +68,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     testTransformFunction(transformFunction, expectedLongValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("%s(%s, %f)", getFuncName(), FLOAT_SV_COLUMN, _floatSVValues[0]));
+        .getExpressionFromSQL(String.format("%s(%s, %f)", getFuncName(), FLOAT_SV_COLUMN, _floatSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedFloatValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -77,7 +77,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     testTransformFunction(transformFunction, expectedFloatValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("%s(%s, %.20f)", getFuncName(), DOUBLE_SV_COLUMN, _doubleSVValues[0]));
+        .getExpressionFromSQL(String.format("%s(%s, %.20f)", getFuncName(), DOUBLE_SV_COLUMN, _doubleSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedDoubleValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -86,7 +86,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
     testTransformFunction(transformFunction, expectedDoubleValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("%s(%s, '%s')", getFuncName(), STRING_SV_COLUMN, _stringSVValues[0]));
+        .getExpressionFromSQL(String.format("%s(%s, '%s')", getFuncName(), STRING_SV_COLUMN, _stringSVValues[0]));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedStringValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -97,7 +97,7 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -22,9 +22,7 @@ import java.util.Random;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
-import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -94,7 +92,7 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   private void testCaseQueryWithIntResults(String predicate, int[] expectedValues) {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE(%s, 100, 10)", predicate));
+        RequestContextUtils.getExpressionFromSQL(String.format("CASE WHEN %s THEN 100 ELSE 10 END", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
@@ -103,7 +101,7 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   private void testCaseQueryWithDoubleResults(String predicate, double[] expectedValues) {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE(%s, 100.0, 10.0)", predicate));
+        RequestContextUtils.getExpressionFromSQL(String.format("CASE WHEN %s THEN 100.0 ELSE 10.0 END", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
@@ -112,23 +110,11 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   private void testCaseQueryWithStringResults(String predicate, String[] expectedValues) {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE(%s, 'aaa', 'bbb')", predicate));
+        RequestContextUtils.getExpressionFromSQL(String.format("CASE WHEN %s THEN 'aaa' ELSE 'bbb' END", predicate));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
     testTransformFunction(transformFunction, expectedValues);
-  }
-
-  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
-  public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
-    TransformFunctionFactory.get(expression, _dataSourceMap);
-  }
-
-  @DataProvider(name = "testIllegalArguments")
-  public Object[][] testIllegalArguments() {
-    return new Object[][]{new Object[]{String.format("case(%s)", INT_SV_COLUMN)}, new Object[]{String.format(
-        "case(%s, %s)", LONG_SV_COLUMN, 10)}};
   }
 
   private int[] getExpectedIntResults(String column, TransformFunctionType type) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -20,9 +20,7 @@ package org.apache.pinot.core.operator.transform.function;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
-import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -31,7 +29,7 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
   @Test
   public void testCastTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("cast(%s,%s)", INT_SV_COLUMN, "'String'"));
+        RequestContextUtils.getExpressionFromSQL(String.format("CAST(%s AS string)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CastTransformFunction.FUNCTION_NAME);
@@ -41,8 +39,8 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(
-        String.format("cast(add(cast(%s, 'STRING'), %s), 'string')", STRING_SV_COLUMN, DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("CAST(ADD(CAST(%s AS INT), %s) AS STRING)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,8 +48,8 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(
-        String.format("cast(cast(add(cast(%s, 'STRING'), %s), 'string'), 'double')", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("caSt(cAst(casT(%s as inT) + %s aS sTring) As DouBle)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     double[] expectedDoubleValues = new double[NUM_ROWS];
@@ -59,17 +57,5 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
       expectedDoubleValues[i] = Double.parseDouble(_stringSVValues[i]) + _intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedDoubleValues);
-  }
-
-  @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
-  public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
-    TransformFunctionFactory.get(expression, _dataSourceMap);
-  }
-
-  @DataProvider(name = "testIllegalArguments")
-  public Object[][] testIllegalArguments() {
-    return new Object[][]{new Object[]{String.format("cast(%s)", INT_SV_COLUMN)}, new Object[]{String.format(
-        "cast(%s, %s, %s)", LONG_SV_COLUMN, "'STRING'", "'STRING'")}};
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
@@ -32,7 +32,7 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
   @Test
   public void testDateTimeConversionTransformFunction() {
     // NOTE: functionality of DateTimeConverter is covered in DateTimeConverterTest
-    ExpressionContext expression = RequestContextUtils.getExpression(
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
         String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','1:MINUTES')", TIME_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DateTimeConversionTransformFunction);
@@ -54,7 +54,7 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -110,8 +110,8 @@ public class DateTruncTransformFunctionTest {
       ProjectionBlock projectionBlock = new ProjectionOperator(dataSourceMap,
           new DocIdSetOperator(new MatchAllFilterOperator(rows.size()), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
 
-      ExpressionContext expression = RequestContextUtils.getExpression(
-          String.format("dateTrunc('%s', %s, '%s', '%s')", unit, TIME_COLUMN, TimeUnit.MILLISECONDS, tz));
+      ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+          String.format("dateTrunc('%s', \"%s\", '%s', '%s')", unit, TIME_COLUMN, TimeUnit.MILLISECONDS, tz));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, dataSourceMap);
       Assert.assertTrue(transformFunction instanceof DateTruncTransformFunction);
       Assert.assertEquals(transformFunction.getName(), DateTruncTransformFunction.FUNCTION_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
@@ -31,7 +31,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
   @Test
   public void testDivisionTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("div(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("div(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), DivisionTransformFunction.FUNCTION_NAME);
@@ -41,7 +41,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("div(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("div(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("div(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("div(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -59,7 +59,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("div(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,7 +67,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("div(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("div(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -75,7 +75,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String
+    expression = RequestContextUtils.getExpressionFromSQL(String
         .format("div(div(div(div(div(12,%s),%s),div(div(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -90,7 +90,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunctionTest.java
@@ -154,7 +154,7 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
   @Test(dataProvider = "groovyFunctionDataProvider")
   public void testGroovyTransformFunctions(String expressionStr, FieldSpec.DataType resultType,
       boolean isResultSingleValue, Object expectedResult) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof GroovyTransformFunction);
     Assert.assertEquals(transformFunction.getName(), GroovyTransformFunction.FUNCTION_NAME);
@@ -245,7 +245,7 @@ public class GroovyTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Random;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
-import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -40,7 +39,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test(dataProvider = "testJsonPathTransformFunctionArguments")
   public void testJsonPathTransformFunction(String expressionStr, FieldSpec.DataType resultsDataType,
       boolean isSingleValue) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -102,7 +101,20 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @DataProvider(name = "testJsonPathTransformFunctionArguments")
   public Object[][] testJsonPathTransformFunctionArguments() {
     //@formatter:off
-    return new Object[][]{new Object[]{"jsonExtractScalar(json,'$.intSV','INT')", FieldSpec.DataType.INT, true}, new Object[]{"jsonExtractScalar(json,'$.intMV','INT_ARRAY')", FieldSpec.DataType.INT, false}, new Object[]{"jsonExtractScalar(json,'$.longSV','LONG')", FieldSpec.DataType.LONG, true}, new Object[]{"jsonExtractScalar(json,'$.floatSV','FLOAT')", FieldSpec.DataType.FLOAT, true}, new Object[]{"jsonExtractScalar(json,'$.doubleSV','DOUBLE')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"jsonExtractScalar(json,'$.stringSV','STRING')", FieldSpec.DataType.STRING, true}, new Object[]{"json_extract_scalar(json,'$.intSV','INT', '0')", FieldSpec.DataType.INT, true}, new Object[]{"json_extract_scalar(json,'$.intMV','INT_ARRAY', ['0'])", FieldSpec.DataType.INT, false}, new Object[]{"json_extract_scalar(json,'$.longSV','LONG', '0')", FieldSpec.DataType.LONG, true}, new Object[]{"json_extract_scalar(json,'$.floatSV','FLOAT', '0.0')", FieldSpec.DataType.FLOAT, true}, new Object[]{"json_extract_scalar(json,'$.doubleSV','DOUBLE', '0.0')", FieldSpec.DataType.DOUBLE, true}, new Object[]{"json_extract_scalar(json,'$.stringSV','STRING', 'null')", FieldSpec.DataType.STRING, true}};
+    return new Object[][]{
+        new Object[]{"jsonExtractScalar(json,'$.intSV','INT')", FieldSpec.DataType.INT, true},
+        new Object[]{"jsonExtractScalar(json,'$.intMV','INT_ARRAY')", FieldSpec.DataType.INT, false},
+        new Object[]{"jsonExtractScalar(json,'$.longSV','LONG')", FieldSpec.DataType.LONG, true},
+        new Object[]{"jsonExtractScalar(json,'$.floatSV','FLOAT')", FieldSpec.DataType.FLOAT, true},
+        new Object[]{"jsonExtractScalar(json,'$.doubleSV','DOUBLE')", FieldSpec.DataType.DOUBLE, true},
+        new Object[]{"jsonExtractScalar(json,'$.stringSV','STRING')", FieldSpec.DataType.STRING, true},
+        new Object[]{"json_extract_scalar(json,'$.intSV','INT', '0')", FieldSpec.DataType.INT, true},
+        new Object[]{"json_extract_scalar(json,'$.intMV','INT_ARRAY', '0')", FieldSpec.DataType.INT, false},
+        new Object[]{"json_extract_scalar(json,'$.longSV','LONG', '0')", FieldSpec.DataType.LONG, true},
+        new Object[]{"json_extract_scalar(json,'$.floatSV','FLOAT', '0.0')", FieldSpec.DataType.FLOAT, true},
+        new Object[]{"json_extract_scalar(json,'$.doubleSV','DOUBLE', '0.0')", FieldSpec.DataType.DOUBLE, true},
+        new Object[]{"json_extract_scalar(json,'$.stringSV','STRING', 'null')", FieldSpec.DataType.STRING, true}
+    };
     //@formatter:on
   }
 
@@ -110,7 +122,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   public void testJsonPathTransformFunctionWithPredicate() {
     String jsonPathExpressionStr =
         String.format("jsonExtractScalar(json,'[?($.stringSV==''%s'')]','STRING')", _stringSVValues[0]);
-    ExpressionContext expression = RequestContextUtils.getExpression(jsonPathExpressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(jsonPathExpressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -140,7 +152,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathTransformFunctionForIntMV() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression("jsonExtractScalar(json,'$.intMV','INT_ARRAY')");
+        RequestContextUtils.getExpressionFromSQL("jsonExtractScalar(json,'$.intMV','INT_ARRAY')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -156,7 +168,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathTransformFunctionForLong() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression("jsonExtractScalar(json,'$.longSV','LONG')");
+        RequestContextUtils.getExpressionFromSQL("jsonExtractScalar(json,'$.longSV','LONG')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -169,7 +181,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathTransformFunctionForFloat() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression("jsonExtractScalar(json,'$.floatSV','FLOAT')");
+        RequestContextUtils.getExpressionFromSQL("jsonExtractScalar(json,'$.floatSV','FLOAT')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -182,7 +194,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathTransformFunctionForDouble() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression("jsonExtractScalar(json,'$.doubleSV','DOUBLE')");
+        RequestContextUtils.getExpressionFromSQL("jsonExtractScalar(json,'$.doubleSV','DOUBLE')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -195,7 +207,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathTransformFunctionForString() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression("jsonExtractScalar(json,'$.stringSV','STRING')");
+        RequestContextUtils.getExpressionFromSQL("jsonExtractScalar(json,'$.stringSV','STRING')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractScalarTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractScalarTransformFunction.FUNCTION_NAME);
@@ -208,8 +220,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   @Test
   public void testJsonPathKeyTransformFunction() {
     ExpressionContext expression = (new Random(System.currentTimeMillis()).nextBoolean()) ? RequestContextUtils
-        .getExpression("jsonExtractKey(json,'$.*')")
-        : RequestContextUtils.getExpression("json_extract_key(json,'$.*')");
+        .getExpressionFromSQL("jsonExtractKey(json,'$.*')")
+        : RequestContextUtils.getExpressionFromSQL("json_extract_key(json,'$.*')");
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof JsonExtractKeyTransformFunction);
     Assert.assertEquals(transformFunction.getName(), JsonExtractKeyTransformFunction.FUNCTION_NAME);
@@ -228,35 +240,39 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
   @Test(dataProvider = "testParsingIllegalQueries", expectedExceptions = {SqlCompilationException.class})
   public void testParsingIllegalQueries(String expressionStr) {
-    QueryContextConverterUtils.getQueryContextFromSQL(String.format("SELECT %s FROM myTable", expressionStr));
+    RequestContextUtils.getExpressionFromSQL(expressionStr);
   }
 
   @DataProvider(name = "testIllegalArguments")
   public Object[][] testIllegalArguments() {
     //@formatter:off
-    return new Object[][]{new Object[]{String.format("jsonExtractScalar(%s)",
-        JSON_COLUMN)}, new Object[]{"jsonExtractScalar(5,'$.store.book[0].author','$.store.book[0].author')"}, new Object[]{String.format(
-        "jsonExtractScalar(%s,'$.store.book[0].author')", INT_MV_COLUMN)}, new Object[]{String.format(
-        "jsonExtractScalar(%s,'$.store.book[0].author')", STRING_SV_COLUMN)}, new Object[]{String.format(
-        "jsonExtractScalar(%s,'$.store.book[0].author', 'STRINGARRAY')", STRING_SV_COLUMN)}, new Object[]{String.format(
-        "jsonExtractScalar(%s,%s,'$.store.book[0].author', 'String','abc')", JSON_COLUMN, INT_SV_COLUMN)}};
+    return new Object[][]{
+        new Object[]{"jsonExtractScalar(5,'$.store.book[0].author','$.store.book[0].author')"},
+        new Object[]{String.format("jsonExtractScalar(%s,'$.store.book[0].author','$.store.book[0].author')", INT_SV_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s,'$.store.book[0].author','$.store.book[0].author')", INT_MV_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s,'$.store.book[0].author', 'STRINGARRAY')", STRING_SV_COLUMN)}
+    };
     //@formatter:on
   }
 
   @DataProvider(name = "testParsingIllegalQueries")
   public Object[][] testParsingIllegalQueries() {
     //@formatter:off
-    return new Object[][]{new Object[]{String.format("jsonExtractScalar(%s, \"$.store.book[0].author\", 'String')",
-        JSON_COLUMN)}, new Object[]{String.format("jsonExtractScalar(%s, '$.store.book[0].author', \"String\")",
-        JSON_COLUMN)}, new Object[]{String.format("json_extract_scalar(%s, \"$.store.book[0].author\", 'String','abc')",
-        JSON_COLUMN)}, new Object[]{String.format("jsonExtractKey(%s, \"$.*\")",
-        JSON_COLUMN)}, new Object[]{String.format("json_extract_key(%s, \"$.*\")", JSON_COLUMN)}};
+    return new Object[][]{
+        new Object[]{String.format("jsonExtractScalar(%s)", JSON_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s,'$.store.book[0].author')", JSON_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s,%s,'$.store.book[0].author', 'String','abc')", JSON_COLUMN, INT_SV_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s, \"$.store.book[0].author\", 'String')", JSON_COLUMN)},
+        new Object[]{String.format("jsonExtractScalar(%s, '$.store.book[0].author', \"String\")", JSON_COLUMN)},
+        new Object[]{String.format("json_extract_scalar(%s, \"$.store.book[0].author\", 'String','abc')", JSON_COLUMN)},
+        new Object[]{String.format("jsonExtractKey(%s, \"$.*\")", JSON_COLUMN)},
+        new Object[]{String.format("json_extract_key(%s, \"$.*\")", JSON_COLUMN)}};
     //@formatter:on
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunctionTest.java
@@ -45,9 +45,9 @@ public abstract class LogicalOperatorTransformFunctionTest extends BaseTransform
   @Test
   public void testLogicalOperatorTransformFunction() {
     ExpressionContext intEqualsExpr =
-        RequestContextUtils.getExpression(String.format("EQUALS(%s, %d)", INT_SV_COLUMN, _intSVValues[0]));
+        RequestContextUtils.getExpressionFromSQL(String.format("EQUALS(%s, %d)", INT_SV_COLUMN, _intSVValues[0]));
     ExpressionContext longEqualsExpr =
-        RequestContextUtils.getExpression(String.format("EQUALS(%s, %d)", LONG_SV_COLUMN, _longSVValues[0]));
+        RequestContextUtils.getExpressionFromSQL(String.format("EQUALS(%s, %d)", LONG_SV_COLUMN, _longSVValues[0]));
     ExpressionContext expression = ExpressionContext.forFunction(
         new FunctionContext(FunctionContext.Type.TRANSFORM, getFuncName(),
             Arrays.asList(intEqualsExpr, longEqualsExpr)));
@@ -64,7 +64,7 @@ public abstract class LogicalOperatorTransformFunctionTest extends BaseTransform
   public void testIllegalArguments(String[] expressions) {
     List<ExpressionContext> expressionContextList = new ArrayList<>();
     for (int i = 0; i < expressions.length; i++) {
-      expressionContextList.add(RequestContextUtils.getExpression(expressions[i]));
+      expressionContextList.add(RequestContextUtils.getExpressionFromSQL(expressions[i]));
     }
     TransformFunctionFactory.get(ExpressionContext
             .forFunction(new FunctionContext(FunctionContext.Type.TRANSFORM, getFuncName(), expressionContextList)),

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -111,7 +111,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
       throws Exception {
     // Success case
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LookupTransformFunction);
     Assert.assertEquals(transformFunction.getName(), LookupTransformFunction.FUNCTION_NAME);
@@ -119,13 +119,13 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Wrong number of arguments
     Assert.assertThrows(BadQueryRequestException.class, () -> {
       TransformFunctionFactory
-          .get(RequestContextUtils.getExpression(String.format("lookup('baseballTeams','teamName','teamID')")),
+          .get(RequestContextUtils.getExpressionFromSQL(String.format("lookup('baseballTeams','teamName','teamID')")),
               _dataSourceMap);
     });
 
     // Wrong number of join keys
     Assert.assertThrows(BadQueryRequestException.class, () -> {
-      TransformFunctionFactory.get(RequestContextUtils.getExpression(
+      TransformFunctionFactory.get(RequestContextUtils.getExpressionFromSQL(
           String.format("lookup('baseballTeams','teamName','teamID', %s, 'danglingKey')", STRING_SV_COLUMN)),
           _dataSourceMap);
     });
@@ -133,22 +133,20 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Non literal tableName argument
     Assert.assertThrows(BadQueryRequestException.class, () -> {
       TransformFunctionFactory.get(RequestContextUtils
-              .getExpression(String.format("lookup(%s,'teamName','teamID', %s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
+              .getExpressionFromSQL(String.format("lookup(%s,'teamName','teamID', %s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
           _dataSourceMap);
     });
 
     // Non literal lookup columnName argument
     Assert.assertThrows(BadQueryRequestException.class, () -> {
-      TransformFunctionFactory.get(RequestContextUtils
-              .getExpression(String.format("lookup('baseballTeams',%s,'teamID',%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
-          _dataSourceMap);
+      TransformFunctionFactory.get(RequestContextUtils.getExpressionFromSQL(
+          String.format("lookup('baseballTeams',%s,'teamID',%s)", STRING_SV_COLUMN, INT_SV_COLUMN)), _dataSourceMap);
     });
 
     // Non literal lookup columnName argument
     Assert.assertThrows(BadQueryRequestException.class, () -> {
-      TransformFunctionFactory.get(RequestContextUtils
-              .getExpression(String.format("lookup('baseballTeams','teamName',%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN)),
-          _dataSourceMap);
+      TransformFunctionFactory.get(RequestContextUtils.getExpressionFromSQL(
+          String.format("lookup('baseballTeams','teamName',%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN)), _dataSourceMap);
     });
   }
 
@@ -164,7 +162,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     }};
 
     for (Map.Entry<String, FieldSpec.DataType> testCase : testCases.entrySet()) {
-      ExpressionContext expression = RequestContextUtils.getExpression(
+      ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
           String.format("lookup('baseballTeams','%s','teamID',%s)", testCase.getKey(), STRING_SV_COLUMN));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), testCase.getValue(),
@@ -178,7 +176,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: StringSV
     // PK: [String]
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamName','teamID',%s)", STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     String[] expectedStringValues = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -189,7 +187,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: IntSV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamInteger','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamInteger','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[] expectedIntValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -200,7 +198,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: DoubleSV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamDouble','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamDouble','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     double[] expectedDoubleValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -211,7 +209,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: BytesSV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamBytes','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamBytes','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     byte[][] expectedBytesValues = new byte[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -226,7 +224,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: StringMV
     // PK: [String]
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamName_MV','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamName_MV','teamID',%s)", STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     String[][] expectedStringMVValues = new String[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -239,7 +237,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: IntegerMV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamInteger_MV','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamInteger_MV','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     int[][] expectedIntegerMVValues = new int[NUM_ROWS][0];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -252,7 +250,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: FloatMV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamFloat_MV','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamFloat_MV','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     float[][] expectedFloatMVValues = new float[NUM_ROWS][0];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -265,7 +263,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: LongMV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamLong_MV','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamLong_MV','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     long[][] expectedLongMVValues = new long[NUM_ROWS][0];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -278,7 +276,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     // Lookup col: DoubleMV
     // PK: [String]
     expression = RequestContextUtils
-        .getExpression(String.format("lookup('baseballTeams','teamDouble_MV','teamID',%s)", STRING_SV_COLUMN));
+        .getExpressionFromSQL(String.format("lookup('baseballTeams','teamDouble_MV','teamID',%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     double[][] expectedDoubleMVValues = new double[NUM_ROWS][0];
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -318,7 +316,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     }
 
     // PK: [Int]
-    ExpressionContext expression = RequestContextUtils.getExpression(
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithIntPK', 'lookupColumn', 'primaryColumn', %s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     String[] expectedResults = new String[NUM_ROWS];
@@ -329,7 +327,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedResults);
 
     // PK: [String]
-    expression = RequestContextUtils.getExpression(
+    expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithStringPK', 'lookupColumn', 'primaryColumn', %s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
@@ -340,7 +338,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedResults);
 
     // PK: [Long]
-    expression = RequestContextUtils.getExpression(
+    expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithLongPK', 'lookupColumn', 'primaryColumn', %s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
@@ -351,7 +349,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedResults);
 
     // PK: [Float]
-    expression = RequestContextUtils.getExpression(
+    expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithFloatPK', 'lookupColumn', 'primaryColumn', %s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
@@ -362,7 +360,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedResults);
 
     // PK: [Double]
-    expression = RequestContextUtils.getExpression(
+    expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithDoublePK', 'lookupColumn', 'primaryColumn', %s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];
@@ -373,7 +371,7 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedResults);
 
     // PK: [Byte[]]
-    expression = RequestContextUtils.getExpression(
+    expression = RequestContextUtils.getExpressionFromSQL(
         String.format("lookup('dimTableWithBytesPK', 'lookupColumn', 'primaryColumn', %s)", BYTES_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     expectedResults = new String[NUM_ROWS];

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
@@ -31,7 +31,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
   @Test
   public void testModuloTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("mod(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("mod(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ModuloTransformFunction.FUNCTION_NAME);
@@ -41,7 +41,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("mod(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("mod(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("mod(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("mod(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -59,7 +59,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("mod(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("mod(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,7 +67,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("mod(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("mod(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -75,7 +75,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String
+    expression = RequestContextUtils.getExpressionFromSQL(String
         .format("mod(mod(mod(mod(mod(12,%s),%s),mod(mod(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -90,7 +90,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
@@ -30,7 +30,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test
   public void testMultiplicationTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String
         .format("mult(%s,%s,%s,%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN, FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN,
             STRING_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -44,7 +44,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String
+    expression = RequestContextUtils.getExpressionFromSQL(String
         .format("mult(mult(12,%s),%s,mult(mult(%s,%s),0.34,%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -58,7 +58,7 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -42,7 +42,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringLowerTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("lower(%s)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("lower(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "lower");
@@ -56,7 +56,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringUpperTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("UPPER(%s)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("UPPER(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "upper");
@@ -70,7 +70,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringReverseTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("rEvErSe(%s)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("rEvErSe(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "reverse");
@@ -84,7 +84,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringSubStrTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("sub_str(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sub_str(%s, 0, 2)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "substr");
@@ -95,7 +95,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("substr(%s, '2', '-1')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("substr(%s, '2', '-1')", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "substr");
@@ -108,8 +108,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringConcatTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("concat(%s, %s, '-')", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("concat(%s, %s, '-')", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "concat");
@@ -123,7 +123,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringReplaceTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("replace(%s, 'A', 'B')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("replace(%s, 'A', 'B')", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "replace");
@@ -139,7 +139,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     int padLength = 50;
     String padString = "#";
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+        .getExpressionFromSQL(String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "lpad");
@@ -150,7 +150,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+        .getExpressionFromSQL(String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "rpad");
@@ -164,21 +164,28 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringTrimTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("ltrim(lpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("ltrim(lpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "ltrim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("rtrim(rpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("rtrim(rpad(%s, 50, ' '))", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "rtrim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
 
     expression = RequestContextUtils
-        .getExpression(String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
+        .getExpressionFromSQL(String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "trim");
+    testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("trim(leading ' _&|' from lpad(%s, 10, '& |_'))", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "trim");
@@ -187,7 +194,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testShaTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("sha(%s)", BYTES_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("sha(%s)", BYTES_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "sha");
@@ -201,7 +208,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testSha256TransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("sha256(%s)", BYTES_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sha256(%s)", BYTES_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "sha256");
@@ -215,7 +222,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testSha512TransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("sha512(%s)", BYTES_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sha512(%s)", BYTES_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "sha512");
@@ -228,7 +235,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testMd5TransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("md5(%s)", BYTES_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("md5(%s)", BYTES_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "md5");
@@ -242,7 +249,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringContainsTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("contains(%s, 'a')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("contains(%s, 'a')", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "contains");
@@ -256,7 +263,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringSplitTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("split(%s, ',')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("split(%s, ',')", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "split");
@@ -269,8 +276,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testStringHammingDistanceTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("hamming_distance(%s, %s)", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("hamming_distance(%s, %s)", STRING_ALPHANUM_SV_COLUMN, STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "hammingDistance");
@@ -290,7 +297,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringToUTFTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("to_utf8(%s)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("to_utf8(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "toUtf8");
@@ -304,7 +311,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringStrPositionTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("str_pos(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("str_pos(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "strpos");
@@ -315,7 +322,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("str_r_pos(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("str_r_pos(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "strrpos");
@@ -326,7 +333,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("str_r_pos(%s, 'A', 1)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("str_r_pos(%s, 'A', 1)", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "strrpos");
@@ -340,7 +347,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testStringNormalizeTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("normalize(%s)", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("normalize(%s)", STRING_ALPHANUM_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "normalize");
@@ -351,7 +358,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("normalize(%s, 'NFC')", STRING_ALPHANUM_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("normalize(%s, 'NFC')", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "normalize");
@@ -367,7 +374,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   public void testArrayReverseIntTransformFunction() {
     {
       ExpressionContext expression =
-          RequestContextUtils.getExpression(String.format("array_reverse_int(%s)", INT_MV_COLUMN));
+          RequestContextUtils.getExpressionFromSQL(String.format("array_reverse_int(%s)", INT_MV_COLUMN));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
       assertEquals(transformFunction.getName(), "arrayReverseInt");
@@ -382,7 +389,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     {
       ExpressionContext expression =
-          RequestContextUtils.getExpression(String.format("array_reverse_int(%s)", LONG_MV_COLUMN));
+          RequestContextUtils.getExpressionFromSQL(String.format("array_reverse_int(%s)", LONG_MV_COLUMN));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
       assertEquals(transformFunction.getName(), "arrayReverseInt");
@@ -402,7 +409,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   public void testArrayReverseStringTransformFunction() {
     {
       ExpressionContext expression =
-          RequestContextUtils.getExpression(String.format("array_reverse_string(%s)", STRING_MV_COLUMN));
+          RequestContextUtils.getExpressionFromSQL(String.format("array_reverse_string(%s)", STRING_MV_COLUMN));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
       assertEquals(transformFunction.getName(), "arrayReverseString");
@@ -417,7 +424,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     {
       ExpressionContext expression =
-          RequestContextUtils.getExpression(String.format("array_reverse_string(%s)", INT_MV_COLUMN));
+          RequestContextUtils.getExpressionFromSQL(String.format("array_reverse_string(%s)", INT_MV_COLUMN));
       TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
       assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
       assertEquals(transformFunction.getName(), "arrayReverseString");
@@ -436,7 +443,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArraySortIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_sort_int(%s)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_sort_int(%s)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arraySortInt");
@@ -453,7 +460,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArraySortStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_sort_string(%s)", STRING_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_sort_string(%s)", STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arraySortString");
@@ -470,7 +477,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayIndexOfIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_index_of_int(%s, 2)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_index_of_int(%s, 2)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayIndexOfInt");
@@ -486,7 +493,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayIndexOfStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_index_of_string(%s, 'a')", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_index_of_string(%s, 'a')", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayIndexOfString");
@@ -502,7 +509,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayContainsIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_contains_int(%s, 2)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_contains_int(%s, 2)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayContainsInt");
@@ -518,7 +525,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayContainsStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_contains_string(%s, 'a')", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_contains_string(%s, 'a')", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayContainsString");
@@ -534,7 +541,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArraySliceIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_slice_int(%s, 1, 3)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_slice_int(%s, 1, 3)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arraySliceInt");
@@ -551,7 +558,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArraySliceStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_slice_string(%s, 1, 2)", STRING_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_slice_string(%s, 1, 2)", STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arraySliceString");
@@ -568,7 +575,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayDistinctIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_distinct_int(%s)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_distinct_int(%s)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayDistinctInt");
@@ -584,7 +591,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayDistinctStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_distinct_string(%s)", STRING_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_distinct_string(%s)", STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayDistinctString");
@@ -600,7 +607,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayRemoveIntTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_remove_int(%s, 2)", INT_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_remove_int(%s, 2)", INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayRemoveInt");
@@ -617,7 +624,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayRemoveStringTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("array_remove_string(%s, 2)", STRING_MV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("array_remove_string(%s, 2)", STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayRemoveString");
@@ -634,7 +641,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayUnionIntTransformFunction() {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+        .getExpressionFromSQL(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionInt");
@@ -650,7 +657,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testUnionStringTransformFunction() {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+        .getExpressionFromSQL(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionString");
@@ -666,7 +673,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testArrayConcatIntTransformFunction() {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+        .getExpressionFromSQL(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatInt");
@@ -683,7 +690,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   @Test
   public void testConcatStringTransformFunction() {
     ExpressionContext expression = RequestContextUtils
-        .getExpression(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+        .getExpressionFromSQL(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatString");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -34,7 +34,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testAbsTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("abs(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("abs(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     Assert.assertEquals(transformFunction.getName(), AbsTransformFunction.FUNCTION_NAME);
@@ -44,7 +44,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("abs(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("abs(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -52,7 +52,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("abs(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("abs(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -60,7 +60,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("abs(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("abs(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -68,7 +68,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("abs(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("abs(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -79,7 +79,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testCeilTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("ceil(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("ceil(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     Assert.assertEquals(transformFunction.getName(), CeilTransformFunction.FUNCTION_NAME);
@@ -89,7 +89,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ceil(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ceil(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -97,7 +97,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ceil(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ceil(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -105,7 +105,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ceil(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ceil(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -113,7 +113,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ceil(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ceil(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -124,7 +124,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testExpTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("exp(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("exp(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ExpTransformFunction.FUNCTION_NAME);
@@ -134,7 +134,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("exp(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("exp(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -142,7 +142,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("exp(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("exp(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -150,7 +150,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("exp(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("exp(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -158,7 +158,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("exp(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("exp(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ExpTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -169,7 +169,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testFloorTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("floor(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("floor(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     Assert.assertEquals(transformFunction.getName(), FloorTransformFunction.FUNCTION_NAME);
@@ -179,7 +179,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("floor(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("floor(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -187,7 +187,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("floor(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("floor(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -195,7 +195,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("floor(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("floor(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -203,7 +203,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("floor(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("floor(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -214,7 +214,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testLnTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("ln(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("ln(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     Assert.assertEquals(transformFunction.getName(), LnTransformFunction.FUNCTION_NAME);
@@ -224,7 +224,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ln(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ln(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -232,7 +232,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ln(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ln(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -240,7 +240,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ln(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ln(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -248,7 +248,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("ln(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("ln(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -259,7 +259,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
 
   @Test
   public void testSqrtTransformFunction() {
-    ExpressionContext expression = RequestContextUtils.getExpression(String.format("sqrt(%s)", INT_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("sqrt(%s)", INT_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     Assert.assertEquals(transformFunction.getName(), SqrtTransformFunction.FUNCTION_NAME);
@@ -269,7 +269,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sqrt(%s)", LONG_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sqrt(%s)", LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -277,7 +277,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sqrt(%s)", FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sqrt(%s)", FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -285,7 +285,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sqrt(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sqrt(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -293,7 +293,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sqrt(%s)", STRING_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sqrt(%s)", STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
@@ -31,7 +31,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
   @Test
   public void testSubtractionTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("sub(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sub(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), SubtractionTransformFunction.FUNCTION_NAME);
@@ -41,7 +41,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sub(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sub(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -50,7 +50,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("sub(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sub(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -59,7 +59,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     testTransformFunction(transformFunction, expectedValues);
 
     expression =
-        RequestContextUtils.getExpression(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("sub(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -67,7 +67,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String.format("sub(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sub(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
@@ -75,7 +75,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpression(String
+    expression = RequestContextUtils.getExpressionFromSQL(String
         .format("sub(sub(sub(sub(sub(12,%s),%s),sub(sub(%s,%s),0.34)),%s),%s)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN,
             FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
@@ -90,7 +90,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunctionTest.java
@@ -31,7 +31,7 @@ public class TimeConversionTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test(dataProvider = "testTimeConversionTransformFunction")
   public void testTimeConversionTransformFunction(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof TimeConversionTransformFunction);
     Assert.assertEquals(transformFunction.getName(), TimeConversionTransformFunction.FUNCTION_NAME);
@@ -60,7 +60,7 @@ public class TimeConversionTransformFunctionTest extends BaseTransformFunctionTe
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
@@ -33,7 +33,7 @@ public class ValueInTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testValueInTransformFunction")
   public void testValueInTransformFunction(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ValueInTransformFunction);
     Assert.assertEquals(transformFunction.getName(), ValueInTransformFunction.FUNCTION_NAME);
@@ -76,7 +76,7 @@ public class ValueInTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})
   public void testIllegalArguments(String expressionStr) {
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(expressionStr);
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -35,7 +35,8 @@ import org.testng.annotations.Test;
 
 
 public class CombinePlanNodeTest {
-  private final QueryContext _queryContext = QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM table");
+  private final QueryContext _queryContext =
+      QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable");
   private final ExecutorService _executorService = Executors.newFixedThreadPool(10);
 
   /**
@@ -107,8 +108,7 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -141,7 +141,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @Test(dataProvider = "testPlanMakerDataProvider")
   public void testPlanMaker(String query, Class<? extends PlanNode> planNodeClass,
       Class<? extends PlanNode> upsertPlanNodeClass) {
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
     PlanNode planNode = PLAN_MAKER.makeSegmentPlanNode(_indexSegment, queryContext);
     assertTrue(planNodeClass.isInstance(planNode));
     PlanNode upsertPlanNode = PLAN_MAKER.makeSegmentPlanNode(_upsertIndexSegment, queryContext);
@@ -186,7 +186,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @Test(dataProvider = "isFitForPlanDataProvider")
   public void testIsFitFor(String query, IndexSegment indexSegment, boolean expectedIsFitForMetadata,
       boolean expectedIsFitForDictionary) {
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
     assertEquals(InstancePlanMakerImplV2.isFitForMetadataBasedPlan(queryContext), expectedIsFitForMetadata);
     assertEquals(InstancePlanMakerImplV2.isFitForDictionaryBasedPlan(queryContext, indexSegment),
         expectedIsFitForDictionary);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -111,7 +111,7 @@ public class DefaultAggregationExecutorTest {
       }
     }
     queryBuilder.append(" FROM testTable");
-    _queryContext = QueryContextConverterUtils.getQueryContextFromPQL(queryBuilder.toString());
+    _queryContext = QueryContextConverterUtils.getQueryContextFromSQL(queryBuilder.toString());
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.assertTrue;
 public class AggregationFunctionFactoryTest {
   private static final String ARGUMENT = "(column)";
   private static final QueryContext DUMMY_QUERY_CONTEXT =
-      QueryContextConverterUtils.getQueryContextFromPQL("SELECT * FROM testTable");
+      QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable");
 
   @Test
   public void testGetAggregationFunction() {
@@ -317,13 +317,13 @@ public class AggregationFunctionFactoryTest {
   }
 
   private FunctionContext getFunction(String functionName, String args) {
-    return RequestContextUtils.getExpression(functionName + args).getFunction();
+    return RequestContextUtils.getExpressionFromSQL(functionName + args).getFunction();
   }
 
   @Test
   public void testAggregationFunctionWithMultipleArgs() {
     QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContextFromPQL("SELECT distinct(column1, column2, column3) FROM testTable");
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT DISTINCT column1, column2, column3 FROM testTable");
     AggregationFunction aggregationFunction = AggregationFunctionFactory
         .getAggregationFunction(queryContext.getSelectExpressions().get(0).getFunction(), queryContext);
     assertTrue(aggregationFunction instanceof DistinctAggregationFunction);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -140,9 +140,9 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     int docId2 = docId1 + 1 + _random.nextInt(50);
     // NOTE: put all columns into group-by so that transform operator has expressions for all columns
     String query = String
-        .format("SELECT COUNT(*) FROM table WHERE %s IN (%d, %d) GROUP BY %s, %s", FILTER_COLUMN, docId1, docId2,
+        .format("SELECT COUNT(*) FROM testTable WHERE %s IN (%d, %d) GROUP BY %s, %s", FILTER_COLUMN, docId1, docId2,
             StringUtils.join(SV_COLUMNS, ", "), StringUtils.join(MV_COLUMNS, ", "));
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
 
     List<ExpressionContext> expressions = new ArrayList<>();
     for (String column : SV_COLUMNS) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -147,8 +147,8 @@ public class NoDictionaryGroupKeyGeneratorTest {
 
     // Create transform operator and block
     // NOTE: put all columns into group-by so that transform operator has expressions for all columns
-    String query = "SELECT COUNT(*) FROM table GROUP BY " + StringUtils.join(COLUMNS, ", ");
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    String query = "SELECT COUNT(*) FROM testTable GROUP BY " + StringUtils.join(COLUMNS, ", ");
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
     List<ExpressionContext> expressions = new ArrayList<>();
     for (String column : COLUMNS) {
       expressions.add(ExpressionContext.forIdentifier(column));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -60,45 +60,47 @@ public class ColumnValueSegmentPrunerTest {
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
 
     // Equality predicate
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 20"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 30"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 20"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 30"));
     // Range predicate
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column < 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column <= 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column >= 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 20"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 20 AND 30"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 30 AND 40"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 10 AND 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 20 AND 20"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column < 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column <= 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column >= 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column > 20"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 20 AND 30"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 30 AND 40"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 10 AND 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 20 AND 20"));
     // Invalid range predicate
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 20 AND 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 30 AND 20"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 20 AND 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 30 AND 20"));
     // In Predicate
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 5, 8)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (21, 30)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (10)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (5, 10, 15)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 5, 8)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21, 30)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (10)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (5, 10, 15)"));
     //although the segment can be pruned, it will not be pruned as the size of values is greater than threshold
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)"));
+    assertFalse(
+        runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)"));
+    assertFalse(
+        runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)"));
     // AND operator
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 AND column > 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 0 AND column < 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column >= 0 AND column <= 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 20 AND column < 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column >= 20 AND column < 30"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 0 AND column BETWEEN 0 AND 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 AND column > 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column > 0 AND column < 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column >= 0 AND column <= 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column > 20 AND column < 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column >= 20 AND column < 30"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column > 0 AND column BETWEEN 0 AND 10"));
     // OR operator
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 OR column > 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 OR column < 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column >= 0 OR column <= 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column > 30 OR column < 10"));
-    assertTrue(
-        runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column BETWEEN 0 AND 5 OR column BETWEEN 30 AND 35"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column > 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column < 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column >= 0 OR column <= 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column > 30 OR column < 10"));
+    assertTrue(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column BETWEEN 0 AND 5 OR column BETWEEN 30 AND 35"));
   }
 
   @Test
@@ -116,23 +118,23 @@ public class ColumnValueSegmentPrunerTest {
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
 
     // Equality predicate
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 2"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 7"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 2"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 7"));
     // AND operator
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 AND column = 2"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column >= 0 AND column = 10"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 2 AND column > 0"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column <= 10 AND column = 7"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 AND column = 2"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column >= 0 AND column = 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 2 AND column > 0"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column <= 10 AND column = 7"));
     // OR operator
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 OR column = 2"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 OR column < 10"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM table WHERE column = 0 OR column = 10"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 2"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column < 10"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 10"));
   }
 
   private boolean runPruner(IndexSegment indexSegment, String query) {
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
     return PRUNER.prune(indexSegment, queryContext);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/predicate/PredicateTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/predicate/PredicateTest.java
@@ -34,8 +34,7 @@ import static org.testng.Assert.assertEquals;
 public class PredicateTest {
 
   @Test
-  public void testSerDe()
-      throws Exception {
+  public void testSerDe() {
     // EqPredicate
     assertEquals(testSerDe("foo\t= 123"), "foo = '123'");
     assertEquals(testSerDe("foo='123'"), "foo = '123'");
@@ -91,8 +90,7 @@ public class PredicateTest {
    * Tests that the serialized predicate can be parsed and converted back to the same predicate, and returns the
    * serialized predicate (standardized string representation of the predicate expression).
    */
-  private String testSerDe(String predicateExpression)
-      throws Exception {
+  private String testSerDe(String predicateExpression) {
     // Parse and convert the string predicate expression into Predicate
     Expression thriftExpression = CalciteSqlParser.compileToExpression(predicateExpression);
     FilterContext filter = RequestContextUtils.getFilter(thriftExpression);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PartitionerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PartitionerTest.java
@@ -170,7 +170,7 @@ public class PartitionerTest {
 
     partitionerConfig =
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
-            .setTransformFunction("toEpochDays(timestamp)").build();
+            .setTransformFunction("toEpochDays(\"timestamp\")").build();
     Partitioner partitioner = PartitionerFactory.getPartitioner(partitionerConfig);
     assertEquals(partitioner.getClass(), TransformFunctionPartitioner.class);
     GenericRow row = new GenericRow();

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -142,7 +142,8 @@ abstract class BaseStarTreeV2Test<R, A> {
         MAX_LEAF_RECORDS);
     File indexDir = new File(TEMP_DIR, SEGMENT_NAME);
     // Randomly build star-tree using on-heap or off-heap mode
-    MultipleTreesBuilder.BuildMode buildMode = RANDOM.nextBoolean() ? MultipleTreesBuilder.BuildMode.ON_HEAP : MultipleTreesBuilder.BuildMode.OFF_HEAP;
+    MultipleTreesBuilder.BuildMode buildMode =
+        RANDOM.nextBoolean() ? MultipleTreesBuilder.BuildMode.ON_HEAP : MultipleTreesBuilder.BuildMode.OFF_HEAP;
     try (MultipleTreesBuilder builder = new MultipleTreesBuilder(Collections.singletonList(starTreeIndexConfig), false,
         indexDir, buildMode)) {
       builder.build();
@@ -183,7 +184,7 @@ abstract class BaseStarTreeV2Test<R, A> {
 
   void testQuery(String query)
       throws IOException {
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(query);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(query);
 
     // Aggregations
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -98,7 +98,7 @@ public class BenchmarkCombineGroupBy {
     }
 
     _queryContext = QueryContextConverterUtils
-        .getQueryContextFromPQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500");
+        .getQueryContextFromSQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
     _aggregationFunctions = _queryContext.getAggregationFunctions();
     assert _aggregationFunctions != null;
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"},

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -87,7 +87,7 @@ public class BenchmarkIndexedTable {
     }
 
     _queryContext = QueryContextConverterUtils
-        .getQueryContextFromPQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) TOP 500");
+        .getQueryContextFromSQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
 
@@ -114,7 +114,8 @@ public class BenchmarkIndexedTable {
     int numSegments = 10;
 
     // make 1 concurrent table
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
+    IndexedTable concurrentIndexedTable =
+        new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
 
     // 10 parallel threads putting 10k records into the table
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -47,8 +47,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
   public InbuiltFunctionEvaluator(String functionExpression) {
     _arguments = new ArrayList<>();
-    ExpressionContext expression = RequestContextUtils.getExpression(functionExpression);
-    _rootNode = planExecution(expression);
+    _rootNode = planExecution(RequestContextUtils.getExpressionFromSQL(functionExpression));
   }
 
   private ExecutableNode planExecution(ExpressionContext expression) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
@@ -103,7 +103,7 @@ public class IngestionUtilsTest {
     // inbuilt functions
     schema = new Schema();
     dimensionFieldSpec = new DimensionFieldSpec("hoursSinceEpoch", FieldSpec.DataType.LONG, true);
-    dimensionFieldSpec.setTransformFunction("toEpochHours(timestamp)");
+    dimensionFieldSpec.setTransformFunction("toEpochHours(\"timestamp\")");
     schema.addField(dimensionFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(null, schema));
     Assert.assertEquals(extract.size(), 2);
@@ -112,7 +112,7 @@ public class IngestionUtilsTest {
     // inbuilt functions with literal
     schema = new Schema();
     dimensionFieldSpec = new DimensionFieldSpec("tenMinutesSinceEpoch", FieldSpec.DataType.LONG, true);
-    dimensionFieldSpec.setTransformFunction("toEpochMinutesBucket(timestamp, 10)");
+    dimensionFieldSpec.setTransformFunction("toEpochMinutesBucket(\"timestamp\", 10)");
     schema.addField(dimensionFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(null, schema));
     Assert.assertEquals(extract.size(), 2);
@@ -122,7 +122,7 @@ public class IngestionUtilsTest {
     schema = new Schema();
     DateTimeFieldSpec dateTimeFieldSpec =
         new DateTimeFieldSpec("date", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS");
-    dateTimeFieldSpec.setTransformFunction("toDateTime(timestamp, 'yyyy-MM-dd')");
+    dateTimeFieldSpec.setTransformFunction("toDateTime(\"timestamp\", 'yyyy-MM-dd')");
     schema.addField(dateTimeFieldSpec);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(null, schema));
     Assert.assertEquals(extract.size(), 2);


### PR DESCRIPTION
## Description
Use `CalciteSqlParser` instead of `Pql2Compiler` to parse queries/expressions for:
- `InbuiltFunctionEvaluator` (for filter and transform used in data ingestion)
- Query tests

Add the implementation of standard SQL `trim` scalar function which takes 3 arguments: which end to trim (`BOTH|LEADING|TRAILING`), characters to be trimmed off, value to trim.

## Release Notes
The filter function and transform function configured in `IngestionConfig` should follow the SQL syntax.