### PR TITLE
Allow BYTES/Struct and complex type fields to exceed default max length

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -381,10 +381,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
 
     /**
      * Check if the data type is for fixed width data (INT, LONG, FLOAT, DOUBLE)
-     * or variable width data (STRING, BYTES)
+     * or variable width data (STRING, BYTES, STRUCT, MAP, LIST)
      */
     public boolean isFixedWidth() {
-      return this != STRING && this != BYTES;
+      return this == INT || this == LONG || this == FLOAT || this == DOUBLE;
     }
 
     public boolean isNumeric() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -45,8 +45,6 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
-
 
 /**
  * The <code>Schema</code> class is defined for each table to describe the details of the table's fields (columns).
@@ -507,7 +505,7 @@ public final class Schema implements Serializable {
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
-      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
+      Preconditions.checkArgument(!dataType.isFixedWidth(), "The maxLength field only applies to variable fields.");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
       return this;
     }
@@ -533,7 +531,7 @@ public final class Schema implements Serializable {
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
-      Preconditions.checkArgument(dataType == STRING, "The maxLength field only applies to STRING field right now");
+      Preconditions.checkArgument(!dataType.isFixedWidth(), "The maxLength field only applies to variable fields.");
       _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
       return this;
     }


### PR DESCRIPTION
Allow BYTES/Struct and complex type fields to exceed default max length of 500 bytes.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
