### PR TITLE
Refactor how Pinot catalog config is defined in presto helm chart

### DIFF
--- a/kubernetes/helm/presto/Chart.yaml
+++ b/kubernetes/helm/presto/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: 0.2.0
+appVersion: 0.2.1
 name: presto
 description: Presto is an open source distributed SQL query engine for running interactive analytic queries against data sources of all sizes ranging from gigabytes to petabytes.
-version: 0.2.0
+version: 0.2.1
 keywords:
   - analytics
   - database

--- a/kubernetes/helm/presto/templates/coordinator/configmap.yaml
+++ b/kubernetes/helm/presto/templates/coordinator/configmap.yaml
@@ -22,14 +22,10 @@ kind: ConfigMap
 metadata:
   name: presto-catalog
 data:
-  pinot.properties: |-
-    connector.name={{ .Values.pinot.connectorName }}
-    pinot.controller-urls={{ .Values.pinot.controllerUrls }}
-    pinot.controller-rest-service={{ .Values.pinot.controllerRestService }}
-    pinot.allow-multiple-aggregations={{ .Values.pinot.allowMultipleAggregations }}
-    pinot.use-date-trunc={{ .Values.pinot.useDateTrunc }}
-    pinot.infer-date-type-in-schema={{ .Values.pinot.inferDateTypeInSchema }}
-    pinot.infer-timestamp-type-in-schema={{ .Values.pinot.inferTimestampTypeInSchema }}
+{{- range $name, $catalog := .Values.catalogs }}
+  {{ $name }}: |
+{{- tpl $catalog $ | nindent 4 -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/helm/presto/values.yaml
+++ b/kubernetes/helm/presto/values.yaml
@@ -24,14 +24,16 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-pinot:
-  connectorName: pinot
-  controllerUrls: pinot-controller:9000
-  controllerRestService: pinot-controller:9000
-  allowMultipleAggregations: true
-  useDateTrunc: true
-  inferDateTypeInSchema: true
-  inferTimestampTypeInSchema: true
+catalogs:
+  pinot.properties: |-
+    connector.name=pinot
+    pinot.controller-urls=pinot-controller:9000
+    pinot.controller-rest-service=pinot-controller:9000
+    pinot.allow-multiple-aggregations=true
+    pinot.use-date-trunc=true
+    pinot.infer-date-type-in-schema=true
+    pinot.infer-timestamp-type-in-schema=true
+    pinot.use-streaming-for-segment-queries=false
 
 coordinator:
   name: coordinator


### PR DESCRIPTION

## Description
A catalogs map is introduced in the values.yaml, which specifies
the Pinot catalog config in the config map template.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
