### PR TITLE
Update helm chart - Include securityContext, gracePeriod and remove duplicates in helm

### DIFF
--- a/kubernetes/helm/pinot/README.md
+++ b/kubernetes/helm/pinot/README.md
@@ -61,6 +61,7 @@ eksctl create cluster \
 --nodes-max 4 \
 --node-ami auto
 ```
+
 You can monitor cluster status by command:
 
 ```bash
@@ -80,6 +81,7 @@ aws eks update-kubeconfig --name ${EKS_CLUSTER_NAME}
 ```
 
 To verify the connection, you can run
+
 ```bash
 kubectl get nodes
 ```
@@ -114,7 +116,7 @@ GCLOUD_EMAIL=pinot-demo@example.com
 ./setup_gke.sh
 ```
 
-### (Optional) How to connect to an existing cluster
+### (Optional) How to connect to an existing GKE cluster
 
 Simply run below command to get the credential for the cluster you just created or your existing cluster.
 Please modify the Env variables `${GCLOUD_PROJECT}`, `${GCLOUD_ZONE}`, `${GCLOUD_CLUSTER}` accordingly in below script.
@@ -125,7 +127,6 @@ GCLOUD_ZONE=us-west1-b
 GCLOUD_CLUSTER=pinot-quickstart
 gcloud container clusters get-credentials ${GCLOUD_CLUSTER} --zone ${GCLOUD_ZONE} --project ${GCLOUD_PROJECT}
 ```
-
 
 ## (Optional) Setup a Kubernetes cluster on Microsoft Azure
 
@@ -160,7 +161,7 @@ az aks create --resource-group ${AKS_RESOURCE_GROUP}  --name ${AKS_CLUSTER_NAME}
 az provider register --namespace Microsoft.Network
 ```
 
-### (Optional) How to connect to an existing cluster
+### (Optional) How to connect to an existing AKS cluster
 
 Simply run below command to get the credential for the cluster you just created or your existing cluster.
 
@@ -171,6 +172,7 @@ az aks get-credentials --resource-group ${AKS_RESOURCE_GROUP} --name ${AKS_CLUST
 ```
 
 To verify the connection, you can run
+
 ```bash
 kubectl get nodes
 ```
@@ -185,17 +187,22 @@ helm dependency update
 
 ### Start Pinot with Helm
 
-- For helm v3.1.2
+- For helm v3.X.X
 
 ```bash
 kubectl create ns pinot-quickstart
 helm install pinot -n pinot-quickstart .
 ```
 
-- For helm v3.0.0
+- For helm v3.X.X
 
 ```bash
 kubectl create ns pinot-quickstart
+
+# First run dry-run with debug to verify:
+helm install -n pinot-quickstart pinot . --dry-run --debug
+
+# Install the Helm chart with:
 helm install -n pinot-quickstart pinot .
 ```
 
@@ -213,7 +220,8 @@ Then deploy pinot cluster by:
 helm install --namespace "pinot-quickstart" --name "pinot" .
 ```
 
-#### Troubleshooting (For helm v2.12.1)
+### Troubleshooting (For helm v2.12.1)
+
 - Error: Please run below command if encountering issue:
 
 ```
@@ -248,7 +256,7 @@ kubectl get all -n pinot-quickstart
 
 #### Bring up a Kafka Cluster for realtime data ingestion
 
-- For helm v3.0.0
+- For helm v3.X.X
 
 ```bash
 helm repo add incubator https://charts.helm.sh/incubator

--- a/kubernetes/helm/pinot/requirements.lock
+++ b/kubernetes/helm/pinot/requirements.lock
@@ -22,4 +22,4 @@ dependencies:
   repository: https://charts.helm.sh/incubator
   version: 2.1.6
 digest: sha256:ae84e3070d7f4efd24bd0d075820822ff6bec0f0e01a046fc119153dd7e98b51
-generated: "2021-04-24T22:21:14.038375+05:30"
+generated: "2021-04-25T01:25:57.823719+05:30"

--- a/kubernetes/helm/pinot/templates/_helpers.tpl
+++ b/kubernetes/helm/pinot/templates/_helpers.tpl
@@ -17,14 +17,12 @@
 # under the License.
 #
 
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "pinot.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -32,25 +30,128 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "pinot.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "pinot.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Match Selector labels
+*/}}
+{{- define "pinot.matchLabels" -}}
+app: {{ include "pinot.name" . }}
+chart: {{ include "pinot.chart" . }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pinot.labels" -}}
+helm.sh/chart: {{ include "pinot.chart" . }}
+{{ include "pinot.matchLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+heritage: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Broker labels
+*/}}
+{{- define "pinot.brokerLabels" -}}
+{{- include "pinot.labels" . }}
+component: {{ .Values.broker.name }}
+{{- end }}
+
+
+{{/*
+Controller labels
+*/}}
+{{- define "pinot.controllerLabels" -}}
+{{- include "pinot.labels" . }}
+component: {{ .Values.controller.name }}
+{{- end }}
+
+{{/*
+Minion labels
+*/}}
+{{- define "pinot.minionLabels" -}}
+{{- include "pinot.labels" . }}
+component: {{ .Values.minion.name }}
+{{- end }}
+
+{{/*
+Server labels
+*/}}
+{{- define "pinot.serverLabels" -}}
+{{- include "pinot.labels" . }}
+component: {{ .Values.server.name }}
+{{- end }}
+
+
+
+{{/*
+Broker Match Selector labels
+*/}}
+{{- define "pinot.brokerMatchLabels" -}}
+{{- include "pinot.matchLabels" . }}
+component: {{ .Values.broker.name }}
+{{- end }}
+
+{{/*
+Controller Match Selector labels
+*/}}
+{{- define "pinot.controllerMatchLabels" -}}
+{{- include "pinot.matchLabels" . }}
+component: {{ .Values.controller.name }}
+{{- end }}
+
+
+{{/*
+Minion Match Selector labels
+*/}}
+{{- define "pinot.minionMatchLabels" -}}
+{{- include "pinot.matchLabels" . }}
+component: {{ .Values.minion.name }}
+{{- end }}
+
+
+{{/*
+Server Match Selector labels
+*/}}
+{{- define "pinot.serverMatchLabels" -}}
+{{- include "pinot.matchLabels" . }}
+component: {{ .Values.server.name }}
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use for pinot components
+*/}}
+{{- define "pinot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pinot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
 
 
 {{/*

--- a/kubernetes/helm/pinot/templates/broker/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service-external.yaml
@@ -23,19 +23,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pinot.broker.external" . }}
+  {{- if .Values.broker.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.broker.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.brokerLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.broker.external.type }}
   ports:
     - name: external-broker
       port: {{ .Values.broker.external.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    {{- include "pinot.brokerMatchLabels" . | nindent 4 }}
 {{- end }}

--- a/kubernetes/helm/pinot/templates/broker/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service-external.yaml
@@ -24,7 +24,7 @@ kind: Service
 metadata:
   name: {{ template "pinot.broker.external" . }}
   annotations:
-    imageTag: {{ .Values.image.tag }}
+    type: "service-external"
   {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}

--- a/kubernetes/helm/pinot/templates/broker/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service-external.yaml
@@ -23,8 +23,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pinot.broker.external" . }}
-  {{- if .Values.broker.service.gcpInternalLB }}
   annotations:
+    imageTag: {{ .Values.image.tag }}
+  {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/broker/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service-headless.yaml
@@ -24,7 +24,7 @@ metadata:
   labels:
     {{- include "pinot.brokerLabels" . | nindent 4 }}
 spec:
-  clusterIP: {{ .Values.broker.service.clusterIP }}
+  clusterIP: None
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
     - name: {{ .Values.broker.service.name }}

--- a/kubernetes/helm/pinot/templates/broker/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service-headless.yaml
@@ -22,17 +22,12 @@ kind: Service
 metadata:
   name: {{ template "pinot.broker.headless" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.broker.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.brokerLabels" . | nindent 4 }}
 spec:
-  clusterIP: None
+  clusterIP: {{ .Values.broker.service.clusterIP }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.broker.service.port }}
+    - name: {{ .Values.broker.service.name }}
+      port: {{ .Values.broker.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    {{- include "pinot.brokerMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/broker/service.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service.yaml
@@ -21,18 +21,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
+  {{- if .Values.broker.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.broker.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.brokerLabels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.broker.service.type }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.broker.service.port }}
+    - name: {{ .Values.broker.service.name }}
+      port: {{ .Values.broker.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    {{- include "pinot.brokerMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/broker/service.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service.yaml
@@ -21,8 +21,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
-  {{- if .Values.broker.service.gcpInternalLB }}
   annotations:
+    imageTag: {{ .Values.image.tag }}
+  {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/broker/service.yaml
+++ b/kubernetes/helm/pinot/templates/broker/service.yaml
@@ -22,7 +22,7 @@ kind: Service
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
   annotations:
-    imageTag: {{ .Values.image.tag }}
+    type: "service"
   {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}

--- a/kubernetes/helm/pinot/templates/broker/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/broker/statefulset.yml
@@ -22,31 +22,31 @@ kind: StatefulSet
 metadata:
   name: {{ include "pinot.broker.fullname" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.broker.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.brokerLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "pinot.name" . }}
-      release: {{ .Release.Name }}
-      component: {{ .Values.broker.name }}
+      {{- include "pinot.brokerMatchLabels" . | nindent 6 }}
   serviceName: {{ template "pinot.broker.headless" . }}
   replicas: {{ .Values.broker.replicaCount }}
   updateStrategy:
     type: {{ .Values.broker.updateStrategy.type }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.broker.podManagementPolicy }}
   template:
     metadata:
       labels:
-        app: {{ include "pinot.name" . }}
-        release: {{ .Release.Name }}
-        component: {{ .Values.broker.name }}
+        {{- include "pinot.brokerLabels" . | nindent 8 }}
       annotations:
 {{ toYaml .Values.broker.podAnnotations | indent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.broker.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
 {{ toYaml .Values.broker.nodeSelector | indent 8 }}
       affinity:
@@ -55,6 +55,8 @@ spec:
 {{ toYaml .Values.broker.tolerations | indent 8 }}
       containers:
       - name: broker
+        securityContext:
+          {{- toYaml .Values.broker.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [
@@ -72,21 +74,28 @@ spec:
         envFrom:
 {{ toYaml .Values.broker.envFrom | indent 10 }}
         ports:
-          - containerPort: {{ .Values.broker.port }}
-            protocol: TCP
+          - containerPort: {{ .Values.broker.service.port }}
+            protocol: {{ .Values.broker.service.protocol }}
+            name: {{ .Values.broker.service.name }}
         volumeMounts:
           - name: config
             mountPath: /var/pinot/broker/config
+        {{- if .Values.broker.probes.livenessEnabled }}
         livenessProbe:
-          initialDelaySeconds: 60
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
           httpGet:
-            path: /health
-            port: {{ .Values.broker.port }}
+            path: {{ .Values.broker.probes.endpoint }}
+            port: {{ .Values.broker.service.port }}
+        {{- end }}
+        {{- if .Values.broker.probes.livenessEnabled }}
         readinessProbe:
-          initialDelaySeconds: 60
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
           httpGet:
-            path: /health
-            port: {{ .Values.broker.port }}
+            path: {{ .Values.broker.probes.endpoint }}
+            port: {{ .Values.broker.service.port }}
+        {{- end }}
         resources:
 {{ toYaml .Values.broker.resources | indent 12 }}
       restartPolicy: Always

--- a/kubernetes/helm/pinot/templates/controller/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service-external.yaml
@@ -23,8 +23,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pinot.controller.external" . }}
-  {{- if .Values.controller.service.gcpInternalLB }}
   annotations:
+    imageTag: {{ .Values.image.tag }}
+  {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/controller/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service-external.yaml
@@ -24,7 +24,7 @@ kind: Service
 metadata:
   name: {{ template "pinot.controller.external" . }}
   annotations:
-    imageTag: {{ .Values.image.tag }}
+    type: "service-external"
   {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}

--- a/kubernetes/helm/pinot/templates/controller/service-external.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service-external.yaml
@@ -23,19 +23,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pinot.controller.external" . }}
+  {{- if .Values.controller.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.controller.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.controllerLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.controller.external.type }}
   ports:
     - name: external-controller
       port: {{ .Values.controller.external.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.controller.name }}
+    {{- include "pinot.controllerMatchLabels" . | nindent 4 }}
 {{- end }}

--- a/kubernetes/helm/pinot/templates/controller/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service-headless.yaml
@@ -24,7 +24,7 @@ metadata:
   labels:
     {{- include "pinot.controllerLabels" . | nindent 4 }}
 spec:
-  clusterIP: {{ .Values.controller.service.clusterIP }}
+  clusterIP: None
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
     - name: {{ .Values.controller.service.name }}

--- a/kubernetes/helm/pinot/templates/controller/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service-headless.yaml
@@ -22,17 +22,12 @@ kind: Service
 metadata:
   name: {{ template "pinot.controller.headless" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.controller.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.controllerLabels" . | nindent 4 }}
 spec:
-  clusterIP: None
+  clusterIP: {{ .Values.controller.service.clusterIP }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.controller.service.port }}
+    - name: {{ .Values.controller.service.name }}
+      port: {{ .Values.controller.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.controller.name }}
+    {{- include "pinot.controllerMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/controller/service.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service.yaml
@@ -21,8 +21,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.controller.fullname" . }}
-  {{- if .Values.controller.service.gcpInternalLB }}
   annotations:
+    type: "service"
+  {{- if .Values.controller.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/controller/service.yaml
+++ b/kubernetes/helm/pinot/templates/controller/service.yaml
@@ -21,18 +21,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.controller.fullname" . }}
+  {{- if .Values.controller.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.controller.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.controllerLabels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.controller.service.type }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.controller.service.port }}
+    - name: {{ .Values.controller.service.name }}
+      port: {{ .Values.controller.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.controller.name }}
+    {{- include "pinot.controllerMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/controller/statefulset.yaml
+++ b/kubernetes/helm/pinot/templates/controller/statefulset.yaml
@@ -22,31 +22,31 @@ kind: StatefulSet
 metadata:
   name: {{ include "pinot.controller.fullname" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.controller.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.controllerLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "pinot.name" . }}
-      release: {{ .Release.Name }}
-      component: {{ .Values.controller.name }}
+      {{- include "pinot.controllerMatchLabels" . | nindent 6 }}
   serviceName: {{ template "pinot.controller.headless" . }}
   replicas: {{ .Values.controller.replicaCount }}
   updateStrategy:
     type: {{ .Values.controller.updateStrategy.type }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.controller.podManagementPolicy }}
   template:
     metadata:
       labels:
-        app: {{ include "pinot.name" . }}
-        release: {{ .Release.Name }}
-        component: {{ .Values.controller.name }}
+        {{- include "pinot.controllerLabels" . | nindent 8 }}
       annotations:
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
       affinity:
@@ -55,6 +55,8 @@ spec:
 {{ toYaml .Values.controller.tolerations | indent 8 }}
       containers:
       - name: controller
+        securityContext:
+          {{- toYaml .Values.controller.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "StartController", "-configFileName", "/var/pinot/controller/config/pinot-controller.conf" ]
@@ -67,8 +69,25 @@ spec:
         envFrom:
 {{ toYaml .Values.controller.envFrom | indent 10 }}
         ports:
-          - containerPort: {{ .Values.controller.port }}
-            protocol: TCP
+          - containerPort: {{ .Values.controller.service.port }}
+            protocol: {{ .Values.controller.service.protocol }}
+            name: {{ .Values.controller.service.name }}
+        {{- if .Values.controller.probes.livenessEnabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.controller.probes.endpoint }}
+            port: {{ .Values.controller.service.port }}
+        {{- end }}
+        {{- if .Values.controller.probes.livenessEnabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.controller.probes.endpoint }}
+            port: {{ .Values.controller.service.port }}
+        {{- end }}
         volumeMounts:
           - name: config
             mountPath: /var/pinot/controller/config

--- a/kubernetes/helm/pinot/templates/minion/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service-headless.yaml
@@ -22,17 +22,12 @@ kind: Service
 metadata:
   name: {{ template "pinot.minion.headless" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.minion.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.minionLabels" . | nindent 4 }}
 spec:
-  clusterIP: None
+  clusterIP: {{ .Values.minion.service.clusterIP }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.minion.service.port }}
+    - name: {{ .Values.minion.service.name }}
+      port: {{ .Values.minion.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.minion.name }}
+    {{- include "pinot.minionMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/minion/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service-headless.yaml
@@ -24,7 +24,7 @@ metadata:
   labels:
     {{- include "pinot.minionLabels" . | nindent 4 }}
 spec:
-  clusterIP: {{ .Values.minion.service.clusterIP }}
+  clusterIP: None
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
     - name: {{ .Values.minion.service.name }}

--- a/kubernetes/helm/pinot/templates/minion/service.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service.yaml
@@ -22,8 +22,8 @@ kind: Service
 metadata:
   name: {{ include "pinot.minion.fullname" . }}
   annotations:
-    imageTag: {{ .Values.image.tag }}
-  {{- if .Values.broker.service.gcpInternalLB }}
+    type: "service"
+  {{- if .Values.minion.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/minion/service.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service.yaml
@@ -21,8 +21,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.minion.fullname" . }}
-  {{- if .Values.minion.service.gcpInternalLB }}
   annotations:
+    imageTag: {{ .Values.image.tag }}
+  {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/minion/service.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service.yaml
@@ -21,18 +21,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.minion.fullname" . }}
+  {{- if .Values.minion.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.minion.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.minionLabels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.minion.service.type }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.minion.service.port }}
+    - name: {{ .Values.minion.service.name }}
+      port: {{ .Values.minion.service.port }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.minion.name }}
+    {{- include "pinot.minionMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/minion/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/minion/statefulset.yml
@@ -22,31 +22,31 @@ kind: StatefulSet
 metadata:
   name: {{ include "pinot.minion.fullname" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.minion.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.minionLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "pinot.name" . }}
-      release: {{ .Release.Name }}
-      component: {{ .Values.minion.name }}
+      {{- include "pinot.minionMatchLabels" . | nindent 6 }}
   serviceName: {{ template "pinot.minion.headless" . }}
   replicas: {{ .Values.minion.replicaCount }}
   updateStrategy:
     type: {{ .Values.minion.updateStrategy.type }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.minion.podManagementPolicy }}
   template:
     metadata:
       labels:
-        app: {{ include "pinot.name" . }}
-        release: {{ .Release.Name }}
-        component: {{ .Values.minion.name }}
+        {{- include "pinot.minionLabels" . | nindent 8 }}
       annotations:
 {{ toYaml .Values.minion.podAnnotations | indent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.minion.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
 {{ toYaml .Values.minion.nodeSelector | indent 8 }}
       affinity:
@@ -55,6 +55,8 @@ spec:
 {{ toYaml .Values.minion.tolerations | indent 8 }}
       containers:
       - name: minion
+        securityContext:
+          {{- toYaml .Values.minion.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [
@@ -72,8 +74,25 @@ spec:
         envFrom:
 {{ toYaml .Values.minion.envFrom | indent 10 }}
         ports:
-          - containerPort: {{ .Values.minion.port }}
-            protocol: TCP
+          - containerPort: {{ .Values.minion.service.port }}
+            protocol: {{ .Values.minion.service.protocol }}
+            name: {{ .Values.minion.service.name }}
+        {{- if .Values.minion.probes.livenessEnabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.minion.probes.endpoint }}
+            port: {{ .Values.minion.service.port }}
+        {{- end }}
+        {{- if .Values.minion.probes.livenessEnabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.minion.probes.endpoint }}
+            port: {{ .Values.minion.service.port }}
+        {{- end }}
         volumeMounts:
           - name: config
             mountPath: /var/pinot/minion/config

--- a/kubernetes/helm/pinot/templates/server/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/server/configmap.yaml
@@ -23,8 +23,8 @@ metadata:
   name: {{ include "pinot.server.config" . }}
 data:
   pinot-server.conf: |-
-    pinot.server.netty.port={{ .Values.server.ports.netty }}
-    pinot.server.adminapi.port={{ .Values.server.ports.admin }}
+    pinot.server.netty.port={{ .Values.server.service.nettyPort }}
+    pinot.server.adminapi.port={{ .Values.server.service.adminPort }}
     pinot.server.instance.dataDir={{ .Values.server.dataDir }}
     pinot.server.instance.segmentTarDir={{ .Values.server.segmentTarDir }}
 {{ .Values.server.extra.configs | indent 4 }}

--- a/kubernetes/helm/pinot/templates/server/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/server/service-headless.yaml
@@ -22,17 +22,17 @@ kind: Service
 metadata:
   name: {{ template "pinot.server.headless" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.server.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.serverLabels" . | nindent 4 }}
 spec:
-  clusterIP: None
+  clusterIP: {{ .Values.server.service.clusterIP }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.server.service.port }}
+    - name: {{ .Values.server.service.nettyPortName }}
+      port: {{ .Values.server.service.nettyPort }}
+      protocol: {{ .Values.server.service.protocol }}
+    - name: {{ .Values.server.service.adminPortName }}
+      port: {{ .Values.server.service.adminExposePort }}
+      targetPort: {{ .Values.server.service.adminPort }}
+      protocol: {{ .Values.server.service.protocol }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.server.name }}
+    {{- include "pinot.serverMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/server/service-headless.yaml
+++ b/kubernetes/helm/pinot/templates/server/service-headless.yaml
@@ -24,7 +24,7 @@ metadata:
   labels:
     {{- include "pinot.serverLabels" . | nindent 4 }}
 spec:
-  clusterIP: {{ .Values.server.service.clusterIP }}
+  clusterIP: None
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
     - name: {{ .Values.server.service.nettyPortName }}

--- a/kubernetes/helm/pinot/templates/server/service.yaml
+++ b/kubernetes/helm/pinot/templates/server/service.yaml
@@ -21,18 +21,22 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.server.fullname" . }}
+  {{- if .Values.server.service.gcpInternalLB }}
+  annotations:
+    cloud.google.com/load-balancer-type: Internal
+  {{- end }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.server.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.serverLabels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.server.service.type }}
   ports:
     # [pod_name].[service_name].[namespace].svc.cluster.local
-    - port: {{ .Values.server.service.port }}
+    - name: {{ .Values.server.service.nettyPortName }}
+      port: {{ .Values.server.service.nettyPort }}
+      protocol: {{ .Values.server.service.protocol }}
+    - name: {{ .Values.server.service.adminPortName }}
+      port: {{ .Values.server.service.adminExposePort }}
+      targetPort: {{ .Values.server.service.adminPort }}
+      protocol: {{ .Values.server.service.protocol }}
   selector:
-    app: {{ include "pinot.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.server.name }}
+    {{- include "pinot.serverMatchLabels" . | nindent 4 }}

--- a/kubernetes/helm/pinot/templates/server/service.yaml
+++ b/kubernetes/helm/pinot/templates/server/service.yaml
@@ -22,8 +22,8 @@ kind: Service
 metadata:
   name: {{ include "pinot.server.fullname" . }}
   annotations:
-    imageTag: {{ .Values.image.tag }}
-  {{- if .Values.broker.service.gcpInternalLB }}
+    type: "service"
+  {{- if .Values.server.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/server/service.yaml
+++ b/kubernetes/helm/pinot/templates/server/service.yaml
@@ -21,8 +21,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pinot.server.fullname" . }}
-  {{- if .Values.server.service.gcpInternalLB }}
   annotations:
+    imageTag: {{ .Values.image.tag }}
+  {{- if .Values.broker.service.gcpInternalLB }}
     cloud.google.com/load-balancer-type: Internal
   {{- end }}
   labels:

--- a/kubernetes/helm/pinot/templates/server/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/server/statefulset.yml
@@ -22,31 +22,31 @@ kind: StatefulSet
 metadata:
   name: {{ include "pinot.server.fullname" . }}
   labels:
-    app: {{ include "pinot.name" . }}
-    chart: {{ include "pinot.chart" . }}
-    component: {{ .Values.server.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "pinot.serverLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "pinot.name" . }}
-      release: {{ .Release.Name }}
-      component: {{ .Values.server.name }}
+      {{- include "pinot.serverMatchLabels" . | nindent 6 }}
   serviceName: {{ template "pinot.server.headless" . }}
   replicas: {{ .Values.server.replicaCount }}
   updateStrategy:
     type: {{ .Values.server.updateStrategy.type }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
   template:
     metadata:
       labels:
-        app: {{ include "pinot.name" . }}
-        release: {{ .Release.Name }}
-        component: {{ .Values.server.name }}
+        {{- include "pinot.serverLabels" . | nindent 8 }}
       annotations:
 {{ toYaml .Values.server.podAnnotations | indent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
       affinity:
@@ -55,6 +55,8 @@ spec:
 {{ toYaml .Values.server.tolerations | indent 8 }}
       containers:
       - name: server
+        securityContext:
+          {{- toYaml .Values.server.securityContext | nindent 10 }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [
@@ -70,12 +72,30 @@ spec:
 {{ toYaml .Values.server.extraEnv | indent 10 }}
 {{- end}}
         envFrom:
-{{ toYaml .Values.server.envFrom | indent 10 }}
+{{ toYaml .Values.server.envFrom | indent 10 }} 
         ports:
-          - containerPort: {{ .Values.server.ports.netty }}
-            protocol: TCP
-          - containerPort: {{ .Values.server.ports.admin }}
-            protocol: TCP
+          - containerPort: {{ .Values.server.service.nettyPort }}
+            protocol: {{ .Values.server.service.protocol }}
+            name: {{ .Values.server.service.nettyPortName }}
+          - containerPort: {{ .Values.server.service.adminPort }}
+            protocol: {{ .Values.server.service.protocol }}
+            name: {{ .Values.server.service.adminPortName }}
+        {{- if .Values.server.probes.livenessEnabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.server.probes.endpoint }}
+            port: {{ .Values.server.service.adminPort }}
+        {{- end }}
+        {{- if .Values.server.probes.livenessEnabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.server.probes.endpoint }}
+            port: {{ .Values.server.service.adminPort }}
+        {{- end }}
         volumeMounts:
           - name: config
             mountPath: /var/pinot/server/config

--- a/kubernetes/helm/pinot/templates/serviceaccount.yaml
+++ b/kubernetes/helm/pinot/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pinot.serviceAccountName" . }}
+  labels:
+    {{- include "pinot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -21,16 +21,52 @@
 
 image:
   repository: apachepinot/pinot
-  tag: latest
+  tag: latest # release-0.7.1
   pullPolicy: IfNotPresent
 
 cluster:
   name: pinot-quickstart
 
+imagePullSecrets: []
+
+terminationGracePeriodSeconds: 30
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+probes:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# ------------------------------------------------------------------------------
+# Pinot Controller:
+# ------------------------------------------------------------------------------
 controller:
   name: controller
-  port: 9000
   replicaCount: 1
+  podManagementPolicy: Parallel
+  podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext: {}
+
+  probes:
+    endpoint: "/health"
+    livenessEnabled: false
+    readinessEnabled: false
 
   persistence:
     enabled: true
@@ -54,18 +90,22 @@ controller:
 
   service:
     annotations: {}
-    clusterIP: ""
+    clusterIP: "None"
     externalIPs: []
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     type: ClusterIP
     port: 9000
     nodePort: ""
+    protocol: TCP
+    gcpInternalLB: false
+    name: controller
 
   external:
     enabled: true
     type: LoadBalancer
     port: 9000
+    gcpInternalLB: false
 
   resources: {}
 
@@ -101,12 +141,16 @@ controller:
       pinot.set.instance.id.to.hostname=true
       controller.task.scheduler.enabled=true
 
+# ------------------------------------------------------------------------------
+# Pinot Broker:
+# ------------------------------------------------------------------------------
 broker:
   name: broker
-
-  port: 8099
-
   replicaCount: 1
+  podManagementPolicy: Parallel
+  podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext: {}
 
   jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xloggc:/opt/pinot/gc-pinot-broker.log"
 
@@ -116,19 +160,28 @@ broker:
   routingTable:
     builderClass: random
 
+  probes:
+    endpoint: "/health"
+    livenessEnabled: true
+    readinessEnabled: true
+
   service:
     annotations: {}
-    clusterIP: ""
+    clusterIP: "None"
     externalIPs: []
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     type: ClusterIP
+    protocol: TCP
+    gcpInternalLB: false
     port: 8099
+    name: broker
     nodePort: ""
 
   external:
     enabled: true
     type: LoadBalancer
+    gcpInternalLB: false
     port: 8099
 
   resources: {}
@@ -164,14 +217,21 @@ broker:
     configs: |-
       pinot.set.instance.id.to.hostname=true
 
+# ------------------------------------------------------------------------------
+# Pinot Server:
+# ------------------------------------------------------------------------------
 server:
   name: server
-
-  ports:
-    netty: 8098
-    admin: 8097
-
   replicaCount: 1
+  podManagementPolicy: Parallel
+  podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext: {}
+
+  probes:
+    endpoint: "/health"
+    livenessEnabled: false
+    readinessEnabled: false
 
   dataDir: /var/pinot/server/data/index
   segmentTarDir: /var/pinot/server/data/segment
@@ -196,8 +256,14 @@ server:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     type: ClusterIP
-    port: 8098
+    nettyPort: 8098
+    nettyPortName: netty
+    adminPort: 8097
+    adminExposePort: 80
+    adminPortName: admin
     nodePort: ""
+    protocol: TCP
+    gcpInternalLB: false
 
   resources: {}
 
@@ -234,12 +300,21 @@ server:
       pinot.server.instance.realtime.alloc.offheap=true
       pinot.server.instance.currentDataTableVersion=2
 
+# ------------------------------------------------------------------------------
+# Pinot Minion:
+# ------------------------------------------------------------------------------
 minion:
   name: minion
-
-  port: 9514
-
   replicaCount: 1
+  podManagementPolicy: Parallel
+  podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext: {}
+
+  probes:
+    endpoint: "/health"
+    livenessEnabled: false
+    readinessEnabled: false
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xloggc:/opt/pinot/gc-pinot-minion.log"
@@ -264,6 +339,9 @@ minion:
     type: ClusterIP
     port: 9514
     nodePort: ""
+    protocol: TCP
+    gcpInternalLB: false
+    name: minion
 
   resources: {}
 
@@ -300,6 +378,8 @@ minion:
 
 # ------------------------------------------------------------------------------
 # Zookeeper:
+# NOTE: IN PRODUCTION USE CASES, IT's BEST TO USE ZOOKEEPER K8S OPERATOR
+# ref: https://github.com/pravega/zookeeper-operator#install-the-operator
 # ------------------------------------------------------------------------------
 
 zookeeper:


### PR DESCRIPTION
Update helm chart - Include security context, gracePeriod, etc.. and remove duplicates in helm

- Add `terminationGracePeriodSeconds` to broker, controller, minion, and server sts
- Use pinot `serviceAccountName`
- Allow custom `securityContext`
- Add `imagePullSecrets`
- Add container `securityContext`
- Add separate `livenessProbe` and `readinessProbe` for broker, controller, minion, and server 
- Allow creation of Internal GCP Load balancer for services
- etc.. and other refractoring changes and reduce duplication