### PR TITLE
Add extraEnv and envFrom to pinot helm.

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/broker/statefulset.yml
@@ -66,6 +66,11 @@ spec:
         env:
           - name: JAVA_OPTS
             value: "{{ .Values.broker.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.broker.log4j2ConfFile }} -Dplugins.dir={{ .Values.broker.pluginsDir }}"
+{{- if .Values.broker.extraEnv }}
+{{ toYaml .Values.broker.extraEnv | indent 10 }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.broker.envFrom | indent 10 }}
         ports:
           - containerPort: {{ .Values.broker.port }}
             protocol: TCP

--- a/kubernetes/helm/pinot/templates/controller/statefulset.yaml
+++ b/kubernetes/helm/pinot/templates/controller/statefulset.yaml
@@ -61,6 +61,11 @@ spec:
         env:
           - name: JAVA_OPTS
             value: "{{ .Values.controller.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.controller.log4j2ConfFile }} -Dplugins.dir={{ .Values.controller.pluginsDir }}"
+{{- if .Values.controller.extraEnv }}
+{{ toYaml .Values.controller.extraEnv | indent 10 }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.controller.envFrom | indent 10 }}
         ports:
           - containerPort: {{ .Values.controller.port }}
             protocol: TCP

--- a/kubernetes/helm/pinot/templates/minion/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/minion/statefulset.yml
@@ -66,6 +66,11 @@ spec:
         env:
           - name: JAVA_OPTS
             value: "{{ .Values.minion.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.minion.log4j2ConfFile }} -Dplugins.dir={{ .Values.minion.pluginsDir }}"
+{{- if .Values.minion.extraEnv }}
+{{ toYaml .Values.minion.extraEnv | indent 10 }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.minion.envFrom | indent 10 }}
         ports:
           - containerPort: {{ .Values.minion.port }}
             protocol: TCP

--- a/kubernetes/helm/pinot/templates/server/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/server/statefulset.yml
@@ -66,6 +66,11 @@ spec:
         env:
           - name: JAVA_OPTS
             value: "{{ .Values.server.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.server.log4j2ConfFile }} -Dplugins.dir={{ .Values.server.pluginsDir }}"
+{{- if .Values.server.extraEnv }}
+{{ toYaml .Values.server.extraEnv | indent 10 }}
+{{- end}}
+        envFrom:
+{{ toYaml .Values.server.envFrom | indent 10 }}
         ports:
           - containerPort: {{ .Values.server.ports.netty }}
             protocol: TCP

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -80,9 +80,20 @@ controller:
   updateStrategy:
     type: RollingUpdate
 
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
   envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
 
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
   extraEnv: []
+  #  - name: PINOT_CUSTOM_ENV
+  #    value: custom-value
 
   # Extra configs will be appended to pinot-controller.conf file
   extra:
@@ -133,9 +144,20 @@ broker:
   updateStrategy:
     type: RollingUpdate
 
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
   envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
 
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
   extraEnv: []
+  #  - name: PINOT_CUSTOM_ENV
+  #    value: custom-value
 
   # Extra configs will be appended to pinot-broker.conf file
   extra:
@@ -190,9 +212,20 @@ server:
   updateStrategy:
     type: RollingUpdate
 
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
   envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
 
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
   extraEnv: []
+  #  - name: PINOT_CUSTOM_ENV
+  #    value: custom-value
 
   # Extra configs will be appended to pinot-server.conf file
   extra:
@@ -244,9 +277,20 @@ minion:
   updateStrategy:
     type: RollingUpdate
 
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
   envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
 
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
   extraEnv: []
+  #  - name: PINOT_CUSTOM_ENV
+  #    value: custom-value
 
   # Extra configs will be appended to pinot-minion.conf file
   extra:

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -42,7 +42,6 @@ controller:
   data:
     dir: /var/pinot/controller/data
 
-
   vip:
     enabled: false
     host: pinot-controller
@@ -80,6 +79,10 @@ controller:
 
   updateStrategy:
     type: RollingUpdate
+
+  envFrom: []
+
+  extraEnv: []
 
   # Extra configs will be appended to pinot-controller.conf file
   extra:
@@ -129,6 +132,10 @@ broker:
 
   updateStrategy:
     type: RollingUpdate
+
+  envFrom: []
+
+  extraEnv: []
 
   # Extra configs will be appended to pinot-broker.conf file
   extra:
@@ -183,6 +190,10 @@ server:
   updateStrategy:
     type: RollingUpdate
 
+  envFrom: []
+
+  extraEnv: []
+
   # Extra configs will be appended to pinot-server.conf file
   extra:
     configs: |-
@@ -232,6 +243,10 @@ minion:
 
   updateStrategy:
     type: RollingUpdate
+
+  envFrom: []
+
+  extraEnv: []
 
   # Extra configs will be appended to pinot-minion.conf file
   extra:


### PR DESCRIPTION
## Description
This PR adds the ability to inject environment variables to the respective containers. Variables can either be added from existing secrets or configMaps through `envFrom` or they can be added individually through an `extraEnv`.

Example:
```yaml
server:
  envFrom:
    - secretRef:
        name: my-secret
  extraEnv:
    - name: PINOT_CUSTOM_ENV_1
      value: my-value-1
    - name: PINOT_CUSTOM_ENV_2
      value: my-value-2
```

Relates to issue https://github.com/apache/incubator-pinot/issues/6815

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
Adds support to inject environment variables via the Pinot helm chart. Variables can either be added from existing secrets or configMaps through `envFrom` or they can be added individually through the `extraEnv` array.

## Documentation
To inject custom environment variables you can use the `envFrom` or `extraEnv` properties within `values.yaml` within the respective containers.

* Use `envFrom` to define all of the ConfigMap or Secret data as container environment variables. 
* Use `extraEnv` to add individual key value pairs as container environment variables. 

Example:
```yaml
server:
  envFrom:
    - secretRef:
        name: my-secret
  extraEnv:
    - name: PINOT_CUSTOM_ENV_1
      value: my-value-1
    - name: PINOT_CUSTOM_ENV_2
      value: my-value-2
```

See the kubernetes doc on  [Define Environment Variables for a Container](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) for more details.
