### PR TITLE
[PQL Deprecation] Separate SQL and PQL handling on broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerQueryPhase;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.utils.DataTable;
@@ -75,7 +74,7 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
   }
 
   @Override
-  protected BrokerResponse processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
+  protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
       @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
       @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -34,8 +34,13 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.segment.local.partition.PartitionFunctionFactory;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.utils.CommonConstants.Segment;
@@ -150,21 +155,90 @@ public class PartitionSegmentPruner implements SegmentPruner {
 
   @Override
   public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    if (filterQueryTree == null) {
-      return segments;
-    }
-    Set<String> selectedSegments = new HashSet<>();
-    for (String segment : segments) {
-      PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
-      if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterQueryTree,
-          partitionInfo)) {
-        selectedSegments.add(segment);
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    if (pinotQuery != null) {
+      // SQL
+
+      Expression filterExpression = pinotQuery.getFilterExpression();
+      if (filterExpression == null) {
+        return segments;
       }
+      Set<String> selectedSegments = new HashSet<>();
+      for (String segment : segments) {
+        PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
+        if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterExpression,
+            partitionInfo)) {
+          selectedSegments.add(segment);
+        }
+      }
+      return selectedSegments;
+    } else {
+      // PQL
+      FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+      if (filterQueryTree == null) {
+        return segments;
+      }
+      Set<String> selectedSegments = new HashSet<>();
+      for (String segment : segments) {
+        PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
+        if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterQueryTree,
+            partitionInfo)) {
+          selectedSegments.add(segment);
+        }
+      }
+      return selectedSegments;
     }
-    return selectedSegments;
   }
 
+  private boolean isPartitionMatch(Expression filterExpression, PartitionInfo partitionInfo) {
+    Function function = filterExpression.getFunctionCall();
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+    List<Expression> operands = function.getOperands();
+    switch (filterKind) {
+      case AND:
+        for (Expression child : operands) {
+          if (!isPartitionMatch(child, partitionInfo)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (Expression child : operands) {
+          if (isPartitionMatch(child, partitionInfo)) {
+            return true;
+          }
+        }
+        return false;
+      case EQUALS: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          return partitionInfo._partitions.contains(
+              partitionInfo._partitionFunction.getPartition(operands.get(1).getLiteral().getFieldValue().toString()));
+        } else {
+          return true;
+        }
+      }
+      case IN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_partitionColumn)) {
+          int numOperands = operands.size();
+          for (int i = 1; i < numOperands; i++) {
+            if (partitionInfo._partitions.contains(partitionInfo._partitionFunction
+                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
+              return true;
+            }
+          }
+          return false;
+        } else {
+          return true;
+        }
+      }
+      default:
+        return true;
+    }
+  }
+
+  @Deprecated
   private boolean isPartitionMatch(FilterQueryTree filterQueryTree, PartitionInfo partitionInfo) {
     switch (filterQueryTree.getOperator()) {
       case AND:

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -38,8 +38,13 @@ import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
 import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
@@ -151,11 +156,25 @@ public class TimeSegmentPruner implements SegmentPruner {
   @Override
   public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
     IntervalTree<String> intervalTree = _intervalTree;
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    if (filterQueryTree == null) {
-      return segments;
+
+    List<Interval> intervals;
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    if (pinotQuery != null) {
+      // SQL
+      Expression filterExpression = pinotQuery.getFilterExpression();
+      if (filterExpression == null) {
+        return segments;
+      }
+      intervals = getFilterTimeIntervals(filterExpression);
+    } else {
+      // PQL
+      FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+      if (filterQueryTree == null) {
+        return segments;
+      }
+      intervals = getFilterTimeIntervals(filterQueryTree);
     }
-    List<Interval> intervals = getFilterTimeIntervals(filterQueryTree);
+
     if (intervals == null) { // cannot prune based on time for input request
       return segments;
     }
@@ -176,8 +195,140 @@ public class TimeSegmentPruner implements SegmentPruner {
 
   /**
    * @return Null if no time condition or cannot filter base on the condition (e.g. 'SELECT * from myTable where time < 50 OR firstName = Jason')
+   *         Empty list if time condition is specified but invalid (e.g. 'SELECT * from myTable where time < 50 AND time > 100')
+   */
+  @Nullable
+  private List<Interval> getFilterTimeIntervals(Expression filterExpression) {
+    Function function = filterExpression.getFunctionCall();
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+    List<Expression> operands = function.getOperands();
+    switch (filterKind) {
+      case AND:
+        List<List<Interval>> andIntervals = new ArrayList<>();
+        for (Expression child : operands) {
+          List<Interval> childIntervals = getFilterTimeIntervals(child);
+          if (childIntervals != null) {
+            if (childIntervals.isEmpty()) {
+              return Collections.emptyList();
+            }
+            andIntervals.add(childIntervals);
+          }
+        }
+        if (andIntervals.isEmpty()) {
+          return null;
+        }
+        return getIntersectionSortedIntervals(andIntervals);
+      case OR:
+        List<List<Interval>> orIntervals = new ArrayList<>();
+        for (Expression child : operands) {
+          List<Interval> childIntervals = getFilterTimeIntervals(child);
+          if (childIntervals == null) {
+            return null;
+          } else {
+            orIntervals.add(childIntervals);
+          }
+        }
+        return getUnionSortedIntervals(orIntervals);
+      case EQUALS: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          return Collections.singletonList(new Interval(timeStamp, timeStamp));
+        } else {
+          return null;
+        }
+      }
+      case IN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          int numOperands = operands.size();
+          List<Interval> intervals = new ArrayList<>(numOperands - 1);
+          for (int i = 1; i < numOperands; i++) {
+            long timeStamp =
+                _timeFormatSpec.fromFormatToMillis(operands.get(i).getLiteral().getFieldValue().toString());
+            intervals.add(new Interval(timeStamp, timeStamp));
+          }
+          return intervals;
+        } else {
+          return null;
+        }
+      }
+      case GREATER_THAN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          return Collections.singletonList(new Interval(timeStamp + 1, MAX_END_TIME));
+        } else {
+          return null;
+        }
+      }
+      case GREATER_THAN_OR_EQUAL: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          return Collections.singletonList(new Interval(timeStamp, MAX_END_TIME));
+        } else {
+          return null;
+        }
+      }
+      case LESS_THAN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          if (timeStamp > MIN_START_TIME) {
+            return Collections.singletonList(new Interval(MIN_START_TIME, timeStamp - 1));
+          } else {
+            return Collections.emptyList();
+          }
+        } else {
+          return null;
+        }
+      }
+      case LESS_THAN_OR_EQUAL: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long timeStamp = _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          if (timeStamp >= MIN_START_TIME) {
+            return Collections.singletonList(new Interval(MIN_START_TIME, timeStamp));
+          } else {
+            return Collections.emptyList();
+          }
+        } else {
+          return null;
+        }
+      }
+      case BETWEEN: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          long startTimestamp =
+              _timeFormatSpec.fromFormatToMillis(operands.get(1).getLiteral().getFieldValue().toString());
+          long endTimestamp =
+              _timeFormatSpec.fromFormatToMillis(operands.get(2).getLiteral().getFieldValue().toString());
+          if (endTimestamp >= startTimestamp) {
+            return Collections.singletonList(new Interval(startTimestamp, endTimestamp));
+          } else {
+            return Collections.emptyList();
+          }
+        } else {
+          return null;
+        }
+      }
+      case RANGE: {
+        Identifier identifier = operands.get(0).getIdentifier();
+        if (identifier != null && identifier.getName().equals(_timeColumn)) {
+          return parseInterval(operands.get(1).getLiteral().getFieldValue().toString());
+        }
+      }
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * @return Null if no time condition or cannot filter base on the condition (e.g. 'SELECT * from myTable where time < 50 OR firstName = Jason')
    * @return Empty list if time condition is specified but invalid (e.g. 'SELECT * from myTable where time < 50 AND time > 100')
    */
+  @Deprecated
   @Nullable
   private List<Interval> getFilterTimeIntervals(FilterQueryTree filterQueryTree) {
     switch (filterQueryTree.getOperator()) {
@@ -225,7 +376,7 @@ public class TimeSegmentPruner implements SegmentPruner {
         return null;
       case RANGE:
         if (filterQueryTree.getColumn().equals(_timeColumn)) {
-          return parseInterval(filterQueryTree.getValue());
+          return parseInterval(filterQueryTree.getValue().get(0));
         }
         return null;
       default:
@@ -324,16 +475,13 @@ public class TimeSegmentPruner implements SegmentPruner {
    * Parse interval to millisecond as [min, max] with both sides included.
    * E.g. '(* 16311]' is parsed as [0, 16311], '(1455 16311)' is parsed as [1456, 16310]
    */
-  private List<Interval> parseInterval(List<String> intervalExpressions) {
-    Preconditions.checkState(intervalExpressions != null && intervalExpressions.size() == 1,
-        "Cannot parse range expressions from query: %s", intervalExpressions);
+  private List<Interval> parseInterval(String rangeString) {
     long startTime = MIN_START_TIME;
     long endTime = MAX_END_TIME;
-    String intervalExpression = intervalExpressions.get(0);
-    int length = intervalExpression.length();
-    boolean startExclusive = intervalExpression.charAt(0) == Range.LOWER_EXCLUSIVE;
-    boolean endExclusive = intervalExpression.charAt(length - 1) == Range.UPPER_EXCLUSIVE;
-    String interval = intervalExpression.substring(1, length - 1);
+    int length = rangeString.length();
+    boolean startExclusive = rangeString.charAt(0) == Range.LOWER_EXCLUSIVE;
+    boolean endExclusive = rangeString.charAt(length - 1) == Range.UPPER_EXCLUSIVE;
+    String interval = rangeString.substring(1, length - 1);
     String[] split = StringUtils.split(interval, Range.DELIMITER);
     if (!split[0].equals(Range.UNBOUNDED)) {
       startTime = _timeFormatSpec.fromFormatToMillis(split[0]);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/Interval.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/interval/Interval.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.routing.segmentpruner.interval;
 
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 
 
 /**
@@ -29,29 +30,24 @@ public class Interval implements Comparable<Interval> {
   public final long _max;
 
   public Interval(long min, long max) {
-    Preconditions.checkState(min <= max, "invalid interval [{}, {}]", min, max);
+    Preconditions.checkState(min <= max, "invalid interval [%s, %s]", min, max);
     _min = min;
     _max = max;
   }
 
   public boolean intersects(Interval o) {
-    Preconditions.checkNotNull(o, "Invalid interval: null");
     return _max >= o._min && o._max >= _min;
   }
 
   @Override
   public int compareTo(Interval o) {
-    Preconditions.checkNotNull(o, "Compare to invalid interval: null");
     if (_min < o._min) {
       return -1;
     } else if (_min > o._min) {
       return 1;
-    } else if (_max < o._max) {
-      return -1;
-    } else if (_max > o._max) {
-      return 1;
+    } else {
+      return Long.compare(_max, o._max);
     }
-    else return 0;
   }
 
   @Override
@@ -78,19 +74,17 @@ public class Interval implements Comparable<Interval> {
     return result;
   }
 
+  @Nullable
   public static Interval getIntersection(Interval a, Interval b) {
-    Preconditions.checkNotNull(a, "Intersect invalid intervals {} and {}", a, b);
-    Preconditions.checkNotNull(b, "Intersect invalid intervals {} and {}", a, b);
     if (!a.intersects(b)) {
       return null;
     }
     return new Interval(Math.max(a._min, b._min), Math.min(a._max, b._max));
   }
 
+  @Nullable
   public static Interval getUnion(Interval a, Interval b) {
     // Can only merge two intervals if they overlap
-    Preconditions.checkNotNull(a, "Union invalid intervals {} and {}", a, b);
-    Preconditions.checkNotNull(b, "Union invalid intervals {} and {}", a, b);
     if (!a.intersects(b)) {
       return null;
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
@@ -149,7 +150,9 @@ public class RealtimeSegmentSelector implements SegmentSelector {
     }
 
     // Handle HLC and LLC coexisting scenario, select HLC segments only if it is forced in the routing options
-    Map<String, String> debugOptions = brokerRequest.getDebugOptions();
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    Map<String, String> debugOptions =
+        pinotQuery != null ? pinotQuery.getDebugOptions() : brokerRequest.getDebugOptions();
     if (debugOptions != null) {
       String routingOptions = debugOptions.get(ROUTING_OPTIONS_KEY);
       if (routingOptions != null && routingOptions.toUpperCase().contains(FORCE_HLC)) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,7 +37,115 @@ import org.testng.annotations.Test;
 public class BrokerRequestOptionsTest {
 
   @Test
-  public void testSetOptions() {
+  public void testSQLSetOptions() {
+    long requestId = 1;
+    String query = "select * from testTable";
+
+    // None of the options
+    ObjectNode jsonRequest = JsonUtils.newObjectNode();
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+
+    // TRACE
+    // Has trace false
+    jsonRequest.put(Request.TRACE, false);
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+
+    // Has trace true
+    jsonRequest.put(Request.TRACE, true);
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
+
+    // DEBUG_OPTIONS
+    // Has debugOptions
+    jsonRequest = JsonUtils.newObjectNode();
+    jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+
+    // Has multiple debugOptions
+    jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo;debugOption2=bar");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 2);
+    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
+    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption2"), "bar");
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+
+    // Invalid debug options
+    jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    try {
+      BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+      Assert.fail();
+    } catch (Exception e) {
+      // Expected
+    }
+
+    // QUERY_OPTIONS
+    jsonRequest = JsonUtils.newObjectNode();
+    // Has queryOptions in pinotQuery already
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("queryOption1", "foo");
+    pinotQuery.setQueryOptions(queryOptions);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+
+    // Has queryOptions in query
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+
+    // Has query options in json payload
+    jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=foo");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+
+    // Has query options in both json payload and pinotQuery, pinotQuery takes priority
+    jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertNull(pinotQuery.getDebugOptions());
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
+
+    // Has all 3
+    jsonRequest = JsonUtils.newObjectNode();
+    jsonRequest.put(Request.TRACE, true);
+    jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
+    jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "bar");
+    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
+    Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
+  }
+
+  @Test
+  public void testPQLSetOptions() {
     Pql2Compiler compiler = new Pql2Compiler();
 
     BrokerRequest brokerRequest;
@@ -47,7 +157,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest = JsonUtils.newObjectNode();
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 0);
 
@@ -56,7 +165,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.TRACE, false);
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 0);
 
@@ -64,7 +172,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.TRACE, true);
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertTrue(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getQueryOptions().get(Request.TRACE), "true");
@@ -75,7 +182,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertEquals(brokerRequest.getDebugOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getDebugOptions().get("debugOption1"), "foo");
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 0);
@@ -84,7 +190,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo;debugOption2=bar");
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertEquals(brokerRequest.getDebugOptionsSize(), 2);
     Assert.assertEquals(brokerRequest.getDebugOptions().get("debugOption1"), "foo");
     Assert.assertEquals(brokerRequest.getDebugOptions().get("debugOption2"), "bar");
@@ -108,7 +213,6 @@ public class BrokerRequestOptionsTest {
     queryOptions.put("queryOption1", "foo");
     brokerRequest.setQueryOptions(queryOptions);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getQueryOptions().get("queryOption1"), "foo");
@@ -116,7 +220,6 @@ public class BrokerRequestOptionsTest {
     // has queryOptions in query
     brokerRequest = compiler.compileToBrokerRequest("select * from table option(queryOption1=foo)");
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getQueryOptions().get("queryOption1"), "foo");
@@ -125,7 +228,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=foo");
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getQueryOptions().get("queryOption1"), "foo");
@@ -134,7 +236,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
     brokerRequest = compiler.compileToBrokerRequest("select * from table option(queryOption1=foo)");
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertFalse(brokerRequest.isEnableTrace());
     Assert.assertNull(brokerRequest.getDebugOptions());
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 2);
     Assert.assertEquals(brokerRequest.getQueryOptions().get("queryOption1"), "foo");
@@ -147,7 +248,6 @@ public class BrokerRequestOptionsTest {
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
     brokerRequest = compiler.compileToBrokerRequest(query);
     BaseBrokerRequestHandler.setOptions(requestId, query, jsonRequest, brokerRequest);
-    Assert.assertTrue(brokerRequest.isEnableTrace());
     Assert.assertEquals(brokerRequest.getDebugOptionsSize(), 1);
     Assert.assertEquals(brokerRequest.getDebugOptions().get("debugOption1"), "foo");
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 3);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -31,7 +31,7 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.BytesUtils;
-import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -39,54 +39,54 @@ import org.testng.annotations.Test;
 public class LiteralOnlyBrokerRequestTest {
   private static final AccessControlFactory ACCESS_CONTROL_FACTORY = new AllowAllAccessControlFactory();
   private static final Random RANDOM = new Random(System.currentTimeMillis());
-  private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
 
   @Test
   public void testStringLiteralBrokerRequestFromSQL() {
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a'")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 'a'")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a', 'b'")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 'a', 'b'")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a' FROM myTable")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 'a' FROM myTable")));
     Assert.assertTrue(BaseBrokerRequestHandler
-        .isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 'a', 'b' FROM myTable")));
+        .isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 'a', 'b' FROM myTable")));
   }
 
   @Test
   public void testSelectStarBrokerRequestFromSQL() {
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT '*'")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT '*'")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT '*' FROM myTable")));
-    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT *")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT '*' FROM myTable")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT *")));
     Assert.assertFalse(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT * FROM myTable")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT * FROM myTable")));
   }
 
   @Test
   public void testNumberLiteralBrokerRequestFromSQL() {
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 1")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1, '2', 3")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 1, '2', 3")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1 FROM myTable")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 1 FROM myTable")));
     Assert.assertTrue(BaseBrokerRequestHandler
-        .isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT 1, '2', 3 FROM myTable")));
+        .isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT 1, '2', 3 FROM myTable")));
   }
 
   @Test
   public void testLiteralOnlyTransformBrokerRequestFromSQL() {
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT now()")));
+    Assert
+        .assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT now()")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        SQL_COMPILER.compileToBrokerRequest("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z')")));
+        CalciteSqlParser.compileToPinotQuery("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z')")));
     Assert.assertTrue(
-        BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest("SELECT now() FROM myTable")));
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER
-        .compileToBrokerRequest("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') FROM myTable")));
+        BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT now() FROM myTable")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT now(), fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') FROM myTable")));
   }
 
   @Test
   public void testLiteralOnlyWithAsBrokerRequestFromSQL() {
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(SQL_COMPILER.compileToBrokerRequest(
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
         "SELECT now() AS currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') AS firstDayOf2020")));
   }
 
@@ -102,8 +102,7 @@ public class LiteralOnlyBrokerRequestTest {
     String ranStr = BytesUtils.toHexString(randBytes);
     JsonNode request = new ObjectMapper().readTree(String.format("{\"sql\":\"SELECT %d, '%s'\"}", randNum, ranStr));
     RequestStatistics requestStats = new RequestStatistics();
-    BrokerResponseNative brokerResponse =
-        (BrokerResponseNative) requestHandler.handleRequest(request, null, requestStats);
+    BrokerResponseNative brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), String.format("%d", randNum));
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
         DataSchema.ColumnDataType.LONG);
@@ -127,8 +126,7 @@ public class LiteralOnlyBrokerRequestTest {
     JsonNode request = new ObjectMapper().readTree(
         "{\"sql\":\"SELECT now() as currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') as firstDayOf2020\"}");
     RequestStatistics requestStats = new RequestStatistics();
-    BrokerResponseNative brokerResponse =
-        (BrokerResponseNative) requestHandler.handleRequest(request, null, requestStats);
+    BrokerResponseNative brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     long currentTsMax = System.currentTimeMillis();
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "currentTs");
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryLimitOverrideTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryLimitOverrideTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.requesthandler;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
 import org.apache.pinot.parsers.AbstractCompiler;
 import org.testng.Assert;
@@ -55,23 +56,31 @@ public class QueryLimitOverrideTest {
 
   private void testSelectionQueryWithCompiler(AbstractCompiler compiler, String query, int maxQuerySelectionLimit,
       int expectedLimit) {
-    BrokerRequest brokerRequest;
-    brokerRequest = compiler.compileToBrokerRequest(query);
-    BaseBrokerRequestHandler.handleQueryLimitOverride(brokerRequest, maxQuerySelectionLimit);
-    Assert.assertEquals(brokerRequest.getLimit(), expectedLimit);
-    if (brokerRequest.getPinotQuery() != null) {
-      Assert.assertEquals(brokerRequest.getPinotQuery().getLimit(), expectedLimit);
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    if (pinotQuery != null) {
+      // SQL
+      BaseBrokerRequestHandler.handleQueryLimitOverride(pinotQuery, maxQuerySelectionLimit);
+      Assert.assertEquals(pinotQuery.getLimit(), expectedLimit);
+    } else {
+      // PQL
+      BaseBrokerRequestHandler.handleQueryLimitOverride(brokerRequest, maxQuerySelectionLimit);
+      Assert.assertEquals(brokerRequest.getLimit(), expectedLimit);
     }
   }
 
   private void testGroupByQueryWithCompiler(AbstractCompiler compiler, String query, int maxQuerySelectionLimit,
       int expectedLimit) {
-    BrokerRequest brokerRequest;
-    brokerRequest = compiler.compileToBrokerRequest(query);
-    BaseBrokerRequestHandler.handleQueryLimitOverride(brokerRequest, maxQuerySelectionLimit);
-    Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), expectedLimit);
-    if (brokerRequest.getPinotQuery() != null) {
-      Assert.assertEquals(brokerRequest.getPinotQuery().getLimit(), expectedLimit);
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    if (pinotQuery != null) {
+      // SQL
+      BaseBrokerRequestHandler.handleQueryLimitOverride(pinotQuery, maxQuerySelectionLimit);
+      Assert.assertEquals(pinotQuery.getLimit(), expectedLimit);
+    } else {
+      // PQL
+      BaseBrokerRequestHandler.handleQueryLimitOverride(brokerRequest, maxQuerySelectionLimit);
+      Assert.assertEquals(brokerRequest.getGroupBy().getTopN(), expectedLimit);
     }
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -20,12 +20,30 @@
 package org.apache.pinot.broker.requesthandler;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class QueryValidationTest {
+  private static final Pql2Compiler PQL_COMPILER = new Pql2Compiler();
+
+  @Test
+  public void testLargeLimit() {
+    String pql = "SELECT * FROM testTable LIMIT 10000";
+    testUnsupportedPQLQuery(pql, "Value for 'LIMIT' (10000) exceeds maximum allowed value of 1000");
+
+    pql = "SELECT COUNT(*) FROM testTable GROUP BY col1 LIMIT 10000";
+    testUnsupportedPQLQuery(pql, "Value for 'LIMIT' (10000) exceeds maximum allowed value of 1000");
+
+    pql = "SELECT COUNT(*) FROM testTable GROUP BY col1 TOP 10000";
+    testUnsupportedPQLQuery(pql, "Value for 'TOP' (10000) exceeds maximum allowed value of 1000");
+
+    String sql = "SELECT * FROM testTable LIMIT 10000 OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "Value for 'LIMIT' (10000) exceeds maximum allowed value of 1000");
+  }
 
   /**
    * The behavior of GROUP BY with multiple aggregations, is different in PQL vs SQL.
@@ -37,67 +55,93 @@ public class QueryValidationTest {
    */
   @Test
   public void testUnsupportedGroupByQueries() {
-    Pql2Compiler compiler = new Pql2Compiler();
-    String errorMsg =
+    String pqlErrorMessage =
         "The results of a GROUP BY query with multiple aggregations in PQL is not tabular, and cannot be returned in SQL responseFormat";
 
-    String query =
+    String pql =
         "SELECT MAX(column1), SUM(column2) FROM testTable GROUP BY column3 ORDER BY column3 option(responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query =
+    pql =
         "SELECT MAX(column1), SUM(column2) FROM testTable GROUP BY column3 TOP 3 option(groupByMode=pql,responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query =
+    pql =
         "SELECT MAX(column1), SUM(column2) FROM testTable WHERE column5 = '100' GROUP BY column3 option(responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query =
+    pql =
         "SELECT MAX(column1), SUM(column2), SUM(column10) FROM testTable GROUP BY column3 option(groupByMode=pql,responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query = "SELECT MAXMV(column1), SUMMV(column2) FROM testTable GROUP BY column3 option(responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    pql = "SELECT MAXMV(column1), SUMMV(column2) FROM testTable GROUP BY column3 option(responseFormat=sql)";
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query =
+    pql =
         "SELECT MAXMV(column1), SUM(column2) FROM testTable GROUP BY column3 ORDER BY MAXMV(column1) option(responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
 
-    query =
+    pql =
         "SELECT PERCENTILE95(column1), DISTINCTCOUNTHLL(column2) FROM testTable GROUP BY column3 option(responseFormat=sql)";
-    testUnsupportedQueriesHelper(compiler, query, errorMsg);
+    testUnsupportedPQLQuery(pql, pqlErrorMessage);
+
+    String sqlErrorMessage = "SQL query should always have response format and group-by mode set to SQL";
+
+    String sql = "SELECT * FROM testTable";
+    testUnsupportedSQLQuery(sql, sqlErrorMessage);
+
+    sql = "SELECT * FROM testTable OPTION(groupByMode=sql)";
+    testUnsupportedSQLQuery(sql, sqlErrorMessage);
+
+    sql = "SELECT * FROM testTable OPTION(responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, sqlErrorMessage);
   }
 
   @Test
   public void testUnsupportedDistinctQueries() {
-    Pql2Compiler compiler = new Pql2Compiler();
-
     String pql = "SELECT DISTINCT(col1, col2) FROM foo ORDER BY col3";
-    testUnsupportedQueriesHelper(compiler, pql,
-        "ORDER By should be only on some/all of the columns passed as arguments to DISTINCT");
+    testUnsupportedPQLQuery(pql, "ORDER By should be only on some/all of the columns passed as arguments to DISTINCT");
 
     pql = "SELECT DISTINCT(col1, col2) FROM foo GROUP BY col1";
-    testUnsupportedQueriesHelper(compiler, pql, "DISTINCT with GROUP BY is currently not supported");
+    testUnsupportedPQLQuery(pql, "DISTINCT with GROUP BY is currently not supported");
 
     pql = "SELECT sum(col1), min(col2), DISTINCT(col3, col4) FROM foo";
-    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+    testUnsupportedPQLQuery(pql, "Aggregation functions cannot be used with DISTINCT");
 
     pql = "SELECT sum(col1), DISTINCT(col2, col3), min(col4) FROM foo";
-    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+    testUnsupportedPQLQuery(pql, "Aggregation functions cannot be used with DISTINCT");
 
     pql = "SELECT DISTINCT(col1, col2), DISTINCT(col3) FROM foo";
-    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+    testUnsupportedPQLQuery(pql, "Aggregation functions cannot be used with DISTINCT");
 
     pql = "SELECT DISTINCT(col1, col2), sum(col3), min(col4) FROM foo";
-    testUnsupportedQueriesHelper(compiler, pql, "Aggregation functions cannot be used with DISTINCT");
+    testUnsupportedPQLQuery(pql, "Aggregation functions cannot be used with DISTINCT");
+
+    String sql = "SELECT DISTINCT col1, col2 FROM foo GROUP BY col1 OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "DISTINCT with GROUP BY is not supported");
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo LIMIT 0 OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "DISTINCT must have positive LIMIT");
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col3 OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
   }
 
-  private void testUnsupportedQueriesHelper(Pql2Compiler compiler, String query, String errorMessage) {
+  private void testUnsupportedPQLQuery(String query, String errorMessage) {
     try {
-      BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+      BrokerRequest brokerRequest = PQL_COMPILER.compileToBrokerRequest(query);
       BaseBrokerRequestHandler.validateRequest(brokerRequest, 1000);
-      Assert.fail("query should have failed");
+      Assert.fail("Query should have failed");
+    } catch (Exception e) {
+      Assert.assertEquals(errorMessage, e.getMessage());
+    }
+  }
+
+  private void testUnsupportedSQLQuery(String query, String errorMessage) {
+    try {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
+      Assert.fail("Query should have failed");
     } catch (Exception e) {
       Assert.assertEquals(errorMessage, e.getMessage());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
@@ -133,6 +134,12 @@ public class BrokerReduceService {
     long realtimeThreadCpuTimeNs = 0L;
     boolean numGroupsLimitReached = false;
 
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    Map<String, String> queryOptions =
+        pinotQuery != null ? pinotQuery.getQueryOptions() : brokerRequest.getQueryOptions();
+    boolean enableTrace =
+        queryOptions != null && Boolean.parseBoolean(queryOptions.get(CommonConstants.Broker.Request.TRACE));
+
     // Cache a data schema from data tables (try to cache one with data rows associated with it).
     DataSchema cachedDataSchema = null;
 
@@ -144,7 +151,7 @@ public class BrokerReduceService {
       Map<String, String> metadata = dataTable.getMetadata();
 
       // Reduce on trace info.
-      if (brokerRequest.isEnableTrace()) {
+      if (enableTrace) {
         brokerResponseNative.getTraceInfo()
             .put(entry.getKey().getHostname(), metadata.get(MetadataKey.TRACE_INFO.getName()));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/PinotQueryParserFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/PinotQueryParserFactory.java
@@ -46,4 +46,12 @@ public class PinotQueryParserFactory {
   public static BrokerRequest parsePinotQueryRequest(PinotQueryRequest pinotQueryRequest) {
     return get(pinotQueryRequest.getQueryFormat()).compileToBrokerRequest(pinotQueryRequest.getQuery());
   }
+
+  public static BrokerRequest parseSQLQuery(String query) {
+    return CALCITE_SQL_COMPILER.compileToBrokerRequest(query);
+  }
+
+  public static BrokerRequest parsePQLQuery(String query) {
+    return PQL_2_COMPILER.compileToBrokerRequest(query);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -29,9 +29,11 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.DataTable.MetadataKey;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,7 +163,12 @@ public class QueryRouter {
     InstanceRequest instanceRequest = new InstanceRequest();
     instanceRequest.setRequestId(requestId);
     instanceRequest.setQuery(brokerRequest);
-    instanceRequest.setEnableTrace(brokerRequest.isEnableTrace());
+    PinotQuery pinotQuery = brokerRequest.getPinotQuery();
+    Map<String, String> queryOptions =
+        pinotQuery != null ? pinotQuery.getQueryOptions() : brokerRequest.getQueryOptions();
+    if (queryOptions != null) {
+      instanceRequest.setEnableTrace(Boolean.parseBoolean(queryOptions.get(CommonConstants.Broker.Request.TRACE)));
+    }
     instanceRequest.setSearchSegments(segments);
     instanceRequest.setBrokerId(_brokerId);
     return instanceRequest;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -184,7 +184,7 @@ public abstract class BaseQueriesTest {
   @SuppressWarnings("SameParameterValue")
   protected BrokerResponseNative getBrokerResponseForSqlQuery(String sqlQuery, PlanMaker planMaker) {
     BrokerRequest brokerRequest = SQL_COMPILER.compileToBrokerRequest(sqlQuery);
-    Map<String, String> queryOptions = brokerRequest.getQueryOptions();
+    Map<String, String> queryOptions = brokerRequest.getPinotQuery().getQueryOptions();
     if (queryOptions == null) {
       queryOptions = new HashMap<>();
       brokerRequest.getPinotQuery().setQueryOptions(queryOptions);


### PR DESCRIPTION
## Description
Currently in `BaseBrokerRequestHandler`, all the query rewrite and optimization applies to both PQL `BrokerRequest` and SQL `PinotQuery`, which is doubling the work.
In this PR, we separate the SQL and PQL query handling, and only process one of `BrokerRequest` and `PinotQuery`.
Also modify the `PartitionSegmentPruner` and `TimeSegmentPruner` to support segment pruning based on SQL `PinotQuery`.

There are some duplicate code in `BaseBrokerRequestHandler` for SQL and PQL query handling, which is intentional. The PQL query handling code is subject to be removed in the future.