### PR TITLE
Add endpoints in Pinot Controller, Broker and Server to get system and application configs.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerAppConfigs.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerAppConfigs.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Resource to get the app configs {@link PinotAppConfigs} for
+ * the broker.
+ */
+@Api(tags = "AppConfig")
+@Path("/")
+public class PinotBrokerAppConfigs {
+
+  @Context
+  private Application _application;
+
+  @GET
+  @Path("/appconfigs")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAppConfigs() {
+    PinotConfiguration pinotConfiguration =
+        (PinotConfiguration) _application.getProperties().get(BrokerAdminApiApplication.PINOT_CONFIGURATION);
+    PinotAppConfigs pinotAppConfigs = new PinotAppConfigs(pinotConfiguration);
+    return pinotAppConfigs.toJSONString();
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -28,6 +28,7 @@ import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
@@ -39,12 +40,15 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 public class BrokerAdminApiApplication extends ResourceConfig {
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
+  public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
   private HttpServer _httpServer;
 
   public BrokerAdminApiApplication(RoutingManager routingManager, BrokerRequestHandler brokerRequestHandler,
-      BrokerMetrics brokerMetrics) {
+      BrokerMetrics brokerMetrics, PinotConfiguration brokerConf) {
     packages(RESOURCE_PACKAGE);
+    property(PINOT_CONFIGURATION, brokerConf);
+
     register(new AbstractBinder() {
       @Override
       protected void configure() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -256,7 +256,8 @@ public class HelixBrokerStarter implements ServiceStartable {
     }
 
     LOGGER.info("Starting broker admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
-    _brokerAdminApplication = new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics);
+    _brokerAdminApplication =
+        new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics, _brokerConf);
     _brokerAdminApplication.start(_listenerConfigs);
 
     LOGGER.info("Initializing cluster change mediator");

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
@@ -1,0 +1,367 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryManagerMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Class that represents various configs for a pinot component:
+ * <ul>
+ *   <li>System Configs</li>
+ *   <li>JVM Configs</li>
+ *   <li>Runtime Configs</li>
+ *   <li>PinotConfiguration</li>
+ * </ul>
+ *
+ * This class is JSON serializable and de-serializable.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"systemConfig", "runtimeConfig", "pinotConfig", "jvmConfig"})
+public class PinotAppConfigs {
+  private static final String UNKNOWN_VALUE = "-";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @JsonProperty("systemConfig")
+  private SystemConfig _systemConfig;
+
+  @JsonProperty("jvmConfig")
+  private JVMConfig _jvmConfig;
+
+  @JsonProperty("runtimeConfig")
+  private RuntimeConfig _runtimeConfig;
+
+  @JsonProperty("pinotConfig")
+  private Map<String, Object> _pinotConfig;
+
+  @JsonCreator
+  @SuppressWarnings("unused")
+  public PinotAppConfigs() {
+
+  }
+
+  public PinotAppConfigs(PinotConfiguration pinotConfig) {
+    _systemConfig = buildSystemConfig();
+    _jvmConfig = buildJVMConfig();
+    _runtimeConfig = buildRuntimeConfig();
+    _pinotConfig = pinotConfig.toMap();
+  }
+
+  public SystemConfig getSystemConfig() {
+    return _systemConfig;
+  }
+
+  public JVMConfig getJvmConfig() {
+    return _jvmConfig;
+  }
+
+  public RuntimeConfig getRuntimeConfig() {
+    return _runtimeConfig;
+  }
+
+  public Map<String, Object> getPinotConfig() {
+    return _pinotConfig;
+  }
+
+  private SystemConfig buildSystemConfig() {
+    OperatingSystemMXBean osMXBean = ManagementFactory.getOperatingSystemMXBean();
+    SystemConfig systemConfig;
+
+    // Not all platforms may implement this, and so we may not have access to some of the api's.
+    if (osMXBean instanceof com.sun.management.OperatingSystemMXBean) {
+      com.sun.management.OperatingSystemMXBean sunOsMXBean = (com.sun.management.OperatingSystemMXBean) osMXBean;
+      systemConfig = new SystemConfig(osMXBean.getArch(), osMXBean.getName(), osMXBean.getVersion(),
+          osMXBean.getAvailableProcessors(), FileUtils.byteCountToDisplaySize(sunOsMXBean.getTotalPhysicalMemorySize()),
+          FileUtils.byteCountToDisplaySize(sunOsMXBean.getFreePhysicalMemorySize()),
+          FileUtils.byteCountToDisplaySize(sunOsMXBean.getTotalSwapSpaceSize()),
+          FileUtils.byteCountToDisplaySize(sunOsMXBean.getFreeSwapSpaceSize()));
+    } else {
+      systemConfig = new SystemConfig(osMXBean.getArch(), osMXBean.getName(), osMXBean.getVersion(),
+          osMXBean.getAvailableProcessors(), UNKNOWN_VALUE, UNKNOWN_VALUE, UNKNOWN_VALUE, UNKNOWN_VALUE);
+    }
+    return systemConfig;
+  }
+
+  private JVMConfig buildJVMConfig() {
+    RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+    List<GarbageCollectorMXBean> garbageCollectorMXBeans = ManagementFactory.getGarbageCollectorMXBeans();
+
+    return new JVMConfig(runtimeMXBean.getInputArguments(), runtimeMXBean.getLibraryPath(),
+        runtimeMXBean.getBootClassPath(), runtimeMXBean.getSystemProperties(), System.getenv(),
+        garbageCollectorMXBeans.stream().map(MemoryManagerMXBean::getName).collect(Collectors.toList()));
+  }
+
+  private RuntimeConfig buildRuntimeConfig() {
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    return new RuntimeConfig(threadMXBean.getTotalStartedThreadCount(), threadMXBean.getThreadCount(),
+        FileUtils.byteCountToDisplaySize(heapMemoryUsage.getMax()),
+        FileUtils.byteCountToDisplaySize(heapMemoryUsage.getUsed()));
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class SystemConfig {
+    private final String _arch;
+    private final String _name;
+    private final String _version;
+    private final int _availableProcessors;
+    private final String _totalPhysicalMemory;
+    private final String _freePhysicalMemory;
+    private final String _totalSwapSpace;
+    private final String _freeSwapSpace;
+
+    @JsonCreator
+    public SystemConfig(@JsonProperty("arch") String arch, @JsonProperty("name") String name,
+        @JsonProperty("version") String version, @JsonProperty("availableProcessors") int availableProcessors,
+        @JsonProperty("totalPhysicalMemory") String totalPhysicalMemory,
+        @JsonProperty("freePhysicalMemory") String freePhysicalMemory,
+        @JsonProperty("totalSwapSpace") String totalSwapSpace, @JsonProperty("freeSwapSpace") String freeSwapSpace) {
+      _arch = arch;
+      _name = name;
+      _version = version;
+      _availableProcessors = availableProcessors;
+      _totalPhysicalMemory = totalPhysicalMemory;
+      _freePhysicalMemory = freePhysicalMemory;
+      _totalSwapSpace = totalSwapSpace;
+      _freeSwapSpace = freeSwapSpace;
+    }
+
+    public String getArch() {
+      return _arch;
+    }
+
+    public String getName() {
+      return _name;
+    }
+
+    public String getVersion() {
+      return _version;
+    }
+
+    public int getAvailableProcessors() {
+      return _availableProcessors;
+    }
+
+    public String getTotalPhysicalMemory() {
+      return _totalPhysicalMemory;
+    }
+
+    public String getFreePhysicalMemory() {
+      return _freePhysicalMemory;
+    }
+
+    public String getTotalSwapSpace() {
+      return _totalSwapSpace;
+    }
+
+    public String getFreeSwapSpace() {
+      return _freeSwapSpace;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      SystemConfig that = (SystemConfig) o;
+      return _availableProcessors == that._availableProcessors && Objects.equals(_arch, that._arch) && Objects
+          .equals(_name, that._name) && Objects.equals(_version, that._version) && Objects
+          .equals(_totalPhysicalMemory, that._totalPhysicalMemory) && Objects
+          .equals(_freePhysicalMemory, that._freePhysicalMemory) && Objects
+          .equals(_totalSwapSpace, that._totalSwapSpace) && Objects.equals(_freeSwapSpace, that._freeSwapSpace);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_arch, _name, _version, _availableProcessors, _totalPhysicalMemory, _freePhysicalMemory,
+          _totalSwapSpace, _freeSwapSpace);
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class RuntimeConfig {
+    private final long _numTotalThreads;
+    private final int _numCurrentThreads;
+    private final String _maxHeapSize;
+    private final String _currentHeapSize;
+
+    @JsonCreator
+    public RuntimeConfig(@JsonProperty("numTotalThreads") long numTotalThreads,
+        @JsonProperty("numCurrentThreads") int numCurrentThreads, @JsonProperty("maxHeapSize") String maxHeapSize,
+        @JsonProperty("currentHeapSize") String currentHeapSize) {
+      _numTotalThreads = numTotalThreads;
+      _numCurrentThreads = numCurrentThreads;
+      _maxHeapSize = maxHeapSize;
+      _currentHeapSize = currentHeapSize;
+    }
+
+    public long getNumTotalThreads() {
+      return _numTotalThreads;
+    }
+
+    public int getNumCurrentThreads() {
+      return _numCurrentThreads;
+    }
+
+    public String getMaxHeapSize() {
+      return _maxHeapSize;
+    }
+
+    public String getCurrentHeapSize() {
+      return _currentHeapSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      RuntimeConfig that = (RuntimeConfig) o;
+      return _numTotalThreads == that._numTotalThreads && _numCurrentThreads == that._numCurrentThreads && Objects
+          .equals(_maxHeapSize, that._maxHeapSize) && Objects.equals(_currentHeapSize, that._currentHeapSize);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_numTotalThreads, _numCurrentThreads, _maxHeapSize, _currentHeapSize);
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"args", "garbageCollectors", "envVariables", "libraryPath", "bootClassPath"})
+  public static class JVMConfig {
+    private final List<String> _args;
+    private final String _libraryPath;
+    private final String _bootClassPath;
+    private final Map<String, String> _envVariables;
+    private final Map<String, String> _systemProperties;
+    private final List<String> _garbageCollectors;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      JVMConfig jvmConfig = (JVMConfig) o;
+      return Objects.equals(_args, jvmConfig._args) && Objects.equals(_libraryPath, jvmConfig._libraryPath) && Objects
+          .equals(_bootClassPath, jvmConfig._bootClassPath) && Objects.equals(_envVariables, jvmConfig._envVariables)
+          && Objects.equals(_systemProperties, jvmConfig._systemProperties) && Objects
+          .equals(_garbageCollectors, jvmConfig._garbageCollectors);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_args, _libraryPath, _bootClassPath, _envVariables, _systemProperties, _garbageCollectors);
+    }
+
+    @JsonCreator
+    public JVMConfig(@JsonProperty("args") List<String> args, @JsonProperty("libraryPath") String libraryPath,
+        @JsonProperty("bootClassPath") String bootClassPath,
+        @JsonProperty("systemProperties") Map<String, String> systemProperties,
+        @JsonProperty("envVariables") Map<String, String> envVariables,
+        @JsonProperty("garbageCollectors") List<String> garbageCollectors) {
+      _args = args;
+      _libraryPath = libraryPath;
+      _bootClassPath = bootClassPath;
+      _envVariables = envVariables;
+      _systemProperties = systemProperties;
+      _garbageCollectors = garbageCollectors;
+    }
+
+    public List<String> getArgs() {
+      return _args;
+    }
+
+    public String getLibraryPath() {
+      return _libraryPath;
+    }
+
+    public String getBootClassPath() {
+      return _bootClassPath;
+    }
+
+    public Map<String, String> getEnvVariables() {
+      return _envVariables;
+    }
+
+    public Map<String, String> getSystemProperties() {
+      return _systemProperties;
+    }
+
+    public List<String> getGarbageCollectors() {
+      return _garbageCollectors;
+    }
+  }
+
+  public String toJSONString() {
+    try {
+      return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      return e.getMessage();
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PinotAppConfigs that = (PinotAppConfigs) o;
+    return Objects.equals(_systemConfig, that._systemConfig) && Objects.equals(_jvmConfig, that._jvmConfig) && Objects
+        .equals(_runtimeConfig, that._runtimeConfig) && Objects.equals(_pinotConfig, that._pinotConfig);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_systemConfig, _jvmConfig, _runtimeConfig, _pinotConfig);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -170,7 +170,7 @@ public class ControllerStarter implements ServiceStartable {
       // Initialize FunctionRegistry before starting the admin application (PinotQueryResource requires it to compile
       // queries)
       FunctionRegistry.init();
-      _adminApp = new ControllerAdminApiApplication();
+      _adminApp = new ControllerAdminApiApplication(conf);
       // Do not use this before the invocation of {@link PinotHelixResourceManager::start()}, which happens in {@link ControllerStarter::start()}
       _helixResourceManager = new PinotHelixResourceManager(_config);
       _executorService =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -26,6 +26,7 @@ import java.util.List;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AuthenticationFilter;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
@@ -42,12 +43,14 @@ import org.slf4j.LoggerFactory;
 
 public class ControllerAdminApiApplication extends ResourceConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerAdminApiApplication.class);
+  public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
   private HttpServer _httpServer;
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.controller.api.resources";
 
-  public ControllerAdminApiApplication() {
+  public ControllerAdminApiApplication(ControllerConf conf) {
     super();
+    property(PINOT_CONFIGURATION, conf);
 
     packages(RESOURCE_PACKAGE);
     // TODO See ControllerResponseFilter

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
   public static final String LEAD_CONTROLLER_TAG = "Leader";
   public static final String TABLE_NAME = "tableName";
   public static final String ZOOKEEPER = "Zookeeper";
+  public static final String APP_CONFIGS = "AppConfigs";
 
   public static TableType validateTableType(String tableTypeStr) {
     if (tableTypeStr == null || tableTypeStr.isEmpty()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAppConfigs.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAppConfigs.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.controller.api.ControllerAdminApiApplication;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Resource to get the application configs {@link PinotAppConfigs}
+ * for the pinot controller.
+ */
+@Api(tags = Constants.APP_CONFIGS)
+@Path("/")
+public class PinotControllerAppConfigs {
+
+  @Context
+  private Application _application;
+
+  @GET
+  @Path("/appconfigs")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAppConfigs() {
+    PinotConfiguration pinotConfiguration =
+        (PinotConfiguration) _application.getProperties().get(ControllerAdminApiApplication.PINOT_CONFIGURATION);
+    PinotAppConfigs pinotAppConfigs = new PinotAppConfigs(pinotConfiguration);
+    return pinotAppConfigs.toJSONString();
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -340,4 +340,8 @@ public class ControllerRequestURLBuilder {
   public String forClusterConfigs() {
     return StringUtil.join("/", _baseUrl, "cluster/configs");
   }
+
+  public String forAppConfigs() {
+    return StringUtil.join("/", _baseUrl, "appconfigs");
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotControllerAppConfigsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotControllerAppConfigsTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.ControllerTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test for {@link org.apache.pinot.controller.api.resources.PinotControllerAppConfigs} class.
+ */
+public class PinotControllerAppConfigsTest {
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    ControllerTestUtils.setupClusterAndValidate();
+  }
+
+  /**
+   * Asserts that app configurations returned by the controller endpoint
+   * are as expected.
+   * @throws IOException In case of exception
+   */
+  @Test
+  public void testControllerAppConfigs()
+      throws IOException {
+    ControllerConf expectedControllerConf = ControllerTestUtils.getControllerConfig();
+    PinotAppConfigs expected = new PinotAppConfigs(expectedControllerConf);
+
+    String configsJson =
+        ControllerTestUtils.sendGetRequest(ControllerTestUtils.getControllerRequestURLBuilder().forAppConfigs());
+    PinotAppConfigs actual = new ObjectMapper().readValue(configsJson, PinotAppConfigs.class);
+
+    // RuntimeConfig is not checked as it has information that can change during the test run.
+    // Also, some of the system configs can change, so compare the ones that don't.
+    PinotAppConfigs.SystemConfig actualSystemConfig = actual.getSystemConfig();
+    PinotAppConfigs.SystemConfig expectedSystemConfig = expected.getSystemConfig();
+
+    Assert.assertEquals(actualSystemConfig.getName(), expectedSystemConfig.getName());
+    Assert.assertEquals(actualSystemConfig.getVersion(), expectedSystemConfig.getVersion());
+    Assert.assertEquals(actualSystemConfig.getAvailableProcessors(), expectedSystemConfig.getAvailableProcessors());
+    Assert.assertEquals(actualSystemConfig.getTotalPhysicalMemory(), expectedSystemConfig.getTotalPhysicalMemory());
+    Assert.assertEquals(actualSystemConfig.getTotalSwapSpace(), expectedSystemConfig.getTotalSwapSpace());
+
+    Assert.assertEquals(actual.getJvmConfig(), expected.getJvmConfig());
+    Assert.assertEquals(actual.getPinotConfig(), expectedControllerConf.toMap());
+  }
+
+  @AfterClass
+  public void tearDown() {
+    ControllerTestUtils.cleanup();
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerAppConfigs.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerAppConfigs.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.server.starter.helix.AdminApiApplication;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Resource to get the application configs {@link PinotAppConfigs} for
+ * Pinot Server.
+ */
+@Api(tags = "AppConfigs")
+@Path("/")
+public class PinotServerAppConfigs {
+
+  @Context
+  private Application _application;
+
+  @GET
+  @Path("/appconfigs")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAppConfigs() {
+    PinotConfiguration pinotConfiguration =
+        (PinotConfiguration) _application.getProperties().get(AdminApiApplication.PINOT_CONFIGURATION);
+    PinotAppConfigs pinotAppConfigs = new PinotAppConfigs(pinotConfiguration);
+    return pinotAppConfigs.toJSONString();
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.server.api.access.AccessControlFactory;
 import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 public class AdminApiApplication extends ResourceConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminApiApplication.class);
+  public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
   private final ServerInstance serverInstance;
   private final AccessControlFactory accessControlFactory;
@@ -51,10 +53,13 @@ public class AdminApiApplication extends ResourceConfig {
   private HttpServer httpServer;
   public static final String RESOURCE_PACKAGE = "org.apache.pinot.server.api.resources";
 
-  public AdminApiApplication(ServerInstance instance, AccessControlFactory accessControlFactory) {
+  public AdminApiApplication(ServerInstance instance, AccessControlFactory accessControlFactory,
+      PinotConfiguration serverConf) {
     this.serverInstance = instance;
     this.accessControlFactory = accessControlFactory;
     packages(RESOURCE_PACKAGE);
+    property(PINOT_CONFIGURATION, serverConf);
+
     register(new AbstractBinder() {
       @Override
       protected void configure() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -363,7 +363,7 @@ public class HelixServerStarter implements ServiceStartable {
 
     // Update admin API port
     LOGGER.info("Starting server admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
-    _adminApiApplication = new AdminApiApplication(_serverInstance, accessControlFactory);
+    _adminApiApplication = new AdminApiApplication(_serverInstance, accessControlFactory, _serverConf);
     _adminApiApplication.start(_listenerConfigs);
 
     // Update http admin port

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -33,6 +33,8 @@ import org.apache.pinot.server.api.access.AccessControl;
 import org.apache.pinot.server.api.access.AccessControlFactory;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.helix.AdminApiApplication;
+import org.apache.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.testng.Assert;
@@ -61,7 +63,8 @@ public class AccessControlTest {
     // Mock the server instance
     ServerInstance serverInstance = mock(ServerInstance.class);
 
-    _adminApiApplication = new AdminApiApplication(serverInstance, new DenyAllAccessFactory());
+    PinotConfiguration serverConf = DefaultHelixStarterServerConfig.loadDefaultServerConf();
+    _adminApiApplication = new AdminApiApplication(serverInstance, new DenyAllAccessFactory(), serverConf);
     _adminApiApplication.start(Collections.singletonList(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, "0.0.0.0",
         CommonConstants.Server.DEFAULT_ADMIN_API_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig())));
 

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -49,6 +49,8 @@ import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.server.api.access.AllowAllAccessFactory;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.helix.AdminApiApplication;
+import org.apache.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -122,7 +124,8 @@ public abstract class BaseResourceTest {
     setUpSegment(realtimeTableName, null, "default", _realtimeIndexSegments);
     setUpSegment(offlineTableName, null, "default", _offlineIndexSegments);
 
-    _adminApiApplication = new AdminApiApplication(serverInstance, new AllowAllAccessFactory());
+    PinotConfiguration serverConf = DefaultHelixStarterServerConfig.loadDefaultServerConf();
+    _adminApiApplication = new AdminApiApplication(serverInstance, new AllowAllAccessFactory(), serverConf);
     _adminApiApplication.start(Collections.singletonList(
         new ListenerConfig(CommonConstants.HTTP_PROTOCOL, "0.0.0.0", CommonConstants.Server.DEFAULT_ADMIN_API_PORT,
             CommonConstants.HTTP_PROTOCOL, new TlsConfig())));

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link org.apache.pinot.server.api.resources.PinotServerAppConfigs} class.
+ */
+public class PinotServerAppConfigsTest extends BaseResourceTest {
+
+  /**
+   * Asserts that application configs returned by the server endpoint are as expected.
+   *
+   * @throws JsonProcessingException In case an exception is encountered during JSON processing.
+   */
+  @Test
+  public void testAppConfigs()
+      throws JsonProcessingException {
+    PinotConfiguration expectedServerConf = DefaultHelixStarterServerConfig.loadDefaultServerConf();
+    PinotAppConfigs expected = new PinotAppConfigs(expectedServerConf);
+
+    Response response = _webTarget.path("/appconfigs").request().get(Response.class);
+    String configsJson = response.readEntity(String.class);
+    PinotAppConfigs actual = new ObjectMapper().readValue(configsJson, PinotAppConfigs.class);
+
+    // RuntimeConfig is not checked as it has information that can change during the test run.
+    // Also, some of the system configs can change, so compare the ones that don't.
+    PinotAppConfigs.SystemConfig actualSystemConfig = actual.getSystemConfig();
+    PinotAppConfigs.SystemConfig expectedSystemConfig = expected.getSystemConfig();
+
+    Assert.assertEquals(actualSystemConfig.getName(), expectedSystemConfig.getName());
+    Assert.assertEquals(actualSystemConfig.getVersion(), expectedSystemConfig.getVersion());
+    Assert.assertEquals(actualSystemConfig.getAvailableProcessors(), expectedSystemConfig.getAvailableProcessors());
+    Assert.assertEquals(actualSystemConfig.getTotalPhysicalMemory(), expectedSystemConfig.getTotalPhysicalMemory());
+    Assert.assertEquals(actualSystemConfig.getTotalSwapSpace(), expectedSystemConfig.getTotalSwapSpace());
+
+    Assert.assertEquals(actual.getJvmConfig(), expected.getJvmConfig());
+    Assert.assertEquals(actual.getPinotConfig(), expectedServerConf.toMap());
+  }
+}


### PR DESCRIPTION
During operational support, we frequently run into a situation where we would like to get various
information such as JVM configs, various system configs such as CPU/Thread/Mem size, PinotConfiguration
used to start the component etc. In this PR, we add an endpoint that consolidates all these information
at one place.

- The endpoint in all components is `/appconfigs`.

- Added a POJO PinotAppConfigs that contains the following POJOs:
  - JVM Configs
  - System Configs
  - Runtime Configs
  - PinotConfiguration

- Added tests for the new functionality

TODO:
- Pinot Broker does not have existing tests for testing api's, once that is added, we can add a test
  for this endpoint as well.
- Add this feature for Pinot Minion as well.

Sample output:
```
{
  "systemConfig" : {
    "arch" : "x86_64",
    "name" : "Mac OS X",
    "version" : "10.15.7",
    "availableProcessors" : 16,
    "totalPhysicalMemory" : "32 GB",
    "freePhysicalMemory" : "1 GB",
    "totalSwapSpace" : "5 GB",
    "freeSwapSpace" : "1 GB"
  },
  "runtimeConfig" : {
    "numTotalThreads" : 327,
    "numCurrentThreads" : 313,
    "maxHeapSize" : "7 GB",
    "currentHeapSize" : "253 MB"
  },
  "pinotConfig" : {
    "cluster.tenant.isolation.enable" : true,
    "controller.mode" : "DUAL",
    "controller.data.dir" : "/var/folders/3g/41r4c56x5yjcywvkj6mgdlhw0000gn/T/1618877963207/baseballStats/rawdata/PinotControllerDir0",
    "controller.vip.host" : "192.168.1.90",
    "controller.helix.cluster.name" : "QuickStartCluster",
    "controller.offline.segment.interval.checker.frequencyinseconds" : 3600,
    "controller.port" : "9000",
    "controller.retention.frequencyinseconds" : 21600,
    "controller.zk.str" : "localhost:2123",
    "controller.host" : "192.168.1.90",
    "controller.realtime.segment.validation.frequencyinseconds" : 3600,
    "controller.broker.resource.validation.frequencyinseconds" : 3600,
    "pinot.service.role" : "CONTROLLER"
  },
  "jvmConfig" : {
    "args" : [ "-javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=54453:/Applications/IntelliJ IDEA.app/Contents/bin", "-Dfile.encoding=UTF-8" ],
    "garbageCollectors" : [ "PS Scavenge", "PS MarkSweep" ],
    "envVariables" : {
      "PATH" : "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
      "SHELL" : "/bin/zsh",
      "JAVA_MAIN_CLASS_88970" : "org.apache.pinot.tools.BatchQuickstartWithMinion",
      "JAVA_HOME" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home",
      "OLDPWD" : "/",
      "USER" : "mayank",
      "TMPDIR" : "/var/folders/3g/41r4c56x5yjcywvkj6mgdlhw0000gn/T/",
      "SSH_AUTH_SOCK" : "/private/tmp/com.apple.launchd.961BOlpTAr/Listeners",
      "XPC_FLAGS" : "0x0",
      "VERSIONER_PYTHON_VERSION" : "2.7",
      "__CF_USER_TEXT_ENCODING" : "0x1F5:0x0:0x0",
      "LOGNAME" : "mayank",
      "LC_CTYPE" : "en_US.UTF-8",
      "PWD" : "/Users/mayank/projects/pinot",
      "XPC_SERVICE_NAME" : "com.jetbrains.intellij.2348",
      "HOME" : "/Users/mayank"
    },
    "libraryPath" : "/Users/mayank/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.",
    "bootClassPath" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/sunrsasign.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/classes",
    "systemProperties" : {
      "gopherProxySet" : "false",
      "awt.toolkit" : "sun.lwawt.macosx.LWCToolkit",
      "jdk.tls.rejectClientInitiatedRenegotiation" : "true",
      "helixmanager.flappingTimeWindow" : "1",
      "file.encoding.pkg" : "sun.io",
      "java.specification.version" : "1.8",
      "sun.cpu.isalist" : "",
      "sun.jnu.encoding" : "UTF-8",
      "java.class.path" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/cldrdata.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/dnsns.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/jaccess.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/localedata.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/nashorn.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/sunec.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/sunjce_provider.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/sunpkcs11.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext/zipfs.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/management-agent.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/lib/dt.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/lib/jconsole.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/lib/sa-jdi.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/lib/tools.jar:/Users/mayank/projects/pinot/pinot-tools/target/classes:/Users/mayank/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar:/Users/mayank/.m2/repository/org/apache/thrift/libthrift/0.12.0/libthrift-0.12.0.jar:/Users/mayank/.m2/repository/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar:/Users/mayank/.m2/repository/org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar:/Users/mayank/.m2/repository/org/apache/httpcomponents/httpcore/4.4.9/httpcore-4.4.9.jar:/Users/mayank/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar:/Users/mayank/.m2/repository/commons-codec/commons-codec/1.6/commons-codec-1.6.jar:/Users/mayank/.m2/repository/commons-configuration/commons-configuration/1.10/commons-configuration-1.10.jar:/Users/mayank/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar:/Users/mayank/.m2/repository/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar:/Users/mayank/.m2/repository/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar:/Users/mayank/.m2/repository/com/google/guava/guava/20.0/guava-20.0.jar:/Users/mayank/.m2/repository/com/google/code/findbugs/jsr305/3.0.0/jsr305-3.0.0.jar:/Users/mayank/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.11.2/log4j-slf4j-impl-2.11.2.jar:/Users/mayank/.m2/repository/org/apache/logging/log4j/log4j-api/2.11.2/log4j-api-2.11.2.jar:/Users/mayank/.m2/repository/org/apache/logging/log4j/log4j-core/2.11.2/log4j-core-2.11.2.jar:/Users/mayank/.m2/repository/com/lmax/disruptor/3.3.4/disruptor-3.3.4.jar:/Users/mayank/.m2/repository/org/apache/logging/log4j/log4j-1.2-api/2.11.2/log4j-1.2-api-2.11.2.jar:/Users/mayank/.m2/repository/joda-time/joda-time/2.10.5/joda-time-2.10.5.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.10.0/jackson-annotations-2.10.0.jar:/Users/mayank/.m2/repository/org/yaml/snakeyaml/1.16/snakeyaml-1.16.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.10.0/jackson-databind-2.10.0.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.10.0/jackson-core-2.10.0.jar:/Users/mayank/.m2/repository/org/apache/avro/avro/1.9.2/avro-1.9.2.jar:/Users/mayank/.m2/repository/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar:/Users/mayank/.m2/repository/org/codehaus/groovy/groovy-all/2.4.21/groovy-all-2.4.21.jar:/Users/mayank/.m2/repository/org/reflections/reflections/0.9.11/reflections-0.9.11.jar:/Users/mayank/.m2/repository/org/javassist/javassist/3.19.0-GA/javassist-3.19.0-GA.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/s3/2.13.46/s3-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/aws-xml-protocol/2.13.46/aws-xml-protocol-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/aws-query-protocol/2.13.46/aws-query-protocol-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/protocol-core/2.13.46/protocol-core-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/sdk-core/2.13.46/sdk-core-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/annotations/2.13.46/annotations-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/http-client-spi/2.13.46/http-client-spi-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/utils/2.13.46/utils-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/profiles/2.13.46/profiles-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/aws-core/2.13.46/aws-core-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/regions/2.13.46/regions-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/auth/2.13.46/auth-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/arns/2.13.46/arns-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/apache-client/2.13.46/apache-client-2.13.46.jar:/Users/mayank/.m2/repository/software/amazon/awssdk/netty-nio-client/2.13.46/netty-nio-client-2.13.46.jar:/Users/mayank/.m2/repository/io/netty/netty-codec-http/4.1.54.Final/netty-codec-http-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-handler/4.1.54.Final/netty-handler-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-resolver/4.1.54.Final/netty-resolver-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-codec-http2/4.1.54.Final/netty-codec-http2-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-transport-native-epoll/4.1.54.Final/netty-transport-native-epoll-4.1.54.Final-linux-x86_64.jar:/Users/mayank/.m2/repository/io/netty/netty-transport-native-unix-common/4.1.54.Final/netty-transport-native-unix-common-4.1.54.Final.jar:/Users/mayank/.m2/repository/com/typesafe/netty/netty-reactive-streams-http/2.0.4/netty-reactive-streams-http-2.0.4.jar:/Users/mayank/.m2/repository/com/typesafe/netty/netty-reactive-streams/2.0.4/netty-reactive-streams-2.0.4.jar:/Users/mayank/.m2/repository/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar:/Users/mayank/.m2/repository/io/netty/netty-codec/4.1.54.Final/netty-codec-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-common/4.1.54.Final/netty-common-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-buffer/4.1.54.Final/netty-buffer-4.1.54.Final.jar:/Users/mayank/.m2/repository/io/netty/netty-transport/4.1.54.Final/netty-transport-4.1.54.Final.jar:/Users/mayank/.m2/repository/javax/servlet/javax.servlet-api/3.0.1/javax.servlet-api-3.0.1.jar:/Users/mayank/.m2/repository/args4j/args4j/2.32/args4j-2.32.jar:/Users/mayank/.m2/repository/org/apache/commons/commons-math3/3.2/commons-math3-3.2.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-avro/1.11.1/parquet-avro-1.11.1.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-column/1.11.1/parquet-column-1.11.1.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-common/1.11.1/parquet-common-1.11.1.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-format-structures/1.11.1/parquet-format-structures-1.11.1.jar:/Users/mayank/.m2/repository/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar:/Users/mayank/.m2/repository/org/apache/yetus/audience-annotations/0.11.0/audience-annotations-0.11.0.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-encoding/1.11.1/parquet-encoding-1.11.1.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-hadoop/1.11.1/parquet-hadoop-1.11.1.jar:/Users/mayank/.m2/repository/org/apache/parquet/parquet-jackson/1.11.1/parquet-jackson-1.11.1.jar:/Users/mayank/.m2/repository/org/xerial/snappy/snappy-java/1.1.1.7/snappy-java-1.1.1.7.jar:/Users/mayank/.m2/repository/commons-pool/commons-pool/1.6/commons-pool-1.6.jar:/Users/mayank/.m2/repository/org/apache/kafka/kafka-clients/2.0.0/kafka-clients-2.0.0.jar:/Users/mayank/.m2/repository/org/lz4/lz4-java/1.4.1/lz4-java-1.4.1.jar:/Users/mayank/.m2/repository/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar:/Users/mayank/.m2/repository/org/apache/kafka/kafka_2.11/2.0.0/kafka_2.11-2.0.0.jar:/Users/mayank/.m2/repository/net/sf/jopt-simple/jopt-simple/4.6/jopt-simple-4.6.jar:/Users/mayank/.m2/repository/com/yammer/metrics/metrics-core/2.2.0/metrics-core-2.2.0.jar:/Users/mayank/.m2/repository/com/typesafe/scala-logging/scala-logging_2.11/3.9.0/scala-logging_2.11-3.9.0.jar:/Users/mayank/.m2/repository/com/101tec/zkclient/0.7/zkclient-0.7.jar:/Users/mayank/.m2/repository/log4j/log4j/1.2.17/log4j-1.2.17.jar:/Users/mayank/.m2/repository/org/apache/zookeeper/zookeeper/3.5.8/zookeeper-3.5.8.jar:/Users/mayank/.m2/repository/org/apache/zookeeper/zookeeper-jute/3.5.8/zookeeper-jute-3.5.8.jar:/Users/mayank/.m2/repository/io/netty/netty-transport-native-epoll/4.1.54.Final/netty-transport-native-epoll-4.1.54.Final.jar:/Users/mayank/.m2/repository/com/uber/h3/3.0.3/h3-3.0.3.jar:/Users/mayank/.m2/repository/me/lemire/integercompression/JavaFastPFOR/0.0.13/JavaFastPFOR-0.0.13.jar:/Users/mayank/.m2/repository/org/roaringbitmap/RoaringBitmap/0.9.0/RoaringBitmap-0.9.0.jar:/Users/mayank/.m2/repository/org/roaringbitmap/shims/0.9.0/shims-0.9.0.jar:/Users/mayank/.m2/repository/it/unimi/dsi/fastutil/8.2.3/fastutil-8.2.3.jar:/Users/mayank/.m2/repository/org/locationtech/jts/jts-core/1.16.1/jts-core-1.16.1.jar:/Users/mayank/.m2/repository/org/apache/httpcomponents/httpmime/4.5.3/httpmime-4.5.3.jar:/Users/mayank/.m2/repository/org/antlr/antlr4-runtime/4.6/antlr4-runtime-4.6.jar:/Users/mayank/.m2/repository/org/apache/calcite/calcite-core/1.19.0/calcite-core-1.19.0.jar:/Users/mayank/.m2/repository/org/apache/calcite/avatica/avatica-core/1.13.0/avatica-core-1.13.0.jar:/Users/mayank/.m2/repository/org/apache/calcite/calcite-linq4j/1.19.0/calcite-linq4j-1.19.0.jar:/Users/mayank/.m2/repository/org/apache/calcite/calcite-babel/1.19.0/calcite-babel-1.19.0.jar:/Users/mayank/.m2/repository/commons-httpclient/commons-httpclient/3.1/commons-httpclient-3.1.jar:/Users/mayank/.m2/repository/org/apache/helix/helix-core/0.9.8/helix-core-0.9.8.jar:/Users/mayank/.m2/repository/org/slf4j/slf4j-log4j12/1.7.14/slf4j-log4j12-1.7.14.jar:/Users/mayank/.m2/repository/org/codehaus/jackson/jackson-core-asl/1.9.13/jackson-core-asl-1.9.13.jar:/Users/mayank/.m2/repository/org/codehaus/jackson/jackson-mapper-asl/1.9.13/jackson-mapper-asl-1.9.13.jar:/Users/mayank/.m2/repository/commons-cli/commons-cli/1.2/commons-cli-1.2.jar:/Users/mayank/.m2/repository/org/apache/commons/commons-math/2.1/commons-math-2.1.jar:/Users/mayank/.m2/repository/io/dropwizard/metrics/metrics-core/4.1.2/metrics-core-4.1.2.jar:/Users/mayank/.m2/repository/io/netty/netty/3.9.6.Final/netty-3.9.6.Final.jar:/Users/mayank/.m2/repository/org/webjars/swagger-ui/3.18.2/swagger-ui-3.18.2.jar:/Users/mayank/.m2/repository/com/jayway/jsonpath/json-path/2.4.0/json-path-2.4.0.jar:/Users/mayank/.m2/repository/net/minidev/json-smart/2.3/json-smart-2.3.jar:/Users/mayank/.m2/repository/net/minidev/accessors-smart/1.2/accessors-smart-1.2.jar:/Users/mayank/.m2/repository/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/core/jersey-server/2.28/jersey-server-2.28.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/core/jersey-common/2.28/jersey-common-2.28.jar:/Users/mayank/.m2/repository/jakarta/ws/rs/jakarta.ws.rs-api/2.1.5/jakarta.ws.rs-api-2.1.5.jar:/Users/mayank/.m2/repository/jakarta/annotation/jakarta.annotation-api/1.3.4/jakarta.annotation-api-1.3.4.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/external/jakarta.inject/2.5.0/jakarta.inject-2.5.0.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/osgi-resource-locator/1.0.1/osgi-resource-locator-1.0.1.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/core/jersey-client/2.28/jersey-client-2.28.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/media/jersey-media-jaxb/2.28/jersey-media-jaxb-2.28.jar:/Users/mayank/.m2/repository/javax/validation/validation-api/2.0.1.Final/validation-api-2.0.1.Final.jar:/Users/mayank/.m2/repository/com/google/protobuf/protobuf-java/3.12.0/protobuf-java-3.12.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-netty-shaded/1.30.0/grpc-netty-shaded-1.30.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-core/1.30.0/grpc-core-1.30.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-api/1.30.0/grpc-api-1.30.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-context/1.30.0/grpc-context-1.30.0.jar:/Users/mayank/.m2/repository/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.jar:/Users/mayank/.m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.18/animal-sniffer-annotations-1.18.jar:/Users/mayank/.m2/repository/com/google/code/gson/gson/2.2.4/gson-2.2.4.jar:/Users/mayank/.m2/repository/com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar:/Users/mayank/.m2/repository/io/perfmark/perfmark-api/0.19.0/perfmark-api-0.19.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-protobuf/1.30.0/grpc-protobuf-1.30.0.jar:/Users/mayank/.m2/repository/com/google/api/grpc/proto-google-common-protos/1.17.0/proto-google-common-protos-1.17.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-protobuf-lite/1.30.0/grpc-protobuf-lite-1.30.0.jar:/Users/mayank/.m2/repository/io/grpc/grpc-stub/1.30.0/grpc-stub-1.30.0.jar:/Users/mayank/.m2/repository/org/xerial/larray/larray-mmap/0.4.1/larray-mmap-0.4.1.jar:/Users/mayank/.m2/repository/org/xerial/larray/larray-buffer/0.4.1/larray-buffer-0.4.1.jar:/Users/mayank/.m2/repository/org/apache/lucene/lucene-core/8.2.0/lucene-core-8.2.0.jar:/Users/mayank/.m2/repository/org/apache/lucene/lucene-queryparser/8.2.0/lucene-queryparser-8.2.0.jar:/Users/mayank/.m2/repository/org/apache/lucene/lucene-queries/8.2.0/lucene-queries-8.2.0.jar:/Users/mayank/.m2/repository/org/apache/lucene/lucene-sandbox/8.2.0/lucene-sandbox-8.2.0.jar:/Users/mayank/.m2/repository/org/apache/lucene/lucene-analyzers-common/8.2.0/lucene-analyzers-common-8.2.0.jar:/Users/mayank/.m2/repository/org/apache/datasketches/datasketches-java/1.2.0-incubating/datasketches-java-1.2.0-incubating.jar:/Users/mayank/.m2/repository/org/apache/datasketches/datasketches-memory/1.2.0-incubating/datasketches-memory-1.2.0-incubating.jar:/Users/mayank/.m2/repository/com/tdunning/t-digest/3.2/t-digest-3.2.jar:/Users/mayank/.m2/repository/com/clearspring/analytics/stream/2.7.0/stream-2.7.0.jar:/Users/mayank/.m2/repository/io/netty/netty-all/4.1.54.Final/netty-all-4.1.54.Final.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/containers/jersey-container-grizzly2-http/2.28/jersey-container-grizzly2-http-2.28.jar:/Users/mayank/.m2/repository/org/glassfish/grizzly/grizzly-http-server/2.4.4/grizzly-http-server-2.4.4.jar:/Users/mayank/.m2/repository/org/glassfish/grizzly/grizzly-http/2.4.4/grizzly-http-2.4.4.jar:/Users/mayank/.m2/repository/org/glassfish/grizzly/grizzly-framework/2.4.4/grizzly-framework-2.4.4.jar:/Users/mayank/.m2/repository/org/apache/commons/commons-csv/1.0/commons-csv-1.0.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/inject/jersey-hk2/2.28/jersey-hk2-2.28.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/hk2-locator/2.5.0/hk2-locator-2.5.0.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/external/aopalliance-repackaged/2.5.0/aopalliance-repackaged-2.5.0.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/hk2-api/2.5.0/hk2-api-2.5.0.jar:/Users/mayank/.m2/repository/org/glassfish/hk2/hk2-utils/2.5.0/hk2-utils-2.5.0.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/media/jersey-media-multipart/2.28/jersey-media-multipart-2.28.jar:/Users/mayank/.m2/repository/org/jvnet/mimepull/mimepull/1.9.11/mimepull-1.9.11.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/media/jersey-media-json-jackson/2.28/jersey-media-json-jackson-2.28.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/ext/jersey-entity-filtering/2.28/jersey-entity-filtering-2.28.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.10.0/jackson-module-jaxb-annotations-2.10.0.jar:/Users/mayank/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/2.3.2/jakarta.xml.bind-api-2.3.2.jar:/Users/mayank/.m2/repository/jakarta/activation/jakarta.activation-api/1.2.1/jakarta.activation-api-1.2.1.jar:/Users/mayank/.m2/repository/io/swagger/swagger-jersey2-jaxrs/1.5.16/swagger-jersey2-jaxrs-1.5.16.jar:/Users/mayank/.m2/repository/io/swagger/swagger-jaxrs/1.5.16/swagger-jaxrs-1.5.16.jar:/Users/mayank/.m2/repository/io/swagger/swagger-core/1.5.16/swagger-core-1.5.16.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.10.0/jackson-dataformat-yaml-2.10.0.jar:/Users/mayank/.m2/repository/io/swagger/swagger-models/1.5.16/swagger-models-1.5.16.jar:/Users/mayank/.m2/repository/io/swagger/swagger-annotations/1.5.16/swagger-annotations-1.5.16.jar:/Users/mayank/.m2/repository/org/glassfish/jersey/containers/jersey-container-servlet-core/2.25.1/jersey-container-servlet-core-2.25.1.jar:/Users/mayank/.m2/repository/javax/ws/rs/javax.ws.rs-api/2.0.1/javax.ws.rs-api-2.0.1.jar:/Users/mayank/.m2/repository/com/jcabi/jcabi-log/0.17.1/jcabi-log-0.17.1.jar:/Users/mayank/.m2/repository/com/jcabi/jcabi-aspects/0.22/jcabi-aspects-0.22.jar:/Users/mayank/.m2/repository/org/aspectj/aspectjrt/1.8.4/aspectjrt-1.8.4.jar:/Users/mayank/.m2/repository/org/quartz-scheduler/quartz/2.3.2/quartz-2.3.2.jar:/Users/mayank/.m2/repository/com/mchange/c3p0/0.9.5.4/c3p0-0.9.5.4.jar:/Users/mayank/.m2/repository/com/mchange/mchange-commons-java/0.2.15/mchange-commons-java-0.2.15.jar:/Users/mayank/.m2/repository/com/zaxxer/HikariCP-java7/2.4.13/HikariCP-java7-2.4.13.jar:/Users/mayank/.m2/repository/org/apache/orc/orc-core/1.5.9/orc-core-1.5.9.jar:/Users/mayank/.m2/repository/org/apache/orc/orc-shims/1.5.9/orc-shims-1.5.9.jar:/Users/mayank/.m2/repository/io/airlift/aircompressor/0.10/aircompressor-0.10.jar:/Users/mayank/.m2/repository/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar:/Users/mayank/.m2/repository/org/apache/hive/hive-storage-api/2.7.1/hive-storage-api-2.7.1.jar:/Users/mayank/.m2/repository/org/threeten/threeten-extra/1.5.0/threeten-extra-1.5.0.jar:/Users/mayank/.m2/repository/org/apache/hadoop/hadoop-common/2.7.0/hadoop-common-2.7.0.jar:/Users/mayank/.m2/repository/org/apache/hadoop/hadoop-annotations/2.7.0/hadoop-annotations-2.7.0.jar:/Users/mayank/.m2/repository/xmlenc/xmlenc/0.52/xmlenc-0.52.jar:/Users/mayank/.m2/repository/commons-net/commons-net/3.1/commons-net-3.1.jar:/Users/mayank/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar:/Users/mayank/.m2/repository/org/mortbay/jetty/jetty/6.1.26/jetty-6.1.26.jar:/Users/mayank/.m2/repository/org/mortbay/jetty/jetty-util/6.1.26/jetty-util-6.1.26.jar:/Users/mayank/.m2/repository/javax/servlet/jsp/jsp-api/2.1/jsp-api-2.1.jar:/Users/mayank/.m2/repository/net/java/dev/jets3t/jets3t/0.9.0/jets3t-0.9.0.jar:/Users/mayank/.m2/repository/com/jamesmurty/utils/java-xmlbuilder/0.4/java-xmlbuilder-0.4.jar:/Users/mayank/.m2/repository/org/apache/hadoop/hadoop-auth/2.7.0/hadoop-auth-2.7.0.jar:/Users/mayank/.m2/repository/org/apache/directory/server/apacheds-kerberos-codec/2.0.0-M15/apacheds-kerberos-codec-2.0.0-M15.jar:/Users/mayank/.m2/repository/org/apache/directory/server/apacheds-i18n/2.0.0-M15/apacheds-i18n-2.0.0-M15.jar:/Users/mayank/.m2/repository/org/apache/directory/api/api-asn1-api/1.0.0-M20/api-asn1-api-1.0.0-M20.jar:/Users/mayank/.m2/repository/org/apache/directory/api/api-util/1.0.0-M20/api-util-1.0.0-M20.jar:/Users/mayank/.m2/repository/org/apache/curator/curator-framework/2.7.1/curator-framework-2.7.1.jar:/Users/mayank/.m2/repository/org/apache/curator/curator-client/2.7.1/curator-client-2.7.1.jar:/Users/mayank/.m2/repository/com/jcraft/jsch/0.1.42/jsch-0.1.42.jar:/Users/mayank/.m2/repository/org/apache/curator/curator-recipes/2.7.1/curator-recipes-2.7.1.jar:/Users/mayank/.m2/repository/org/apache/htrace/htrace-core/3.1.0-incubating/htrace-core-3.1.0-incubating.jar:/Users/mayank/.m2/repository/org/apache/hadoop/hadoop-hdfs/2.7.0/hadoop-hdfs-2.7.0.jar:/Users/mayank/.m2/repository/commons-daemon/commons-daemon/1.0.13/commons-daemon-1.0.13.jar:/Users/mayank/.m2/repository/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar:/Users/mayank/.m2/repository/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar:/Users/mayank/.m2/repository/org/fusesource/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar:/Users/mayank/.m2/repository/org/testng/testng/6.11/testng-6.11.jar:/Users/mayank/.m2/repository/com/beust/jcommander/1.64/jcommander-1.64.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.10.0/jackson-jaxrs-json-provider-2.10.0.jar:/Users/mayank/.m2/repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.10.0/jackson-jaxrs-base-2.10.0.jar:/Users/mayank/.m2/repository/org/mockito/mockito-core/2.10.0/mockito-core-2.10.0.jar:/Users/mayank/.m2/repository/net/bytebuddy/byte-buddy/1.7.4/byte-buddy-1.7.4.jar:/Users/mayank/.m2/repository/net/bytebuddy/byte-buddy-agent/1.7.4/byte-buddy-agent-1.7.4.jar:/Users/mayank/.m2/repository/org/objenesis/objenesis/2.6/objenesis-2.6.jar:/Users/mayank/.m2/repository/org/glassfish/tyrus/bundles/tyrus-standalone-client/1.15/tyrus-standalone-client-1.15.jar:/Users/mayank/projects/pinot/pinot-core/target/classes:/Users/mayank/projects/pinot/pinot-spi/target/classes:/Users/mayank/projects/pinot/pinot-segment-spi/target/classes:/Users/mayank/projects/pinot/pinot-segment-local/target/classes:/Users/mayank/projects/pinot/pinot-common/target/classes:/Users/mayank/projects/pinot/pinot-server/target/classes:/Users/mayank/projects/pinot/pinot-controller/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-avro-base/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/target/classes:/Users/mayank/projects/pinot/pinot-broker/target/classes:/Users/mayank/projects/pinot/pinot-minion/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-avro/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-csv/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-protobuf/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-json/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-orc/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-parquet/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-input-format/pinot-thrift/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-file-system/pinot-s3/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/target/classes:/Users/mayank/projects/pinot/pinot-plugins/pinot-metrics/pinot-yammer/target/classes:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar",
      "java.vm.vendor" : "AdoptOpenJDK",
      "sun.arch.data.model" : "64",
      "java.vendor.url" : "https://adoptopenjdk.net/",
      "user.timezone" : "America/Los_Angeles",
      "os.name" : "Mac OS X",
      "java.vm.specification.version" : "1.8",
      "user.country" : "US",
      "sun.java.launcher" : "SUN_STANDARD",
      "sun.boot.library.path" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib",
      "sun.java.command" : "org.apache.pinot.tools.BatchQuickstartWithMinion",
      "http.nonProxyHosts" : "local|*.local|169.254/16|*.169.254/16",
      "sun.cpu.endian" : "little",
      "user.home" : "/Users/mayank",
      "user.language" : "en",
      "java.specification.vendor" : "Oracle Corporation",
      "java.home" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre",
      "file.separator" : "/",
      "line.separator" : "\n",
      "java.vm.specification.vendor" : "Oracle Corporation",
      "java.specification.name" : "Java Platform API Specification",
      "java.awt.graphicsenv" : "sun.awt.CGraphicsEnvironment",
      "sun.boot.class.path" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/sunrsasign.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/classes",
      "sun.management.compiler" : "HotSpot 64-Bit Tiered Compilers",
      "ftp.nonProxyHosts" : "local|*.local|169.254/16|*.169.254/16",
      "java.runtime.version" : "1.8.0_282-b08",
      "user.name" : "mayank",
      "zookeeper.jmx.log4j.disable" : "true",
      "path.separator" : ":",
      "os.version" : "10.15.7",
      "java.endorsed.dirs" : "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/endorsed",
      "zookeeper.admin.enableServer" : "false",
      "java.runtime.name" : "OpenJDK Runtime Environment",
      "file.encoding" : "UTF-8",
      "sun.nio.ch.bugLevel" : "",
      "java.vm.name" : "OpenJDK 64-Bit Server VM",
      "java.vendor.url.bug" : "https://github.com/AdoptOpenJDK/openjdk-support/issues",
      "java.io.tmpdir" : "/var/folders/3g/41r4c56x5yjcywvkj6mgdlhw0000gn/T/",
      "java.version" : "1.8.0_282",
      "user.dir" : "/Users/mayank/projects/pinot",
      "os.arch" : "x86_64",
      "java.vm.specification.name" : "Java Virtual Machine Specification",
      "java.awt.printerjob" : "sun.lwawt.macosx.CPrinterJob",
      "sun.os.patch.level" : "unknown",
      "java.library.path" : "/Users/mayank/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.",
      "java.vm.info" : "mixed mode",
      "java.vendor" : "AdoptOpenJDK",
      "java.vm.version" : "25.282-b08",
      "java.ext.dirs" : "/Users/mayank/Library/Java/Extensions:/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java",
      "sun.io.unicode.encoding" : "UnicodeBig",
      "java.class.version" : "52.0",
      "socksNonProxyHosts" : "local|*.local|169.254/16|*.169.254/16"
    }
  }
}
```

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
