### PR TITLE
Add admin endpoint for Pinot Minon.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -143,6 +143,27 @@ public final class ListenerConfigUtil {
     return listeners;
   }
 
+  public static List<ListenerConfig> buildMinionAdminConfigs(PinotConfiguration minionConf) {
+    List<ListenerConfig> listeners = new ArrayList<>();
+
+    String adminApiPortString = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_ADMIN_API_PORT);
+    if (adminApiPortString != null) {
+      listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(adminApiPortString),
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
+    }
+
+    TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(minionConf, CommonConstants.Minion.MINION_TLS_PREFIX);
+    listeners.addAll(buildListenerConfigs(minionConf, "pinot.minion.adminapi", tlsDefaults));
+
+    // support legacy behavior < 0.7.0
+    if (listeners.isEmpty()) {
+      listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST,
+          CommonConstants.Minion.DEFAULT_ADMIN_API_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
+    }
+
+    return listeners;
+  }
+
   private static ListenerConfig buildListenerConfig(PinotConfiguration config, String namespace, String protocol,
       TlsConfig tlsConfig) {
     String protocolNamespace = namespace + DOT_ACCESS_PROTOCOLS + "." + protocol;

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -97,5 +97,9 @@
       <artifactId>pinot-yammer</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jersey2-jaxrs</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import org.apache.pinot.core.transport.ListenerConfig;
+import org.apache.pinot.core.util.ListenerConfigUtil;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.glassfish.grizzly.http.server.CLStaticHttpHandler;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+
+
+/**
+ * Admin APP for Pinot Minion.
+ * <ul>
+ *   <li>Starts a http server.</li>
+ *   <li>Sets up swagger.</li>
+ * </ul>
+ */
+public class MinionAdminApiApplication extends ResourceConfig {
+  private static final String RESOURCE_PACKAGE = "org.apache.pinot.minion.api.resources";
+  public static final String PINOT_CONFIGURATION = "pinotConfiguration";
+
+  private HttpServer _httpServer;
+
+  public MinionAdminApiApplication(PinotConfiguration minionConf) {
+    packages(RESOURCE_PACKAGE);
+    property(PINOT_CONFIGURATION, minionConf);
+
+    register(new AbstractBinder() {
+      @Override
+      protected void configure() {
+        // TODO: Add bindings as needed in future.
+      }
+    });
+
+    registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
+    registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+  }
+
+  public void start(List<ListenerConfig> listenerConfigs) {
+    _httpServer = ListenerConfigUtil.buildHttpServer(this, listenerConfigs);
+
+    try {
+      _httpServer.start();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to start http server", e);
+    }
+
+    setupSwagger();
+  }
+
+  private void setupSwagger() {
+    BeanConfig beanConfig = new BeanConfig();
+    beanConfig.setTitle("Pinot Minion API");
+    beanConfig.setDescription("APIs for accessing Pinot Minion information");
+    beanConfig.setContact("https://github.com/apache/incubator-pinot");
+    beanConfig.setVersion("1.0");
+    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    beanConfig.setBasePath("/");
+    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
+    beanConfig.setScan(true);
+
+    HttpHandler httpHandler = new CLStaticHttpHandler(MinionAdminApiApplication.class.getClassLoader(), "/api/");
+    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
+    _httpServer.getServerConfiguration().addHttpHandler(httpHandler, "/api/", "/help/");
+
+    URL swaggerDistLocation =
+        MinionAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/3.18.2/");
+    CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+
+  public void stop() {
+    if (_httpServer != null) {
+      _httpServer.shutdownNow();
+    }
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionAppConfigs.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionAppConfigs.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.minion.MinionAdminApiApplication;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Resource for getting the app configs {@link PinotAppConfigs} for
+ * Pinot Minion instance.
+ */
+@Api(tags = "AppConfig")
+@Path("/")
+public class PinotMinionAppConfigs {
+  @Context
+  private Application _application;
+
+  @GET
+  @Path("/appconfigs")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String getAppConfigs() {
+    PinotConfiguration pinotConfiguration =
+        (PinotConfiguration) _application.getProperties().get(MinionAdminApiApplication.PINOT_CONFIGURATION);
+    PinotAppConfigs pinotAppConfigs = new PinotAppConfigs(pinotConfiguration);
+    return pinotAppConfigs.toJSONString();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -386,6 +386,9 @@ public class CommonConstants {
      * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
      */
     public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
+    public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.minion.adminapi.port";
+    public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
+    public static final int DEFAULT_ADMIN_API_PORT = 6500;
   }
 
   public static class Segment {


### PR DESCRIPTION
## Description
The Pinot Minion component, unlike other components, was missing an admin endpoint.
In this PR, we added an admin endpoint for Pinot Minion.

- The endpoint uses Jersey http server (same as other components).
- Setup swagger for Minion.
- Also, added the endpoint `/appconfigs` similiar to other components.
  (See: https://github.com/apache/incubator-pinot/pull/6817).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
