### PR TITLE
Using an insecure protocol to avoid MITM

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -41,7 +41,7 @@
   <repositories>
     <repository>
       <id>confluent</id>
-      <url>http://packages.confluent.io/maven/</url>
+      <url>https://packages.confluent.io/maven/</url>
     </repository>
   </repositories>
   <dependencies>


### PR DESCRIPTION
This patch use HTTPs instead of HTTP to avoid MITM risk.