### PR TITLE
Use ServerTimer instead of Gauge for emitting cpu time metric

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -31,9 +31,7 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   QUERY_RATE_LIMIT_DISABLED("queryQuota", true),
   NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true),
   REQUEST_SIZE("requestSize", false),
-  RESIZE_TIME_MS("milliseconds", false),
-  OFFLINE_THREAD_CPU_TIME_NS("nanoseconds", false),
-  REALTIME_THREAD_CPU_TIME_NS("nanoseconds", false);
+  RESIZE_TIME_MS("milliseconds", false);
 
   private final String brokerGaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
@@ -29,7 +29,11 @@ public enum BrokerTimer implements AbstractMetrics.Timer {
   ROUTING_TABLE_UPDATE_TIME(true),
   CLUSTER_CHANGE_QUEUE_TIME(true),
   // metric tracking the freshness lag for consuming segments
-  FRESHNESS_LAG_MS(false);
+  FRESHNESS_LAG_MS(false),
+  // aggregated query processing cost (thread cpu time in nanoseconds) from offline servers
+  OFFLINE_THREAD_CPU_TIME_NS(false),
+  // aggregated query processing cost (thread cpu time in nanoseconds) from realtime servers
+  REALTIME_THREAD_CPU_TIME_NS(false);
 
   private final String timerName;
   private final boolean global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -42,7 +42,6 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_SEGMENT_NUM_PARTITIONS("realtimeSegmentNumPartitions", false),
   LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
   RESIZE_TIME_MS("milliseconds", false),
-  EXECUTION_THREAD_CPU_TIME_NS("nanoseconds", false),
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false);
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -29,7 +29,9 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   // metric tracking the freshness lag for consuming segments
   FRESHNESS_LAG_MS("freshnessLagMs", false),
 
-  NETTY_CONNECTION_SEND_RESPONSE_LATENCY("nettyConnection", true);
+  NETTY_CONNECTION_SEND_RESPONSE_LATENCY("nettyConnection", true),
+  // Query cost (thread cpu time) for query processing on server
+  EXECUTION_THREAD_CPU_TIME_NS("nanoseconds", false);
 
   private final String timerName;
   private final boolean global;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
@@ -250,9 +249,9 @@ public class BrokerReduceService {
           .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
       brokerMetrics
           .addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
-      brokerMetrics.addValueToTableGauge(rawTableName, BrokerGauge.OFFLINE_THREAD_CPU_TIME_NS, offlineThreadCpuTimeNs);
+      brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.OFFLINE_THREAD_CPU_TIME_NS, offlineThreadCpuTimeNs, TimeUnit.NANOSECONDS);
       brokerMetrics
-          .addValueToTableGauge(rawTableName, BrokerGauge.REALTIME_THREAD_CPU_TIME_NS, realtimeThreadCpuTimeNs);
+          .addTimedTableValue(rawTableName, BrokerTimer.REALTIME_THREAD_CPU_TIME_NS, realtimeThreadCpuTimeNs, TimeUnit.NANOSECONDS);
       if (numConsumingSegmentsProcessed > 0 && minConsumingFreshnessTimeMs > 0) {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
             System.currentTimeMillis() - minConsumingFreshnessTimeMs, TimeUnit.MILLISECONDS);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -208,7 +208,7 @@ public abstract class QueryScheduler {
       serverMetrics.addValueToTableGauge(tableNameWithType, ServerGauge.RESIZE_TIME_MS, resizeTimeMs);
     }
     if (threadCpuTimeNs > 0) {
-      serverMetrics.addValueToTableGauge(tableNameWithType, ServerGauge.EXECUTION_THREAD_CPU_TIME_NS, threadCpuTimeNs);
+      serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.EXECUTION_THREAD_CPU_TIME_NS, threadCpuTimeNs, TimeUnit.NANOSECONDS);
     }
 
     TimerContext timerContext = queryRequest.getTimerContext();


### PR DESCRIPTION
Gauge is not the right choice for this timer related metric. It should be emitted similar to ServerTimer or ServerQueryPhase which underneath use the API addTimedTableValue. 

See the discussion here - https://github.com/apache/incubator-pinot/pull/6680#discussion_r595643785
