### PR TITLE
Using correct placeholder for dimension table data manager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -116,7 +116,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
       _logger.info("Successfully removed segment {} and reloaded lookup table: {}", segmentName, getTableName());
     } catch (Exception e) {
       throw new RuntimeException(String
-          .format("Error reloading lookup table after segment remove (%s) for table: %s", segmentName, getTableName()),
+          .format("Error reloading lookup table after segment remove '%s' for table: '%s'", segmentName, getTableName()),
           e);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -116,7 +116,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
       _logger.info("Successfully removed segment {} and reloaded lookup table: {}", segmentName, getTableName());
     } catch (Exception e) {
       throw new RuntimeException(String
-          .format("Error reloading lookup table after segment remove ({}) for table: {}", segmentName, getTableName()),
+          .format("Error reloading lookup table after segment remove (%s) for table: %s", segmentName, getTableName()),
           e);
     }
   }


### PR DESCRIPTION
This patch uses correct placeholders for the dimension table data manager.