### PR TITLE
Core Pinot Environment Provider Implementation Logic to fetch Failure…

### DIFF
--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -88,6 +88,12 @@
       <destName>plugins/pinot-file-system/pinot-s3/pinot-s3-${project.version}-shaded.jar</destName>
     </file>
     <!-- End Include Pinot File System Plugins-->
+    <!-- Start Include Pinot Environment Plugins-->
+    <file>
+      <source>${pinot.root}/pinot-plugins/pinot-environment/pinot-azure/target/pinot-azure-${project.version}-shaded.jar</source>
+      <destName>plugins/pinot-environment/pinot-azure/pinot-azure-${project.version}-shaded.jar</destName>
+    </file>
+    <!-- End Include Pinot Environment Plugins-->
     <!-- Start Include Pinot Input Format Plugins-->
     <file>
       <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-avro/target/pinot-avro-${project.version}-shaded.jar</source>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -40,26 +40,14 @@
         <dependency>
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-spi</artifactId>
-            <version>0.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-common</artifactId>
-            <version>0.8.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.11</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pinot-environment</artifactId>
+        <groupId>org.apache.pinot</groupId>
+        <version>0.7.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>pinot-azure</artifactId>
+    <name>Pinot Azure Environment</name>
+    <url>https://pinot.apache.org/</url>
+    <properties>
+        <pinot.root>${basedir}/../../..</pinot.root>
+        <phase.prop>package</phase.prop>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.pinot</groupId>
+            <artifactId>pinot-spi</artifactId>
+            <version>0.7.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pinot</groupId>
+            <artifactId>pinot-common</artifactId>
+            <version>0.7.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pinot-plugins/pinot-environment/pinot-azure/pom.xml
+++ b/pinot-plugins/pinot-environment/pinot-azure/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>pinot-environment</artifactId>
         <groupId>org.apache.pinot</groupId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>pinot-azure</artifactId>
@@ -40,13 +40,13 @@
         <dependency>
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-spi</artifactId>
-            <version>0.7.0-SNAPSHOT</version>
+            <version>0.8.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.pinot</groupId>
             <artifactId>pinot-common</artifactId>
-            <version>0.7.0-SNAPSHOT</version>
+            <version>0.8.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.SSLException;
+import javax.ws.rs.WebApplicationException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider;
+
+import static org.apache.pinot.common.utils.CommonConstants.*;
+
+/**
+ * Azure Environment Provider used to retrieve azure cloud specific instance configuration.
+ */
+public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
+  protected static final String MAX_RETRY = "maxRetry";
+  protected static final String IMDS_ENDPOINT = "imdsEndpoint";
+  protected static final String CONNECTION_TIMEOUT = "connectionTimeout";
+  protected static final String REQUEST_TIMEOUT = "requestTimeout";
+  private static final String COMPUTE = "compute";
+  private static final String METADATA = "Metadata";
+  private static final String TRUE = "true";
+  private int _maxRetry;
+  private String _imdsEndpoint;
+  private CloseableHttpClient _closeableHttpClient;
+
+  public AzureEnvironmentProvider() {
+  }
+
+  public void init(PinotConfiguration pinotConfiguration) throws NullPointerException, IllegalArgumentException {
+    Preconditions.checkArgument(0 < Integer.parseInt(pinotConfiguration.getProperty(MAX_RETRY)),
+         "maxRetry cannot be less than or equal to 0");
+    Preconditions.checkArgument(!StringUtils.isBlank(pinotConfiguration.getProperty(IMDS_ENDPOINT)),
+        "imdsEndpoint should not be null or empty");
+
+    _maxRetry = Integer.parseInt(pinotConfiguration.getProperty(MAX_RETRY));
+    _imdsEndpoint = pinotConfiguration.getProperty(IMDS_ENDPOINT);
+    int connectionTimeout = Integer.parseInt(pinotConfiguration.getProperty(CONNECTION_TIMEOUT));
+    int requestTimeout = Integer.parseInt(pinotConfiguration.getProperty(REQUEST_TIMEOUT));
+
+    final RequestConfig requestConfig = RequestConfig.custom()
+        .setConnectTimeout(connectionTimeout)
+        .setConnectionRequestTimeout(requestTimeout)
+        .build();
+
+    final HttpRequestRetryHandler httpRequestRetryHandler = (iOException, executionCount, httpContext) ->
+        !(executionCount >= _maxRetry
+            || iOException instanceof InterruptedIOException
+            || iOException instanceof UnknownHostException
+            || iOException instanceof SSLException
+            || HttpClientContext.adapt(httpContext).getRequest() instanceof HttpEntityEnclosingRequest);
+
+    _closeableHttpClient =
+        HttpClients.custom().setDefaultRequestConfig(requestConfig).setRetryHandler(httpRequestRetryHandler).build();
+  }
+
+
+  // Constructor for test purposes.
+  public AzureEnvironmentProvider(int maxRetry, String imdsEndpoint, CloseableHttpClient closeableHttpClient) {
+    Preconditions.checkArgument(maxRetry > 0, "maxRetry cannot be less than or equal to 0");
+    Preconditions.checkArgument(!StringUtils.isBlank(imdsEndpoint), "imdsEndpoint should not be null or empty");
+    _maxRetry = maxRetry;
+    _imdsEndpoint = imdsEndpoint;
+    _closeableHttpClient = Preconditions.checkNotNull(closeableHttpClient, "Closeable Http Client cannot be null");
+  }
+
+  /**
+   *
+   * Method for constructing custom pinot configuration used by the service invoking HelixServerStarter to update
+   * zookeeper node with custom instance configs.
+   * @param baseConfiguration Base configuration provided by the invoking service
+   * @return Custom Pinot Configuration
+   */
+  @Override
+  public PinotConfiguration getEnvironment(Map<String, Object> baseConfiguration) {
+    Map<String, Object> customPinotConfiguration = new HashMap<>(baseConfiguration);
+
+    // Populate failure domain information
+    customPinotConfiguration.put(INSTANCE_FAILURE_DOMAIN,  getFaultDomain());
+
+    return new PinotConfiguration(customPinotConfiguration);
+  }
+
+  // Utility used to query the azure instance metadata service (Azure IMDS) to fetch the fault domain information.
+  @VisibleForTesting
+  protected final String getFaultDomain() {
+    final String responsePayload = getAzureInstanceMetadata();
+
+    // For a sample response payload,
+    // check https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux
+    final ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      final JsonNode jsonNode = objectMapper.readTree(responsePayload);
+      final JsonNode computeNode = jsonNode.path(COMPUTE);
+
+      if (computeNode.isMissingNode()) {
+        throw new WebApplicationException(
+            "Compute node is missing in the payload. Cannot retrieve Failure Domain Information");
+      }
+      final JsonNode platformFailureDomainNode = computeNode.path(PLATFORM_FAULT_DOMAIN);
+      if (platformFailureDomainNode.isMissingNode() || !platformFailureDomainNode.isTextual()) {
+        throw new WebApplicationException("Json node platformFaultDomain is missing or is invalid.");
+      }
+      return platformFailureDomainNode.textValue();
+    } catch (IOException ex) {
+      throw new WebApplicationException(
+          String.format(
+              "Errors when parsing response payload from Azure Instance Metadata Service: %s", responsePayload), ex);
+    }
+  }
+
+  // Utility used to construct the HTTP Request and fetch corresponding response entity.
+  @VisibleForTesting
+  private String getAzureInstanceMetadata() {
+    HttpGet httpGet = new HttpGet(_imdsEndpoint);
+    httpGet.setHeader(METADATA, TRUE);
+
+    try {
+      final CloseableHttpResponse closeableHttpResponse = _closeableHttpClient.execute(httpGet);
+      if (closeableHttpResponse == null) {
+        throw new WebApplicationException("Response is null. Please verify the imds endpoint");
+      }
+      final StatusLine statusLine = closeableHttpResponse.getStatusLine();
+      final int statusCode = statusLine.getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        final String errorMsg = String.format(
+            "Failed to retrieve azure instance metadata. Response Status code: %s", statusCode);
+        throw new WebApplicationException(errorMsg);
+      }
+      return EntityUtils.toString(closeableHttpResponse.getEntity());
+    } catch (IOException ex) {
+      throw new WebApplicationException(
+          String.format("Failed to retrieve metadata from Azure Instance Metadata Service %s", _imdsEndpoint), ex);
+    }
+  }
+}

--- a/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
@@ -60,6 +60,7 @@ public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
   private int _maxRetry;
   private String _imdsEndpoint;
   private CloseableHttpClient _closeableHttpClient;
+  private static final String PLATFORM_FAULT_DOMAIN = "platformFaultDomain";
 
   public AzureEnvironmentProvider() {
   }

--- a/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
@@ -44,8 +44,6 @@ import org.apache.http.util.EntityUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider;
 
-import static org.apache.pinot.common.utils.CommonConstants.*;
-
 /**
  * Azure Environment Provider used to retrieve azure cloud specific instance configuration.
  */
@@ -56,7 +54,6 @@ public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
   protected static final String REQUEST_TIMEOUT = "requestTimeout";
   private static final String COMPUTE = "compute";
   private static final String METADATA = "Metadata";
-  private static final String TRUE = "true";
   private int _maxRetry;
   private String _imdsEndpoint;
   private CloseableHttpClient _closeableHttpClient;
@@ -151,7 +148,7 @@ public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
   @VisibleForTesting
   private String getAzureInstanceMetadata() {
     HttpGet httpGet = new HttpGet(_imdsEndpoint);
-    httpGet.setHeader(METADATA, TRUE);
+    httpGet.setHeader(METADATA, Boolean.TRUE.toString());
 
     try {
       final CloseableHttpResponse closeableHttpResponse = _closeableHttpClient.execute(httpGet);

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.provider;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.WebApplicationException;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import static org.apache.http.HttpStatus.*;
+import static org.apache.pinot.plugin.provider.AzureEnvironmentProvider.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+
+/**
+ * Unit test for {@link AzureEnvironmentProviderTest}
+ */
+public class AzureEnvironmentProviderTest {
+  private final static String IMDS_RESPONSE_FILE = "mock-imds-response.json";
+  private final static String IMDS_RESPONSE_WITHOUT_COMPUTE_INFO = "mock-imds-response-without-computenode.json";
+  private final static String IMDS_RESPONSE_WITHOUT_FAULT_DOMAIN_INFO = "mock-imds-response-without-faultDomain.json";
+  private final static String IMDS_ENDPOINT_VALUE = "http://169.254.169.254/metadata/instance?api-version=2020-09-01";
+
+  @Mock
+  private CloseableHttpClient _mockHttpClient;
+  @Mock
+  private CloseableHttpResponse _mockHttpResponse;
+  @Mock
+  private StatusLine _mockStatusLine;
+  @Mock
+  private HttpEntity _mockHttpEntity;
+
+  private AzureEnvironmentProvider _azureEnvironmentProvider;
+
+  private AzureEnvironmentProvider _azureEnvironmentProviderWithParams;
+
+  PinotConfiguration _pinotConfiguration;
+
+  @BeforeMethod
+  public void init() {
+    initMocks(this);
+    _pinotConfiguration = new PinotConfiguration(new HashMap<>());
+    _azureEnvironmentProvider = new AzureEnvironmentProvider();
+    _azureEnvironmentProviderWithParams = new AzureEnvironmentProvider(3, IMDS_ENDPOINT_VALUE, _mockHttpClient);
+  }
+
+  @Test
+  public void testFailureDomainRetrieval() throws IOException {
+    mockUtil();
+    when(_mockHttpEntity.getContent()).thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_FILE));
+    String failureDomain = _azureEnvironmentProviderWithParams.getFaultDomain();
+    Assert.assertEquals(failureDomain, "36");
+    verify(_mockHttpClient, times(1)).execute(any(HttpGet.class));
+    verify(_mockHttpResponse, times(1)).getStatusLine();
+    verify(_mockStatusLine, times(1)).getStatusCode();
+    verify(_mockHttpResponse, times(1)).getEntity();
+    verifyNoMoreInteractions(_mockHttpClient, _mockHttpResponse, _mockStatusLine);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "imdsEndpoint should not be null or empty")
+  public void testInvalidIMDSEndpoint() throws IllegalArgumentException {
+    Map<String, Object> map = _pinotConfiguration.toMap();
+    map.put(MAX_RETRY, "3");
+    map.put(IMDS_ENDPOINT, "");
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(map);
+    _azureEnvironmentProvider.init(pinotConfiguration);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+        expectedExceptionsMessageRegExp = "maxRetry cannot be less than or equal to 0")
+  public void testInvalidRetryCount() throws IllegalArgumentException {
+    Map<String, Object> map = _pinotConfiguration.toMap();
+    map.put(MAX_RETRY, "0");
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(map);
+    _azureEnvironmentProvider.init(pinotConfiguration);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class,
+      expectedExceptionsMessageRegExp = "Closeable Http Client cannot be null")
+  public void testInvalidHttpClient() throws IllegalArgumentException {
+    new AzureEnvironmentProvider(
+        3, IMDS_ENDPOINT_VALUE, null);
+  }
+
+  @Test(expectedExceptions = WebApplicationException.class,
+        expectedExceptionsMessageRegExp = "Compute node is missing in the payload. Cannot retrieve Failure Domain Information")
+  public void testMissingComputeNodeResponse() throws WebApplicationException, IOException {
+    mockUtil();
+    when(_mockHttpEntity.getContent())
+        .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_COMPUTE_INFO));
+    _azureEnvironmentProviderWithParams.getFaultDomain();
+  }
+
+  @Test(expectedExceptions = WebApplicationException.class,
+      expectedExceptionsMessageRegExp = "Json node platformFaultDomain is missing or is invalid.")
+  public void testMissingFaultDomainResponse() throws WebApplicationException, IOException {
+    mockUtil();
+    when(_mockHttpEntity.getContent())
+        .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_FAULT_DOMAIN_INFO));
+    _azureEnvironmentProviderWithParams.getFaultDomain();
+  }
+
+  @Test(expectedExceptions = WebApplicationException.class,
+      expectedExceptionsMessageRegExp = "Failed to retrieve azure instance metadata. Response Status code: " + SC_NOT_FOUND)
+  public void testIMDSCallFailure() throws WebApplicationException, IOException {
+    mockUtil();
+    when(_mockStatusLine.getStatusCode()).thenReturn(SC_NOT_FOUND);
+    _azureEnvironmentProviderWithParams.getFaultDomain();
+  }
+
+  // Mock Response utility method
+  private void mockUtil() throws IOException {
+    when(_mockHttpClient.execute(any(HttpGet.class))).thenReturn(_mockHttpResponse);
+    when(_mockHttpResponse.getStatusLine()).thenReturn(_mockStatusLine);
+    when(_mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+    when(_mockHttpResponse.getEntity()).thenReturn(_mockHttpEntity);
+  }
+}

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
 import static org.apache.http.HttpStatus.*;
 import static org.apache.pinot.plugin.provider.AzureEnvironmentProvider.*;
 import static org.mockito.Mockito.*;

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
@@ -75,7 +75,7 @@ public class AzureEnvironmentProviderTest {
   public void testFailureDomainRetrieval() throws IOException {
     mockUtil();
     when(_mockHttpEntity.getContent()).thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_FILE));
-    String failureDomain = _azureEnvironmentProviderWithParams.getFaultDomain();
+    String failureDomain = _azureEnvironmentProviderWithParams.getFailureDomain();
     Assert.assertEquals(failureDomain, "36");
     verify(_mockHttpClient, times(1)).execute(any(HttpGet.class));
     verify(_mockHttpResponse, times(1)).getStatusLine();
@@ -116,7 +116,7 @@ public class AzureEnvironmentProviderTest {
     mockUtil();
     when(_mockHttpEntity.getContent())
         .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_COMPUTE_INFO));
-    _azureEnvironmentProviderWithParams.getFaultDomain();
+    _azureEnvironmentProviderWithParams.getFailureDomain();
   }
 
   @Test(expectedExceptions = WebApplicationException.class,
@@ -125,7 +125,7 @@ public class AzureEnvironmentProviderTest {
     mockUtil();
     when(_mockHttpEntity.getContent())
         .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_FAULT_DOMAIN_INFO));
-    _azureEnvironmentProviderWithParams.getFaultDomain();
+    _azureEnvironmentProviderWithParams.getFailureDomain();
   }
 
   @Test(expectedExceptions = WebApplicationException.class,
@@ -133,7 +133,7 @@ public class AzureEnvironmentProviderTest {
   public void testIMDSCallFailure() throws WebApplicationException, IOException {
     mockUtil();
     when(_mockStatusLine.getStatusCode()).thenReturn(SC_NOT_FOUND);
-    _azureEnvironmentProviderWithParams.getFaultDomain();
+    _azureEnvironmentProviderWithParams.getFailureDomain();
   }
 
   // Mock Response utility method

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.plugin.provider;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.ws.rs.WebApplicationException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -85,8 +84,8 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class,
-        expectedExceptionsMessageRegExp = "imdsEndpoint should not be null or empty")
-  public void testInvalidIMDSEndpoint() throws IllegalArgumentException {
+      expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: imdsEndpoint should not be null or empty")
+  public void testInvalidIMDSEndpoint() {
     Map<String, Object> map = _pinotConfiguration.toMap();
     map.put(MAX_RETRY, "3");
     map.put(IMDS_ENDPOINT, "");
@@ -95,8 +94,8 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class,
-        expectedExceptionsMessageRegExp = "maxRetry cannot be less than or equal to 0")
-  public void testInvalidRetryCount() throws IllegalArgumentException {
+        expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: maxRetry cannot be less than or equal to 0")
+  public void testInvalidRetryCount() {
     Map<String, Object> map = _pinotConfiguration.toMap();
     map.put(MAX_RETRY, "0");
     PinotConfiguration pinotConfiguration = new PinotConfiguration(map);
@@ -104,33 +103,32 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = NullPointerException.class,
-      expectedExceptionsMessageRegExp = "Closeable Http Client cannot be null")
-  public void testInvalidHttpClient() throws IllegalArgumentException {
-    new AzureEnvironmentProvider(
-        3, IMDS_ENDPOINT_VALUE, null);
+      expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: Closeable Http Client cannot be null")
+  public void testInvalidHttpClient() {
+    new AzureEnvironmentProvider(3, IMDS_ENDPOINT_VALUE, null);
   }
 
-  @Test(expectedExceptions = WebApplicationException.class,
+  @Test(expectedExceptions = RuntimeException.class,
         expectedExceptionsMessageRegExp = "Compute node is missing in the payload. Cannot retrieve Failure Domain Information")
-  public void testMissingComputeNodeResponse() throws WebApplicationException, IOException {
+  public void testMissingComputeNodeResponse() throws IOException {
     mockUtil();
     when(_mockHttpEntity.getContent())
         .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_COMPUTE_INFO));
     _azureEnvironmentProviderWithParams.getFailureDomain();
   }
 
-  @Test(expectedExceptions = WebApplicationException.class,
+  @Test(expectedExceptions = RuntimeException.class,
       expectedExceptionsMessageRegExp = "Json node platformFaultDomain is missing or is invalid.")
-  public void testMissingFaultDomainResponse() throws WebApplicationException, IOException {
+  public void testMissingFaultDomainResponse() throws IOException {
     mockUtil();
     when(_mockHttpEntity.getContent())
         .thenReturn(getClass().getClassLoader().getResourceAsStream(IMDS_RESPONSE_WITHOUT_FAULT_DOMAIN_INFO));
     _azureEnvironmentProviderWithParams.getFailureDomain();
   }
 
-  @Test(expectedExceptions = WebApplicationException.class,
+  @Test(expectedExceptions = RuntimeException.class,
       expectedExceptionsMessageRegExp = "Failed to retrieve azure instance metadata. Response Status code: " + SC_NOT_FOUND)
-  public void testIMDSCallFailure() throws WebApplicationException, IOException {
+  public void testIMDSCallFailure() throws IOException {
     mockUtil();
     when(_mockStatusLine.getStatusCode()).thenReturn(SC_NOT_FOUND);
     _azureEnvironmentProviderWithParams.getFailureDomain();

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/java/org/apache/pinot/plugin/provider/AzureEnvironmentProviderTest.java
@@ -109,7 +109,8 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = RuntimeException.class,
-        expectedExceptionsMessageRegExp = "Compute node is missing in the payload. Cannot retrieve Failure Domain Information")
+      expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: Compute node is missing in the payload. "
+          + "Cannot retrieve failure domain information")
   public void testMissingComputeNodeResponse() throws IOException {
     mockUtil();
     when(_mockHttpEntity.getContent())
@@ -118,7 +119,8 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = RuntimeException.class,
-      expectedExceptionsMessageRegExp = "Json node platformFaultDomain is missing or is invalid.")
+      expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: Json node platformFaultDomain is missing or is invalid."
+          + " No failure domain information retrieved for given server instance")
   public void testMissingFaultDomainResponse() throws IOException {
     mockUtil();
     when(_mockHttpEntity.getContent())
@@ -127,7 +129,8 @@ public class AzureEnvironmentProviderTest {
   }
 
   @Test(expectedExceptions = RuntimeException.class,
-      expectedExceptionsMessageRegExp = "Failed to retrieve azure instance metadata. Response Status code: " + SC_NOT_FOUND)
+      expectedExceptionsMessageRegExp = "\\[AzureEnvironmentProvider\\]: Failed to retrieve azure instance metadata."
+          + " Response Status code: " + SC_NOT_FOUND)
   public void testIMDSCallFailure() throws IOException {
     mockUtil();
     when(_mockStatusLine.getStatusCode()).thenReturn(SC_NOT_FOUND);

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response-without-computenode.json
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response-without-computenode.json
@@ -1,0 +1,118 @@
+{
+  "computer": {
+    "azEnvironment": "AZUREPUBLICCLOUD",
+    "isHostCompatibilityLayerVm": "true",
+    "licenseType":  "Windows_Client",
+    "location": "westus",
+    "name": "examplevmname",
+    "offer": "Windows",
+    "osProfile": {
+      "adminUsername": "admin",
+      "computerName": "examplevmname",
+      "disablePasswordAuthentication": "true"
+    },
+    "osType": "linux",
+    "placementGroupId": "f67c14ab-e92c-408c-ae2d-da15866ec79a",
+    "plan": {
+      "name": "planName",
+      "product": "planProduct",
+      "publisher": "planPublisher"
+    },
+    "platformFaultDomain": "36",
+    "platformUpdateDomain": "42",
+    "publicKeys": [{
+      "keyData": "ssh-rsa 0",
+      "path": "/home/user/.ssh/authorized_keys0"
+    },
+      {
+        "keyData": "ssh-rsa 1",
+        "path": "/home/user/.ssh/authorized_keys1"
+      }
+    ],
+    "publisher": "RDFE-Test-Microsoft-Windows-Server-Group",
+    "resourceGroupName": "macikgo-test-may-23",
+    "resourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/virtualMachines/examplevmname",
+    "securityProfile": {
+      "secureBootEnabled": "true",
+      "virtualTpmEnabled": "false"
+    },
+    "sku": "Windows-Server-2012-R2-Datacenter",
+    "storageProfile": {
+      "dataDisks": [{
+        "caching": "None",
+        "createOption": "Empty",
+        "diskSizeGB": "1024",
+        "image": {
+          "uri": ""
+        },
+        "lun": "0",
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampledatadiskname",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }],
+      "imageReference": {
+        "id": "",
+        "offer": "UbuntuServer",
+        "publisher": "Canonical",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "osDisk": {
+        "caching": "ReadWrite",
+        "createOption": "FromImage",
+        "diskSizeGB": "30",
+        "diffDiskSettings": {
+          "option": "Local"
+        },
+        "encryptionSettings": {
+          "enabled": "false"
+        },
+        "image": {
+          "uri": ""
+        },
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampleosdiskname",
+        "osType": "Linux",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }
+    },
+    "subscriptionId": "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "tags": "baz:bash;foo:bar",
+    "version": "15.05.22",
+    "vmId": "02aab8a4-74ef-476e-8182-f6d2ba4166a6",
+    "vmScaleSetName": "crpteste9vflji9",
+    "vmSize": "Standard_A3",
+    "zone": ""
+  },
+  "network": {
+    "interface": [{
+      "ipv4": {
+        "ipAddress": [{
+          "privateIpAddress": "10.144.133.132",
+          "publicIpAddress": ""
+        }],
+        "subnet": [{
+          "address": "10.144.133.128",
+          "prefix": "26"
+        }]
+      },
+      "ipv6": {
+        "ipAddress": [
+        ]
+      },
+      "macAddress": "0011AAFFBB22"
+    }]
+  }
+}

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response-without-faultDomain.json
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response-without-faultDomain.json
@@ -1,0 +1,118 @@
+{
+  "compute": {
+    "azEnvironment": "AZUREPUBLICCLOUD",
+    "isHostCompatibilityLayerVm": "true",
+    "licenseType":  "Windows_Client",
+    "location": "westus",
+    "name": "examplevmname",
+    "offer": "Windows",
+    "osProfile": {
+      "adminUsername": "admin",
+      "computerName": "examplevmname",
+      "disablePasswordAuthentication": "true"
+    },
+    "osType": "linux",
+    "placementGroupId": "f67c14ab-e92c-408c-ae2d-da15866ec79a",
+    "plan": {
+      "name": "planName",
+      "product": "planProduct",
+      "publisher": "planPublisher"
+    },
+    "platformFailureDomain": "36",
+    "platformUpdateDomain": "42",
+    "publicKeys": [{
+      "keyData": "ssh-rsa 0",
+      "path": "/home/user/.ssh/authorized_keys0"
+    },
+      {
+        "keyData": "ssh-rsa 1",
+        "path": "/home/user/.ssh/authorized_keys1"
+      }
+    ],
+    "publisher": "RDFE-Test-Microsoft-Windows-Server-Group",
+    "resourceGroupName": "macikgo-test-may-23",
+    "resourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/virtualMachines/examplevmname",
+    "securityProfile": {
+      "secureBootEnabled": "true",
+      "virtualTpmEnabled": "false"
+    },
+    "sku": "Windows-Server-2012-R2-Datacenter",
+    "storageProfile": {
+      "dataDisks": [{
+        "caching": "None",
+        "createOption": "Empty",
+        "diskSizeGB": "1024",
+        "image": {
+          "uri": ""
+        },
+        "lun": "0",
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampledatadiskname",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }],
+      "imageReference": {
+        "id": "",
+        "offer": "UbuntuServer",
+        "publisher": "Canonical",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "osDisk": {
+        "caching": "ReadWrite",
+        "createOption": "FromImage",
+        "diskSizeGB": "30",
+        "diffDiskSettings": {
+          "option": "Local"
+        },
+        "encryptionSettings": {
+          "enabled": "false"
+        },
+        "image": {
+          "uri": ""
+        },
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampleosdiskname",
+        "osType": "Linux",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }
+    },
+    "subscriptionId": "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "tags": "baz:bash;foo:bar",
+    "version": "15.05.22",
+    "vmId": "02aab8a4-74ef-476e-8182-f6d2ba4166a6",
+    "vmScaleSetName": "crpteste9vflji9",
+    "vmSize": "Standard_A3",
+    "zone": ""
+  },
+  "network": {
+    "interface": [{
+      "ipv4": {
+        "ipAddress": [{
+          "privateIpAddress": "10.144.133.132",
+          "publicIpAddress": ""
+        }],
+        "subnet": [{
+          "address": "10.144.133.128",
+          "prefix": "26"
+        }]
+      },
+      "ipv6": {
+        "ipAddress": [
+        ]
+      },
+      "macAddress": "0011AAFFBB22"
+    }]
+  }
+}

--- a/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response.json
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/test/resources/mock-imds-response.json
@@ -1,0 +1,118 @@
+{
+  "compute": {
+    "azEnvironment": "AZUREPUBLICCLOUD",
+    "isHostCompatibilityLayerVm": "true",
+    "licenseType":  "Windows_Client",
+    "location": "westus",
+    "name": "examplevmname",
+    "offer": "Windows",
+    "osProfile": {
+      "adminUsername": "admin",
+      "computerName": "examplevmname",
+      "disablePasswordAuthentication": "true"
+    },
+    "osType": "linux",
+    "placementGroupId": "f67c14ab-e92c-408c-ae2d-da15866ec79a",
+    "plan": {
+      "name": "planName",
+      "product": "planProduct",
+      "publisher": "planPublisher"
+    },
+    "platformFaultDomain": "36",
+    "platformUpdateDomain": "42",
+    "publicKeys": [{
+      "keyData": "ssh-rsa 0",
+      "path": "/home/user/.ssh/authorized_keys0"
+    },
+      {
+        "keyData": "ssh-rsa 1",
+        "path": "/home/user/.ssh/authorized_keys1"
+      }
+    ],
+    "publisher": "RDFE-Test-Microsoft-Windows-Server-Group",
+    "resourceGroupName": "macikgo-test-may-23",
+    "resourceId": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/virtualMachines/examplevmname",
+    "securityProfile": {
+      "secureBootEnabled": "true",
+      "virtualTpmEnabled": "false"
+    },
+    "sku": "Windows-Server-2012-R2-Datacenter",
+    "storageProfile": {
+      "dataDisks": [{
+        "caching": "None",
+        "createOption": "Empty",
+        "diskSizeGB": "1024",
+        "image": {
+          "uri": ""
+        },
+        "lun": "0",
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampledatadiskname",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }],
+      "imageReference": {
+        "id": "",
+        "offer": "UbuntuServer",
+        "publisher": "Canonical",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "osDisk": {
+        "caching": "ReadWrite",
+        "createOption": "FromImage",
+        "diskSizeGB": "30",
+        "diffDiskSettings": {
+          "option": "Local"
+        },
+        "encryptionSettings": {
+          "enabled": "false"
+        },
+        "image": {
+          "uri": ""
+        },
+        "managedDisk": {
+          "id": "/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname",
+          "storageAccountType": "Standard_LRS"
+        },
+        "name": "exampleosdiskname",
+        "osType": "Linux",
+        "vhd": {
+          "uri": ""
+        },
+        "writeAcceleratorEnabled": "false"
+      }
+    },
+    "subscriptionId": "xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx",
+    "tags": "baz:bash;foo:bar",
+    "version": "15.05.22",
+    "vmId": "02aab8a4-74ef-476e-8182-f6d2ba4166a6",
+    "vmScaleSetName": "crpteste9vflji9",
+    "vmSize": "Standard_A3",
+    "zone": ""
+  },
+  "network": {
+    "interface": [{
+      "ipv4": {
+        "ipAddress": [{
+          "privateIpAddress": "10.144.133.132",
+          "publicIpAddress": ""
+        }],
+        "subnet": [{
+          "address": "10.144.133.128",
+          "prefix": "26"
+        }]
+      },
+      "ipv6": {
+        "ipAddress": [
+        ]
+      },
+      "macAddress": "0011AAFFBB22"
+    }]
+  }
+}

--- a/pinot-plugins/pinot-environment/pom.xml
+++ b/pinot-plugins/pinot-environment/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>pinot-plugins</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pinot-plugins/pinot-environment/pom.xml
+++ b/pinot-plugins/pinot-environment/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-plugins</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.7.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pinot-environment</artifactId>
+  <packaging>pom</packaging>
+  <name>Pluggable Pinot Environment Provider </name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <plugin.type>pinot-environment</plugin.type>
+  </properties>
+
+  <modules>
+    <module>pinot-azure</module>
+  </modules>
+
+  <dependencies>
+    <!-- test -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -48,6 +48,7 @@
     <module>pinot-metrics</module>
     <module>pinot-segment-writer</module>
     <module>pinot-segment-uploader</module>
+    <module>pinot-environment</module>
   </modules>
 
   <dependencies>

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -76,18 +76,16 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.Instance;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.CommonConstants.Server.SegmentCompletionProtocol;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider.*;
-import static org.apache.pinot.spi.utils.CommonConstants.*;
-import static org.apache.pinot.spi.utils.CommonConstants.Helix.*;
-import static org.apache.pinot.spi.utils.CommonConstants.Server.*;
 
 /**
  * Starter for Pinot server.
@@ -110,9 +108,10 @@ import static org.apache.pinot.spi.utils.CommonConstants.Server.*;
  */
 public class HelixServerStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixServerStarter.class);
+
   private final String _helixClusterName;
   private final String _zkAddress;
-  private PinotConfiguration _serverConf;
+  private final PinotConfiguration _serverConf;
   private final List<ListenerConfig> _listenerConfigs;
   private final String _host;
   private final int _port;
@@ -124,23 +123,25 @@ public class HelixServerStarter implements ServiceStartable {
   private AdminApiApplication _adminApiApplication;
   private ServerQueriesDisabledTracker _serverQueriesDisabledTracker;
   private RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
+  private static Map<String, Map<String, String>> environmentSpecificMapFields = new HashMap<>();
 
-  public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf) throws Exception {
+  public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf)
+      throws Exception {
     _helixClusterName = helixClusterName;
     _zkAddress = zkAddress;
     // Make a clone so that changes to the config won't propagate to the caller
     _serverConf = serverConf.clone();
     _listenerConfigs = ListenerConfigUtil.buildServerAdminConfigs(_serverConf);
 
-    _host = _serverConf.getProperty(KEY_OF_SERVER_NETTY_HOST,
-        _serverConf.getProperty(SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
+    _host = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_HOST,
+        _serverConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
             : NetUtils.getHostAddress());
-    _port = _serverConf.getProperty(KEY_OF_SERVER_NETTY_PORT, DEFAULT_SERVER_NETTY_PORT);
+    _port = _serverConf.getProperty(Helix.KEY_OF_SERVER_NETTY_PORT, Helix.DEFAULT_SERVER_NETTY_PORT);
 
-    String instanceId = _serverConf.getProperty(CONFIG_OF_INSTANCE_ID);
+    String instanceId = _serverConf.getProperty(Server.CONFIG_OF_INSTANCE_ID);
     if (instanceId == null) {
-      instanceId = PREFIX_OF_SERVER_INSTANCE + _host + "_" + _port;
-      _serverConf.addProperty(CONFIG_OF_INSTANCE_ID, instanceId);
+      instanceId = Helix.PREFIX_OF_SERVER_INSTANCE + _host + "_" + _port;
+      _serverConf.addProperty(Server.CONFIG_OF_INSTANCE_ID, instanceId);
     }
     _instanceId = instanceId;
 
@@ -148,23 +149,57 @@ public class HelixServerStarter implements ServiceStartable {
         new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT, _helixClusterName).forParticipant(_instanceId)
             .build();
 
-    // Invoke pinot environment provider factory's init method to register the environment provider
-    for (String key : _serverConf.toMap().keySet()) {
-      if (key.startsWith(PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY.toLowerCase())) {
-        PinotConfiguration environmentProviderConfigs = _serverConf.subset(PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
-        PinotEnvironmentProviderFactory.init(environmentProviderConfigs);
-        break;
-      }
-    }
+    // Fetch Environment Specific Configs
+    fetchEnvironmentSpecificConfigs();
 
     // Enable/disable thread CPU time measurement through instance config.
     ThreadTimer.setThreadCpuTimeMeasurementEnabled(_serverConf
-        .getProperty(CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT,
-            DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
+        .getProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT,
+            Server.DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
 
     // Set data table version send to broker.
     DataTableBuilder.setCurrentDataTableVersion(_serverConf
-        .getProperty(CONFIG_OF_CURRENT_DATA_TABLE_VERSION, DEFAULT_CURRENT_DATA_TABLE_VERSION));
+        .getProperty(Server.CONFIG_OF_CURRENT_DATA_TABLE_VERSION,
+            Server.DEFAULT_CURRENT_DATA_TABLE_VERSION));
+  }
+
+  /**
+   *  Invoke pinot environment provider factory's init method to register the environment provider &
+   *  fetch the overridden server configs for the invoked environment provider.
+   */
+  private void fetchEnvironmentSpecificConfigs() {
+    PinotConfiguration environmentProviderConfigs = _serverConf.subset(
+        Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
+
+    if (environmentProviderConfigs.toMap().isEmpty()) {
+      LOGGER.info("No Environment Provider Configs found.");
+      return;
+    }
+
+    PinotEnvironmentProviderFactory.init(environmentProviderConfigs);
+    String environmentProviderClassName = _serverConf.getProperty(Server.ENVIRONMENT_PROVIDER_CLASS_NAME);
+    if (environmentProviderClassName == null) {
+      LOGGER.info("No Class Name provided for Environment Provider.");
+      return;
+    }
+
+    // Fetch environment provider instance
+    PinotEnvironmentProvider pinotEnvironmentProvider = PinotEnvironmentProviderFactory.getEnvironmentProvider(
+        environmentProviderClassName.toLowerCase());
+
+    // Fetch the overridden pinot configuration containing custom configs.
+    Map<String, Object> overriddenPinotConfigs = pinotEnvironmentProvider.getEnvironment();
+
+    // Populate environment specific fields in the map.
+    String failureDomain = (String)overriddenPinotConfigs.get(PinotEnvironmentProvider.INSTANCE_FAILURE_DOMAIN);
+    if (failureDomain == null) {
+      LOGGER.info("No failure domain information found for instance: {}", _instanceId);
+      return;
+    }
+
+    Map<String, String> failureDomainMap = new HashMap<>();
+    failureDomainMap.put(CommonConstants.FAILURE_DOMAIN_IDENTIFIER, failureDomain);
+    environmentSpecificMapFields.put(CommonConstants.ENVIRONMENT_IDENTIFIER, failureDomainMap);
   }
 
   /**
@@ -172,10 +207,11 @@ public class HelixServerStarter implements ServiceStartable {
    */
   private void registerServiceStatusHandler() {
     double minResourcePercentForStartup = _serverConf
-        .getProperty(CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START, DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START);
+        .getProperty(Server.CONFIG_OF_SERVER_MIN_RESOURCE_PERCENT_FOR_START,
+            Server.DEFAULT_SERVER_MIN_RESOURCE_PERCENT_FOR_START);
     int realtimeConsumptionCatchupWaitMs = _serverConf
-        .getProperty(CONFIG_OF_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS,
-            DEFAULT_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS);
+        .getProperty(Server.CONFIG_OF_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS,
+            Server.DEFAULT_STARTUP_REALTIME_CONSUMPTION_CATCHUP_WAIT_MS);
 
     // collect all resources which have this instance in the ideal state
     List<String> resourcesToMonitor = new ArrayList<>();
@@ -240,7 +276,7 @@ public class HelixServerStarter implements ServiceStartable {
         instanceConfig.addTag(TagNameUtils.getOfflineTagForTenant(null));
         instanceConfig.addTag(TagNameUtils.getRealtimeTagForTenant(null));
       } else {
-        instanceConfig.addTag(UNTAGGED_SERVER_INSTANCE);
+        instanceConfig.addTag(Helix.UNTAGGED_SERVER_INSTANCE);
       }
       needToUpdateInstanceConfig = true;
     }
@@ -273,31 +309,20 @@ public class HelixServerStarter implements ServiceStartable {
         "Failed to update instance config");
   }
 
-  // Fetch the overridden server configs for the invoked environment provider
-  private void populateFailureDomain() {
-    String className = _serverConf.getProperty(ENVIRONMENT_PROVIDER_CLASS_NAME);
-    if (className == null) return;
-    PinotEnvironmentProvider pinotEnvironmentProvider = PinotEnvironmentProviderFactory.getEnvironmentProvider(className.toLowerCase());
-    _serverConf = pinotEnvironmentProvider.getEnvironment(_serverConf.toMap());
-    Map<String, Object> overriddenPinotConfigurationMap = _serverConf.toMap();
-    String failureDomain = overriddenPinotConfigurationMap.containsKey(INSTANCE_FAILURE_DOMAIN.toLowerCase()) ?
-        String.valueOf(overriddenPinotConfigurationMap.get(INSTANCE_FAILURE_DOMAIN.toLowerCase())) : null;
-    if (failureDomain == null) {
-      LOGGER.info("No failure domain information found for instance: {}", _instanceId);
+  // Update instance configs with environment specific properties
+  private void updateInstanceConfigWithEnvironmentSpecificConfigs() {
+    InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(_helixClusterName, _instanceId);
+    if (environmentSpecificMapFields.size() == 0) {
+      LOGGER.info("No environment properties found to update the instance config.");
       return;
     }
-    Map<String, String> failureDomainMap = new HashMap<>();
-    failureDomainMap.put(FAILURE_DOMAIN_IDENTIFIER, failureDomain);
-    Map<String, Map<String, String>> environmentSpecificMapFields = new HashMap<>();
-    environmentSpecificMapFields.put(ENVIRONMENT_IDENTIFIER, failureDomainMap);
 
-    InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(_helixClusterName, _instanceId);
     instanceConfig.getRecord().setMapFields(environmentSpecificMapFields);
     HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
     Preconditions.checkState(
         helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().instanceConfig(_instanceId), instanceConfig),
-        "Failed to update instance config");
-    LOGGER.info("Updated instance config for instance: {} with failure domain information", _instanceId);
+        "Failed to update instance config with environment properties");
+    LOGGER.info("Updated instance config for instance: {} with environment specific properties", _instanceId);
   }
 
   private void setupHelixSystemProperties() {
@@ -305,7 +330,7 @@ public class HelixServerStarter implements ServiceStartable {
     // from ZooKeeper). Setting flapping time window to a small value can avoid this from happening. Helix ignores the
     // non-positive value, so set the default value as 1.
     System.setProperty(SystemPropertyKeys.FLAPPING_TIME_WINDOW,
-        _serverConf.getProperty(CONFIG_OF_SERVER_FLAPPING_TIME_WINDOW_MS, DEFAULT_FLAPPING_TIME_WINDOW_MS));
+        _serverConf.getProperty(Helix.CONFIG_OF_SERVER_FLAPPING_TIME_WINDOW_MS, Helix.DEFAULT_FLAPPING_TIME_WINDOW_MS));
   }
 
   /**
@@ -316,8 +341,8 @@ public class HelixServerStarter implements ServiceStartable {
   private void startupServiceStatusCheck(long endTimeMs) {
     LOGGER.info("Starting startup service status check");
     long startTimeMs = System.currentTimeMillis();
-    long checkIntervalMs = _serverConf.getProperty(CONFIG_OF_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS,
-        DEFAULT_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS);
+    long checkIntervalMs = _serverConf.getProperty(Server.CONFIG_OF_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS,
+        Server.DEFAULT_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS);
 
     while (System.currentTimeMillis() < endTimeMs) {
       Status serviceStatus = ServiceStatus.getServiceStatus();
@@ -395,10 +420,12 @@ public class HelixServerStarter implements ServiceStartable {
     _helixManager.connect();
     _helixAdmin = _helixManager.getClusterManagmentTool();
     updateInstanceConfigIfNeeded(_host, _port);
-    populateFailureDomain();
+
+    updateInstanceConfigWithEnvironmentSpecificConfigs();
+
     // Start restlet server for admin API endpoint
     String accessControlFactoryClass =
-        _serverConf.getProperty(ACCESS_CONTROL_FACTORY_CLASS, DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
+        _serverConf.getProperty(Server.ACCESS_CONTROL_FACTORY_CLASS, Server.DEFAULT_ACCESS_CONTROL_FACTORY_CLASS);
     LOGGER.info("Using class: {} as the AccessControlFactory", accessControlFactoryClass);
     final AccessControlFactory accessControlFactory;
     try {
@@ -456,21 +483,21 @@ public class HelixServerStarter implements ServiceStartable {
     _helixManager.getMessagingService()
         .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(), messageHandlerFactory);
 
-    serverMetrics.addCallbackGauge(INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
+    serverMetrics.addCallbackGauge(Helix.INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
     _helixManager
         .addPreConnectCallback(() -> serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
 
     // Register the service status handler
     registerServiceStatusHandler();
 
-    if (_serverConf.getProperty(CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK,
-        DEFAULT_STARTUP_ENABLE_SERVICE_STATUS_CHECK)) {
+    if (_serverConf.getProperty(Server.CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK,
+        Server.DEFAULT_STARTUP_ENABLE_SERVICE_STATUS_CHECK)) {
       long endTimeMs =
-          startTimeMs + _serverConf.getProperty(CONFIG_OF_STARTUP_TIMEOUT_MS, DEFAULT_STARTUP_TIMEOUT_MS);
+          startTimeMs + _serverConf.getProperty(Server.CONFIG_OF_STARTUP_TIMEOUT_MS, Server.DEFAULT_STARTUP_TIMEOUT_MS);
       startupServiceStatusCheck(endTimeMs);
     }
     _helixAdmin.setConfig(_instanceConfigScope,
-        Collections.singletonMap(IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(false)));
+        Collections.singletonMap(Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(false)));
     LOGGER.info("Pinot server ready");
 
     // Create metrics for mmap stuff
@@ -501,18 +528,18 @@ public class HelixServerStarter implements ServiceStartable {
     }
     _adminApiApplication.stop();
     _helixAdmin.setConfig(_instanceConfigScope,
-        Collections.singletonMap(IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true)));
+        Collections.singletonMap(Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true)));
 
     long endTimeMs =
-        startTimeMs + _serverConf.getProperty(CONFIG_OF_SHUTDOWN_TIMEOUT_MS, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+        startTimeMs + _serverConf.getProperty(Server.CONFIG_OF_SHUTDOWN_TIMEOUT_MS, Server.DEFAULT_SHUTDOWN_TIMEOUT_MS);
     if (_serverConf
-        .getProperty(CONFIG_OF_SHUTDOWN_ENABLE_QUERY_CHECK, DEFAULT_SHUTDOWN_ENABLE_QUERY_CHECK)) {
+        .getProperty(Server.CONFIG_OF_SHUTDOWN_ENABLE_QUERY_CHECK, Server.DEFAULT_SHUTDOWN_ENABLE_QUERY_CHECK)) {
       shutdownQueryCheck(endTimeMs);
     }
     _helixManager.disconnect();
     _serverInstance.shutDown();
     if (_serverConf
-        .getProperty(CONFIG_OF_SHUTDOWN_ENABLE_RESOURCE_CHECK, DEFAULT_SHUTDOWN_ENABLE_RESOURCE_CHECK)) {
+        .getProperty(Server.CONFIG_OF_SHUTDOWN_ENABLE_RESOURCE_CHECK, Server.DEFAULT_SHUTDOWN_ENABLE_RESOURCE_CHECK)) {
       shutdownResourceCheck(endTimeMs);
     }
     _serverQueriesDisabledTracker.stop();
@@ -532,8 +559,8 @@ public class HelixServerStarter implements ServiceStartable {
     long startTimeMs = System.currentTimeMillis();
 
     long maxQueryTimeMs =
-        _serverConf.getProperty(CONFIG_OF_QUERY_EXECUTOR_TIMEOUT, DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
-    long noQueryThresholdMs = _serverConf.getProperty(CONFIG_OF_SHUTDOWN_NO_QUERY_THRESHOLD_MS, maxQueryTimeMs);
+        _serverConf.getProperty(Server.CONFIG_OF_QUERY_EXECUTOR_TIMEOUT, Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    long noQueryThresholdMs = _serverConf.getProperty(Server.CONFIG_OF_SHUTDOWN_NO_QUERY_THRESHOLD_MS, maxQueryTimeMs);
 
     // Wait until no incoming queries
     boolean noIncomingQueries = false;
@@ -613,8 +640,8 @@ public class HelixServerStarter implements ServiceStartable {
         }
       }
 
-      long checkIntervalMs = _serverConf.getProperty(CONFIG_OF_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS,
-          DEFAULT_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS);
+      long checkIntervalMs = _serverConf.getProperty(Server.CONFIG_OF_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS,
+          Server.DEFAULT_SHUTDOWN_RESOURCE_CHECK_INTERVAL_MS);
       while (System.currentTimeMillis() < endTimeMs) {
         Iterator<String> iterator = resourcesToMonitor.iterator();
         String currentResource = null;
@@ -699,9 +726,9 @@ public class HelixServerStarter implements ServiceStartable {
       throws Exception {
     Map<String, Object> properties = new HashMap<>();
     int port = 8003;
-    properties.put(KEY_OF_SERVER_NETTY_PORT, port);
-    properties.put(CONFIG_OF_INSTANCE_DATA_DIR, "/tmp/PinotServer/test" + port + "/index");
-    properties.put(CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, "/tmp/PinotServer/test" + port + "/segmentTar");
+    properties.put(Helix.KEY_OF_SERVER_NETTY_PORT, port);
+    properties.put(Server.CONFIG_OF_INSTANCE_DATA_DIR, "/tmp/PinotServer/test" + port + "/index");
+    properties.put(Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, "/tmp/PinotServer/test" + port + "/segmentTar");
 
     HelixServerStarter serverStarter =
         new HelixServerStarter("quickstart", "localhost:2191", new PinotConfiguration(properties));

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -234,7 +234,7 @@ public class HelixServerStarter implements ServiceStartable {
   }
 
     private void updateInstanceConfigWithMapFieldsIfNeeded(PinotConfiguration overriddenServerConfigs) {
-    if (overriddenServerConfigs.equals(_serverConf)) return;
+    if (overriddenServerConfigs == null || overriddenServerConfigs.equals(_serverConf)) return;
     Map<String, Object> pinotConfigurationMap = overriddenServerConfigs.toMap();
     String failureDomain = pinotConfigurationMap.containsKey(INSTANCE_FAILURE_DOMAIN) ?
         String.valueOf(pinotConfigurationMap.get(INSTANCE_FAILURE_DOMAIN)) : null;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -89,7 +89,6 @@ import static org.apache.pinot.spi.utils.CommonConstants.*;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.*;
 import static org.apache.pinot.spi.utils.CommonConstants.Server.*;
 
-
 /**
  * Starter for Pinot server.
  * <p>When the server starts for the first time, it will automatically join the Helix cluster with the default tag.
@@ -131,7 +130,6 @@ public class HelixServerStarter implements ServiceStartable {
     _zkAddress = zkAddress;
     // Make a clone so that changes to the config won't propagate to the caller
     _serverConf = serverConf.clone();
-
     _listenerConfigs = ListenerConfigUtil.buildServerAdminConfigs(_serverConf);
 
     _host = _serverConf.getProperty(KEY_OF_SERVER_NETTY_HOST,
@@ -276,8 +274,9 @@ public class HelixServerStarter implements ServiceStartable {
   }
 
   // Fetch the overridden server configs for the invoked environment provider
-  private String populateFailureDomain() {
+  private void populateFailureDomain() {
     String className = _serverConf.getProperty(ENVIRONMENT_PROVIDER_CLASS_NAME);
+    if (className == null) return;
     PinotEnvironmentProvider pinotEnvironmentProvider = PinotEnvironmentProviderFactory.getEnvironmentProvider(className.toLowerCase());
     _serverConf = pinotEnvironmentProvider.getEnvironment(_serverConf.toMap());
     Map<String, Object> overriddenPinotConfigurationMap = _serverConf.toMap();
@@ -285,7 +284,7 @@ public class HelixServerStarter implements ServiceStartable {
         String.valueOf(overriddenPinotConfigurationMap.get(INSTANCE_FAILURE_DOMAIN.toLowerCase())) : null;
     if (failureDomain == null) {
       LOGGER.info("No failure domain information found for instance: {}", _instanceId);
-      return null;
+      return;
     }
     Map<String, String> failureDomainMap = new HashMap<>();
     failureDomainMap.put(FAILURE_DOMAIN_IDENTIFIER, failureDomain);
@@ -299,7 +298,6 @@ public class HelixServerStarter implements ServiceStartable {
         helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().instanceConfig(_instanceId), instanceConfig),
         "Failed to update instance config");
     LOGGER.info("Updated instance config for instance: {} with failure domain information", _instanceId);
-    return failureDomain;
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -124,7 +124,7 @@ public class HelixServerStarter implements ServiceStartable {
   private AdminApiApplication _adminApiApplication;
   private ServerQueriesDisabledTracker _serverQueriesDisabledTracker;
   private RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
-  private Map<String, String> _environmentProperties;
+  private PinotEnvironmentProvider _pinotEnvironmentProvider;
 
   public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf)
       throws Exception {
@@ -150,8 +150,8 @@ public class HelixServerStarter implements ServiceStartable {
         new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT, _helixClusterName).forParticipant(_instanceId)
             .build();
 
-    // Fetch Environment Specific Properties
-    _environmentProperties = fetchEnvironmentProperties();
+    // Initialize Pinot Environment Provider
+    _pinotEnvironmentProvider = initializePinotEnvironmentProvider();
 
     // Enable/disable thread CPU time measurement through instance config.
     ThreadTimer.setThreadCpuTimeMeasurementEnabled(_serverConf
@@ -166,20 +166,20 @@ public class HelixServerStarter implements ServiceStartable {
 
   /**
    *  Invoke pinot environment provider factory's init method to register the environment provider &
-   *  fetch the overridden server configs for the invoked environment provider.
+   *  return the instantiated environment provider.
    */
   @Nullable
-  private Map<String, String> fetchEnvironmentProperties() {
-    PinotConfiguration environmentProviderConfigs = _serverConf.subset(
-        Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
-
+  private PinotEnvironmentProvider initializePinotEnvironmentProvider() {
+    PinotConfiguration environmentProviderConfigs = _serverConf.subset(Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
     if (environmentProviderConfigs.toMap().isEmpty()) {
       LOGGER.info("No environment provider config values provided for server property: {}",
           Server.PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY);
       return null;
     }
 
+    // Invoke pinot environment provider factory's init method
     PinotEnvironmentProviderFactory.init(environmentProviderConfigs);
+
     String environmentProviderClassName = _serverConf.getProperty(Server.ENVIRONMENT_PROVIDER_CLASS_NAME);
     if (environmentProviderClassName == null) {
       LOGGER.info("No className value provided for property: {}", Server.ENVIRONMENT_PROVIDER_CLASS_NAME);
@@ -187,11 +187,7 @@ public class HelixServerStarter implements ServiceStartable {
     }
 
     // Fetch environment provider instance
-    PinotEnvironmentProvider pinotEnvironmentProvider = PinotEnvironmentProviderFactory.getEnvironmentProvider(
-        environmentProviderClassName.toLowerCase());
-
-    // Fetch the overridden pinot configuration containing custom configs.
-    return pinotEnvironmentProvider.getEnvironment();
+    return PinotEnvironmentProviderFactory.getEnvironmentProvider(environmentProviderClassName.toLowerCase());
   }
 
   /**
@@ -284,12 +280,22 @@ public class HelixServerStarter implements ServiceStartable {
       needToUpdateInstanceConfig = true;
     }
 
-    // Update instance configs with environment specific properties if needed
-    if (!instanceConfig.getRecord().getMapField(CommonConstants.ENVIRONMENT_IDENTIFIER).equals(_environmentProperties)) {
-      instanceConfig.getRecord().setMapField(CommonConstants.ENVIRONMENT_IDENTIFIER, _environmentProperties);
-      LOGGER.info("Updated instance config for instance: {} with environment specific properties: {}",
-          _instanceId, _environmentProperties);
-      needToUpdateInstanceConfig = true;
+    // Update instance config with environment properties
+    if (_pinotEnvironmentProvider != null) {
+      // Retrieve failure domain information and add to the environment properties map
+      String failureDomain = _pinotEnvironmentProvider.getFailureDomain();
+      Map<String, String> environmentProperties = new HashMap<>();
+      environmentProperties.put(CommonConstants.INSTANCE_FAILURE_DOMAIN, failureDomain);
+
+      // Fetch existing environment properties map from instance configs
+      Map<String, String> existingEnvironmentConfigsMap = instanceConfig.getRecord().getMapField(
+          CommonConstants.ENVIRONMENT_IDENTIFIER);
+
+      if (existingEnvironmentConfigsMap != null && !existingEnvironmentConfigsMap.equals(environmentProperties)) {
+        instanceConfig.getRecord().setMapField(CommonConstants.ENVIRONMENT_IDENTIFIER, environmentProperties);
+        LOGGER.info("Adding environment properties: {} for instance: {}", environmentProperties, _instanceId);
+        needToUpdateInstanceConfig = true;
+      }
     }
 
     if (needToUpdateInstanceConfig) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -69,6 +69,7 @@ import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.server.starter.ServerQueriesDisabledTracker;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProviderFactory;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.services.ServiceRole;
@@ -83,6 +84,8 @@ import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.common.utils.CommonConstants.Server.*;
 
 
 /**
@@ -107,6 +110,13 @@ import org.slf4j.LoggerFactory;
 public class HelixServerStarter implements ServiceStartable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixServerStarter.class);
 
+  private HelixManager _helixManager;
+  private HelixAdmin _helixAdmin;
+  private ServerInstance _serverInstance;
+  private AdminApiApplication _adminApiApplication;
+  private ServerQueriesDisabledTracker _serverQueriesDisabledTracker;
+  private RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
+
   private final String _helixClusterName;
   private final String _zkAddress;
   private final PinotConfiguration _serverConf;
@@ -115,15 +125,8 @@ public class HelixServerStarter implements ServiceStartable {
   private final int _port;
   private final String _instanceId;
   private final HelixConfigScope _instanceConfigScope;
-  private HelixManager _helixManager;
-  private HelixAdmin _helixAdmin;
-  private ServerInstance _serverInstance;
-  private AdminApiApplication _adminApiApplication;
-  private ServerQueriesDisabledTracker _serverQueriesDisabledTracker;
-  private RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
 
-  public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf)
-      throws Exception {
+  public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf) throws Exception {
     _helixClusterName = helixClusterName;
     _zkAddress = zkAddress;
     // Make a clone so that changes to the config won't propagate to the caller
@@ -146,7 +149,6 @@ public class HelixServerStarter implements ServiceStartable {
         new HelixConfigScopeBuilder(ConfigScopeProperty.PARTICIPANT, _helixClusterName).forParticipant(_instanceId)
             .build();
 
-    // Enable/disable thread CPU time measurement through instance config.
     ThreadTimer.setThreadCpuTimeMeasurementEnabled(_serverConf
         .getProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT,
             Server.DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
@@ -338,6 +340,10 @@ public class HelixServerStarter implements ServiceStartable {
     LOGGER.info("Initializing server instance and registering state model factory");
     Utils.logVersions();
     ControllerLeaderLocator.create(_helixManager);
+
+    // Invoke Pinot Environment Provider's Init method to register the environment provider
+    PinotEnvironmentProviderFactory.init(_serverConf.subset(PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY));
+
     ServerSegmentCompletionProtocolHandler
         .init(_serverConf.subset(SegmentCompletionProtocol.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
     ServerConf serverInstanceConfig = DefaultHelixStarterServerConfig.getDefaultHelixServerConfig(_serverConf);
@@ -468,8 +474,7 @@ public class HelixServerStarter implements ServiceStartable {
 
     long endTimeMs =
         startTimeMs + _serverConf.getProperty(Server.CONFIG_OF_SHUTDOWN_TIMEOUT_MS, Server.DEFAULT_SHUTDOWN_TIMEOUT_MS);
-    if (_serverConf
-        .getProperty(Server.CONFIG_OF_SHUTDOWN_ENABLE_QUERY_CHECK, Server.DEFAULT_SHUTDOWN_ENABLE_QUERY_CHECK)) {
+    if (_serverConf.getProperty(Server.CONFIG_OF_SHUTDOWN_ENABLE_QUERY_CHECK, Server.DEFAULT_SHUTDOWN_ENABLE_QUERY_CHECK)) {
       shutdownQueryCheck(endTimeMs);
     }
     _helixManager.disconnect();
@@ -676,4 +681,5 @@ public class HelixServerStarter implements ServiceStartable {
       throws Exception {
     startDefault();
   }
+
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -28,13 +28,13 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 public interface PinotEnvironmentProvider {
 
   /**
+   * Initializes the configurations specific to an environment provider.
+   */
+  void init(PinotConfiguration pinotConfiguration);
+
+  /**
    * Customize base pinot configuration to add environment variables & instance specific configuration
    * @return custom pinot configuration map
    */
   Map<String, String> getEnvironment();
-
-  /**
-   * Initializes the configurations specific to an environment provider.
-   */
-  void init(PinotConfiguration pinotConfiguration);
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -27,13 +27,11 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public interface PinotEnvironmentProvider {
 
-  String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
-
   /**
    * Customize base pinot configuration to add environment variables & instance specific configuration
    * @return custom pinot configuration map
    */
-  Map<String, Object> getEnvironment();
+  Map<String, String> getEnvironment();
 
   /**
    * Initializes the configurations specific to an environment provider.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -29,7 +29,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 public interface PinotEnvironmentProvider {
 
   String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
-
   /**
    * Customize base pinot configuration to add environment variable & instance specific configuration
    * @param baseConfiguration Base configuration provided by the invoking service
@@ -41,5 +40,4 @@ public interface PinotEnvironmentProvider {
    * Initializes the configurations specific to an environment provider.
    */
   void init(PinotConfiguration pinotConfiguration);
-
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.environmentprovider;
+
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+/**
+ *  Environment Provider interface implemented by different cloud
+ *  providers to customize the base pinot configuration to add environment
+ *  variables & instance specific configuration
+ */
+public interface PinotEnvironmentProvider {
+
+  String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
+
+  /**
+   * Customize base pinot configuration to add environment variable & instance specific configuration
+   * @param baseConfiguration Base configuration provided by the invoking service
+   * @return Custom Pinot Configuration
+   */
+  PinotConfiguration getEnvironment(Map<String, Object> baseConfiguration);
+
+  /**
+   * Initializes the configurations specific to an environment provider.
+   */
+  void init(PinotConfiguration pinotConfiguration);
+
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -22,19 +22,18 @@ import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 /**
- *  Environment Provider interface implemented by different cloud
- *  providers to customize the base pinot configuration to add environment
- *  variables & instance specific configuration
+ *  Environment Provider interface implemented by different cloud providers to customize
+ *  the base pinot configuration to add environment variables & instance specific configuration
  */
 public interface PinotEnvironmentProvider {
 
   String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
+
   /**
-   * Customize base pinot configuration to add environment variable & instance specific configuration
-   * @param baseConfiguration Base configuration provided by the invoking service
-   * @return Custom Pinot Configuration
+   * Customize base pinot configuration to add environment variables & instance specific configuration
+   * @return custom pinot configuration map
    */
-  PinotConfiguration getEnvironment(Map<String, Object> baseConfiguration);
+  Map<String, Object> getEnvironment();
 
   /**
    * Initializes the configurations specific to an environment provider.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.spi.environmentprovider;
 
-import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 /**
  *  Environment Provider interface implemented by different cloud providers to customize
@@ -30,11 +30,13 @@ public interface PinotEnvironmentProvider {
   /**
    * Initializes the configurations specific to an environment provider.
    */
-  void init(PinotConfiguration pinotConfiguration);
+   void init(PinotConfiguration pinotConfiguration);
 
   /**
-   * Customize base pinot configuration to add environment variables & instance specific configuration
-   * @return custom pinot configuration map
+   * Method to retrieve failure domain information for a pinot instance.
+   * @return failure domain information
    */
-  Map<String, String> getEnvironment();
+   default String getFailureDomain() {
+     return CommonConstants.DEFAULT_FAILURE_DOMAIN;
+   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 public class PinotEnvironmentProviderFactory {
 
   private PinotEnvironmentProviderFactory() {
-
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotEnvironmentProviderFactory.class);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
@@ -59,8 +59,10 @@ public class PinotEnvironmentProviderFactory {
     // Get environment and their respective classes
     PinotConfiguration environmentConfiguration = environmentProviderFactoryConfig.subset(CLASS);
     List<String> environments = environmentConfiguration.getKeys();
-    if (!environments.isEmpty()) {
+
+    if (environments.isEmpty()) {
       LOGGER.info("Did not find any environment provider classes in the configuration");
+      return;
     }
 
     for (String environment : environments) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.environmentprovider;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This factory class initializes the PinotEnvironmentProvider class.
+ * It creates a PinotEnvironment object based on the URI found.
+ */
+public class PinotEnvironmentProviderFactory {
+
+  private PinotEnvironmentProviderFactory() {
+
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotEnvironmentProviderFactory.class);
+  private static final String CLASS = "class";
+  private static final Map<String, PinotEnvironmentProvider> PINOT_ENVIRONMENT_PROVIDER_MAP = new HashMap<>();
+
+  public static void register(
+      String environment, String environmentProviderFileName, PinotConfiguration environmentProviderConfiguration) {
+    try {
+      LOGGER.info("Initializing PinotEnvironmentProvider for environment {}, classname {}", environment, environmentProviderFileName);
+      PinotEnvironmentProvider pinotEnvironmentProvider = PluginManager.get().createInstance(environmentProviderFileName);
+      pinotEnvironmentProvider.init(environmentProviderConfiguration);
+      PINOT_ENVIRONMENT_PROVIDER_MAP.put(environment, pinotEnvironmentProvider);
+    } catch (Exception ex) {
+      LOGGER.error(
+          "Could not instantiate environment provider for class {} with environment {}", environmentProviderFileName, environment, ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+  public static void init(PinotConfiguration environmentProviderFactoryConfig) {
+    // Get environment and their respective classes
+    PinotConfiguration environmentConfiguration = environmentProviderFactoryConfig.subset(CLASS);
+    List<String> environments = environmentConfiguration.getKeys();
+    if (!environments.isEmpty()) {
+      LOGGER.info("Did not find any environment provider classes in the configuration");
+    }
+
+    for (String environment : environments) {
+      String environmentProviderClassName = environmentConfiguration.getProperty(environment);
+      PinotConfiguration environmentProviderConfiguration = environmentProviderFactoryConfig.subset(environment);
+      LOGGER.info("Got scheme {}, initializing class {}", environment, environmentProviderClassName);
+      register(environment, environmentProviderClassName, environmentProviderConfiguration);
+    }
+  }
+
+  // Utility to invoke the cloud specific environment provider.
+  public static PinotEnvironmentProvider getEnvironmentProvider(String environment) {
+    PinotEnvironmentProvider pinotEnvironmentProvider = PINOT_ENVIRONMENT_PROVIDER_MAP.get(environment);
+    Preconditions.checkState(pinotEnvironmentProvider != null,
+        "PinotEnvironmentProvider for environment: %s has not been initialized", environment);
+    return pinotEnvironmentProvider;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -25,6 +25,7 @@ public class CommonConstants {
 
   public static final String ENVIRONMENT_IDENTIFIER = "environment";
   public static final String INSTANCE_FAILURE_DOMAIN = "failureDomain";
+  public static final String DEFAULT_FAILURE_DOMAIN = "No such domain";
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -25,6 +25,7 @@ public class CommonConstants {
 
   public static final String ENVIRONMENT_IDENTIFIER = "environment";
   public static final String FAILURE_DOMAIN_IDENTIFIER = "failureDomain";
+  public static final String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -24,8 +24,7 @@ import java.io.File;
 public class CommonConstants {
 
   public static final String ENVIRONMENT_IDENTIFIER = "environment";
-  public static final String FAILURE_DOMAIN_IDENTIFIER = "failureDomain";
-  public static final String INSTANCE_FAILURE_DOMAIN = "pinot.environment.instance.failureDomain";
+  public static final String INSTANCE_FAILURE_DOMAIN = "failureDomain";
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -20,8 +20,9 @@ package org.apache.pinot.spi.utils;
 
 import java.io.File;
 
-
 public class CommonConstants {
+
+  public static final String PLATFORM_FAULT_DOMAIN = "platformFaultDomain";
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";
@@ -344,6 +345,9 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_CURRENT_DATA_TABLE_VERSION = "pinot.server.instance.currentDataTableVersion";
     public static final int DEFAULT_CURRENT_DATA_TABLE_VERSION = 3;
+
+    // Environment Provider Configs
+    public static final String PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY = "pinot.server.environmentProvider.factory";
   }
 
   public static class Controller {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -20,9 +20,8 @@ package org.apache.pinot.spi.utils;
 
 import java.io.File;
 
-public class CommonConstants {
 
-  public static final String PLATFORM_FAULT_DOMAIN = "platformFaultDomain";
+public class CommonConstants {
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";
@@ -348,6 +347,8 @@ public class CommonConstants {
 
     // Environment Provider Configs
     public static final String PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY = "pinot.server.environmentProvider.factory";
+    public static final String CONFIG_OF_ENABLE_ENVIRONMENT_PROVIDER_FACTORY = "pinot.server.environmentProvider.enabled";
+    public static final String CONFIG_OF_ENVIRONMENT_PROVIDER_TYPE = "pinot.server.environmentProvider.type";
   }
 
   public static class Controller {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -23,6 +23,9 @@ import java.io.File;
 
 public class CommonConstants {
 
+  public static final String ENVIRONMENT_IDENTIFIER = "environment";
+  public static final String FAILURE_DOMAIN_IDENTIFIER = "failureDomain";
+
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
   public static final String HTTP_PROTOCOL = "http";
   public static final String HTTPS_PROTOCOL = "https";
@@ -347,8 +350,7 @@ public class CommonConstants {
 
     // Environment Provider Configs
     public static final String PREFIX_OF_CONFIG_OF_ENVIRONMENT_PROVIDER_FACTORY = "pinot.server.environmentProvider.factory";
-    public static final String CONFIG_OF_ENABLE_ENVIRONMENT_PROVIDER_FACTORY = "pinot.server.environmentProvider.enabled";
-    public static final String CONFIG_OF_ENVIRONMENT_PROVIDER_TYPE = "pinot.server.environmentProvider.type";
+    public static final String ENVIRONMENT_PROVIDER_CLASS_NAME = "pinot.server.environmentProvider.className";
   }
 
   public static class Controller {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -57,8 +57,8 @@ public class PinotEnvironmentProviderFactoryTest {
     }
 
     @Override
-    public PinotConfiguration getEnvironment(Map<String, Object> baseConfiguration) {
-      return new PinotConfiguration(new HashMap<>());
+    public Map<String, Object> getEnvironment() {
+      return new HashMap<>();
     }
 
     @Override

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -47,18 +47,12 @@ public class PinotEnvironmentProviderFactoryTest {
         testPinotEnvironment).getConfiguration().getProperty("requestTimeout"), "100");
   }
 
-
   public static class TestEnvironmentProvider implements PinotEnvironmentProvider {
     public int initCalled = 0;
     private PinotConfiguration _configuration;
 
     public int getInitCalled() {
       return initCalled;
-    }
-
-    @Override
-    public Map<String, String> getEnvironment() {
-      return new HashMap<>();
     }
 
     @Override

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.environmentprovider;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PinotEnvironmentProviderFactoryTest {
+
+  @Test
+  public void testCustomPinotEnvironmentProviderFactory() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("class.test", PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider.class.getName());
+    properties.put("test.maxRetry", "3");
+    properties.put("test.connectionTimeout", "100");
+    properties.put("test.requestTimeout", "100");
+    PinotEnvironmentProviderFactory.init(new PinotConfiguration(properties));
+
+    PinotEnvironmentProvider testPinotEnvironment = PinotEnvironmentProviderFactory.getEnvironmentProvider("test");
+    Assert.assertTrue(testPinotEnvironment instanceof PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider);
+    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
+        testPinotEnvironment).getInitCalled(), 1);
+    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
+        testPinotEnvironment).getConfiguration().getProperty("maxRetry"), "3");
+    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
+        testPinotEnvironment).getConfiguration().getProperty("connectionTimeout"), "100");
+    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
+        testPinotEnvironment).getConfiguration().getProperty("requestTimeout"), "100");
+  }
+
+
+  public static class TestEnvironmentProvider implements PinotEnvironmentProvider {
+    public int initCalled = 0;
+    private PinotConfiguration _configuration;
+
+    public int getInitCalled() {
+      return initCalled;
+    }
+
+    @Override
+    public PinotConfiguration getEnvironment(Map<String, Object> baseConfiguration) {
+      return new PinotConfiguration(new HashMap<>());
+    }
+
+    @Override
+    public void init(PinotConfiguration configuration) {
+      _configuration = configuration;
+      initCalled++;
+    }
+
+    public PinotConfiguration getConfiguration() {
+      return _configuration;
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -57,7 +57,7 @@ public class PinotEnvironmentProviderFactoryTest {
     }
 
     @Override
-    public Map<String, Object> getEnvironment() {
+    public Map<String, String> getEnvironment() {
       return new HashMap<>();
     }
 


### PR DESCRIPTION
… Domain Information for the Server Instance![Screen Shot 2021-05-04 at 7 59 00 PM](https://user-images.githubusercontent.com/8770850/117217123-c32b1b00-adb5-11eb-8499-95a71fbbc209.png)
## Description
Creating generic interface PinotEnvironment which can be implemented by various cloud providers to customize the PinotConfiguration by setting different environment variables and other instance specific configuration.

Primary aim is to update the server instance config with failure/fault domain information which will be useful when designing segment assignment strategy to achieve high availability.

This change introduces a PinotEnvironment interface under pinot-spi(a.ka pinot-service-provider-interface). We introduce a pinot-enviroment/pinot-azure plugin containing AzureEnvironmentProvider class to provide azure specific pinot configuration customization which contains failure domain information. This failure domain information is retrieved from Azure IMDS (Instance Metadata Service) wherein call has to be made from within the VM.

Unit Tests are written for the same. End-End integration tests are in-progress. Will take LinkedIN Pinot-SRE help to conduct those.

Design Document: https://docs.google.com/document/d/1echXSSZfgKWLtkmA1KKxmdCRUkTqffqoJhNA-ovTfzc/

Testing Overview:

Performed local test to verify that Zookeeper node gets updated with the Failure Domain information.

![Screen Shot 2021-05-04 at 7 59 00 PM](https://user-images.githubusercontent.com/8770850/117217253-ef469c00-adb5-11eb-8db7-71e008d104b6.png)

Configs Provided by the client: 
```
pinot.server.environmentProvider.factory.class.azureEnvironment=org.apache.pinot.plugin.provider.AzureEnvironmentProvider
pinot.server.environmentProvider.className=azureEnvironment
pinot.server.environmentProvider.factory.azureEnvironment.maxRetry=3
pinot.server.environmentProvider.factory.azureEnvironment.imdsEndpoint=http://169.254.169.254/metadata/instance?api-version=2020-09-01
pinot.server.environmentProvider.factory.azureEnvironment.connectionTimeout=100
pinot.server.environmentProvider.factory.azureEnvironment.requestTimeout=100
```

Calling service will provide the environment specific information like class name identifier and the actual class path given by 
pinot.server.environmentProvider.className AND pinot.server.environmentProvider.factory.class.azureEnvironment respectively. 

The class.azureEnvironment information will be utilized by the PinotEnvironmentProviderFactory to construct a Map from environment name to the respective class instance. At the HelixServerStarter constructor layer we will fetch the environment provider info by calling getEnvironmentProvider(className). Once we get the environmentProvider object we call the corresponding getEnvironment() method to fetch the custom properties containing the FD information. 
P.S All the above code gets executed at the constructor level.

The retrieved FD information will be used to update the instance config during Server Starter. 
Other Properties namely imdsEndpoint, maxRetry, connectionTimeout and requestTimeout are specific to the httpClient used to make request to the Azure IMDS endpoint to fetch the FD for a server instance. We can replicate the logic for other Pinot instances too. 

Have uploaded a snapshot of the local testing which represents the updated FD information in the Zk Node's mapFields. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
