### PR TITLE
Fix issue - no authentication is required for GET table endpoint

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -252,14 +252,14 @@ public class PinotTableRestletResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}")
-  @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Get/Enable/Disable/Drop a table", notes =
       "Get/Enable/Disable/Drop a table. If table name is the only parameter specified "
           + ", the tableconfig will be printed")
   public String alterTableStateOrListTableConfig(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "enable|disable|drop") @QueryParam("state") String stateStr,
-      @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr) {
+      @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr,
+      @Context HttpHeaders httpHeaders, @Context Request request) {
     try {
       if (stateStr == null) {
         return listTableConfigs(tableName, tableTypeStr);
@@ -267,6 +267,11 @@ public class PinotTableRestletResource {
 
       StateType stateType = Constants.validateState(stateStr);
       TableType tableType = Constants.validateTableType(tableTypeStr);
+
+      // validate if user has permission to change the table state to enable/disable/drop
+      String endpointUrl = request.getRequestURL().toString();
+      _accessControlUtils
+          .validatePermission(tableName, AccessType.UPDATE, httpHeaders, endpointUrl, _accessControlFactory.create());
 
       ArrayNode ret = JsonUtils.newArrayNode();
       boolean tableExists = false;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -268,7 +268,7 @@ public class PinotTableRestletResource {
       StateType stateType = Constants.validateState(stateStr);
       TableType tableType = Constants.validateTableType(tableTypeStr);
 
-      // validate if user has permission to change the table state to enable/disable/drop
+      // validate if user has permission to change the table state
       String endpointUrl = request.getRequestURL().toString();
       _accessControlUtils
           .validatePermission(tableName, AccessType.UPDATE, httpHeaders, endpointUrl, _accessControlFactory.create());


### PR DESCRIPTION
## Description
`/tables/{tableName}` endpoint on Table Resource is mistakenly annotated with `@Authenticate(UPDATE)`, while this endpoint can be used to update the state of the table as well as only to get the table config. This PR fixes this issue and validate permission only for update case and for there won't be any authentication when it's used for getting table config.

## Testing Done
Deployed locally and and verified the expected behavior
