### PR TITLE
[PQL Deprecation] Do not compile PQL broker request for SQL query

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/request/PqlAndCalciteSqlCompatibilityTest.java
@@ -26,8 +26,9 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.parsers.utils.BrokerRequestComparisonUtils;
+import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
-import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -38,7 +39,6 @@ import org.testng.annotations.Test;
  */
 public class PqlAndCalciteSqlCompatibilityTest {
   private static final Pql2Compiler PQL_COMPILER = new Pql2Compiler();
-  private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
 
   // OPTIMIZER is used to flatten certain queries with filtering optimization.
   // The reason is that SQL parser will parse the structure into a binary tree mode.
@@ -78,7 +78,8 @@ public class PqlAndCalciteSqlCompatibilityTest {
   private void testPqlSqlCompatibilityHelper(String pql, String sql) {
     BrokerRequest pqlBrokerRequest = PQL_COMPILER.compileToBrokerRequest(pql);
     OPTIMIZER.optimize(pqlBrokerRequest, null);
-    BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sql);
+    PinotQuery2BrokerRequestConverter converter = new PinotQuery2BrokerRequestConverter();
+    BrokerRequest sqlBrokerRequest = converter.convert(CalciteSqlParser.compileToPinotQuery(sql));
     OPTIMIZER.optimize(sqlBrokerRequest, null);
     Assert.assertTrue(BrokerRequestComparisonUtils.validate(pqlBrokerRequest, sqlBrokerRequest));
   }
@@ -131,7 +132,8 @@ public class PqlAndCalciteSqlCompatibilityTest {
   private void testPqlSqlOrderByCompatibilityHelper(String pql, String sql, String orderByColumn) {
     BrokerRequest pqlBrokerRequest = PQL_COMPILER.compileToBrokerRequest(pql);
     OPTIMIZER.optimize(pqlBrokerRequest, null);
-    BrokerRequest sqlBrokerRequest = SQL_COMPILER.compileToBrokerRequest(sql);
+    PinotQuery2BrokerRequestConverter converter = new PinotQuery2BrokerRequestConverter();
+    BrokerRequest sqlBrokerRequest = converter.convert(CalciteSqlParser.compileToPinotQuery(sql));
     OPTIMIZER.optimize(sqlBrokerRequest, null);
     Assert.assertTrue(BrokerRequestComparisonUtils.validate(pqlBrokerRequest, sqlBrokerRequest, /*ignoreOrderBy*/true));
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryLimitOverrideTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryLimitOverrideTest.java
@@ -21,7 +21,7 @@ package org.apache.pinot.broker.requesthandler;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
-import org.apache.pinot.parsers.AbstractCompiler;
+import org.apache.pinot.parsers.QueryCompiler;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,17 +30,17 @@ public class QueryLimitOverrideTest {
 
   @Test
   public void testPql() {
-    AbstractCompiler pqlCompiler = PinotQueryParserFactory.get("PQL");
+    QueryCompiler pqlCompiler = PinotQueryParserFactory.get("PQL");
     testFixedQuerySetWithCompiler(pqlCompiler);
   }
 
   @Test
   public void testCalciteSql() {
-    AbstractCompiler sqlCompiler = PinotQueryParserFactory.get("SQL");
+    QueryCompiler sqlCompiler = PinotQueryParserFactory.get("SQL");
     testFixedQuerySetWithCompiler(sqlCompiler);
   }
 
-  private void testFixedQuerySetWithCompiler(AbstractCompiler compiler) {
+  private void testFixedQuerySetWithCompiler(QueryCompiler compiler) {
     // Selections
     testSelectionQueryWithCompiler(compiler, "select * from vegetables LIMIT 999", 1000, 999);
     testSelectionQueryWithCompiler(compiler, "select * from vegetables LIMIT 1000", 1000, 1000);
@@ -54,7 +54,7 @@ public class QueryLimitOverrideTest {
     testGroupByQueryWithCompiler(compiler, "select count(*) from vegetables group by a LIMIT 10000", 1000, 1000);
   }
 
-  private void testSelectionQueryWithCompiler(AbstractCompiler compiler, String query, int maxQuerySelectionLimit,
+  private void testSelectionQueryWithCompiler(QueryCompiler compiler, String query, int maxQuerySelectionLimit,
       int expectedLimit) {
     BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
     PinotQuery pinotQuery = brokerRequest.getPinotQuery();
@@ -69,7 +69,7 @@ public class QueryLimitOverrideTest {
     }
   }
 
-  private void testGroupByQueryWithCompiler(AbstractCompiler compiler, String query, int maxQuerySelectionLimit,
+  private void testGroupByQueryWithCompiler(QueryCompiler compiler, String query, int maxQuerySelectionLimit,
       int expectedLimit) {
     BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
     PinotQuery pinotQuery = brokerRequest.getPinotQuery();

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -40,7 +40,7 @@ import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.ZkStarter;
-import org.apache.pinot.parsers.AbstractCompiler;
+import org.apache.pinot.parsers.QueryCompiler;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -229,7 +229,7 @@ public class SegmentPrunerTest {
   }
 
   @Test(dataProvider = "compilerProvider")
-  public void testPartitionAwareSegmentPruner(AbstractCompiler compiler) {
+  public void testPartitionAwareSegmentPruner(QueryCompiler compiler) {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_2);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_3);
@@ -310,7 +310,7 @@ public class SegmentPrunerTest {
   }
 
   @Test(dataProvider = "compilerProvider")
-  public void testTimeSegmentPruner(AbstractCompiler compiler) {
+  public void testTimeSegmentPruner(QueryCompiler compiler) {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_5);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_6);
@@ -453,7 +453,7 @@ public class SegmentPrunerTest {
   }
 
   @Test(dataProvider = "compilerProvider")
-  public void testTimeSegmentPrunerSimpleDateFormat(AbstractCompiler compiler) {
+  public void testTimeSegmentPrunerSimpleDateFormat(QueryCompiler compiler) {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(SDF_QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(SDF_QUERY_2);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(SDF_QUERY_3);
@@ -497,7 +497,7 @@ public class SegmentPrunerTest {
   }
 
   @Test(dataProvider = "compilerProvider")
-  public void testEmptySegmentPruner(AbstractCompiler compiler) {
+  public void testEmptySegmentPruner(QueryCompiler compiler) {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_2);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_3);

--- a/pinot-common/src/main/java/org/apache/pinot/parsers/QueryCompiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/parsers/QueryCompiler.java
@@ -24,6 +24,10 @@ import org.apache.pinot.common.request.BrokerRequest;
 /**
  * Interface for Pinot Query compilers.
  */
-public interface AbstractCompiler {
-  BrokerRequest compileToBrokerRequest(String expression);
+public interface QueryCompiler {
+
+  /**
+   * Compiles the given query into a broker request.
+   */
+  BrokerRequest compileToBrokerRequest(String query);
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
@@ -37,7 +37,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
-import org.apache.pinot.parsers.AbstractCompiler;
+import org.apache.pinot.parsers.QueryCompiler;
 import org.apache.pinot.parsers.utils.BrokerRequestComparisonUtils;
 import org.apache.pinot.pql.parsers.pql2.ast.AstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.IdentifierAstNode;
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * PQL 2 compiler.
  */
 @ThreadSafe
-public class Pql2Compiler implements AbstractCompiler {
+public class Pql2Compiler implements QueryCompiler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Pql2Compiler.class);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/PinotQueryParserFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/requesthandler/PinotQueryParserFactory.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.requesthandler;
 
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.parsers.AbstractCompiler;
+import org.apache.pinot.parsers.QueryCompiler;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 
@@ -32,7 +32,7 @@ public class PinotQueryParserFactory {
   private static final Pql2Compiler PQL_2_COMPILER = new Pql2Compiler();
   private static final CalciteSqlCompiler CALCITE_SQL_COMPILER = new CalciteSqlCompiler();
 
-  public static AbstractCompiler get(String queryFormat) {
+  public static QueryCompiler get(String queryFormat) {
     switch (queryFormat.toLowerCase()) {
       case PQL:
         return PQL_2_COMPILER;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -68,6 +68,7 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
 import org.apache.pinot.core.requesthandler.PinotQueryRequest;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
@@ -403,7 +404,6 @@ public class ClusterIntegrationTestUtils {
       producer.abortTransaction();
     }
   }
-
 
   /**
    * Push random generated
@@ -801,8 +801,9 @@ public class ClusterIntegrationTestUtils {
       return;
     }
 
+    // TODO: Use PinotQuery instead of BrokerRequest here
     BrokerRequest brokerRequest =
-        PinotQueryParserFactory.get(CommonConstants.Broker.Request.SQL).compileToBrokerRequest(pinotQuery);
+        new PinotQuery2BrokerRequestConverter().convert(CalciteSqlParser.compileToPinotQuery(pinotQuery));
 
     List<String> orderByColumns = new ArrayList<>();
     if (isSelectionQuery(brokerRequest) && brokerRequest.getOrderBy() != null


### PR DESCRIPTION
## Description
Remove the step of converting PinotQuery to BrokerRequest for SQL query compilation.
Also modify the tests and tools to not access the BrokerRequest fields for SQL query.