### PR TITLE
Add ParquetRecordReaderConfig to RecordReaderFactory.

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -38,22 +38,24 @@ public class RecordReaderFactory {
   private static final Map<String, String> DEFAULT_RECORD_READER_CONFIG_CLASS_MAP = new HashMap<>();
 
   // TODO: This could be removed once we have dynamic loading plugins supports.
-  private static final String DEFAULT_AVRO_RECORD_READER_CLASS =
+  static final String DEFAULT_AVRO_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader";
-  private static final String DEFAULT_CSV_RECORD_READER_CLASS =
+  static final String DEFAULT_CSV_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader";
-  private static final String DEFAULT_CSV_RECORD_READER_CONFIG_CLASS =
+  static final String DEFAULT_CSV_RECORD_READER_CONFIG_CLASS =
       "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig";
-  private static final String DEFAULT_JSON_RECORD_READER_CLASS =
+  static final String DEFAULT_JSON_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.json.JSONRecordReader";
-  private static final String DEFAULT_THRIFT_RECORD_READER_CLASS =
+  static final String DEFAULT_THRIFT_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader";
-  private static final String DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS =
+  static final String DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS =
       "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReaderConfig";
-  private static final String DEFAULT_ORC_RECORD_READER_CLASS =
+  static final String DEFAULT_ORC_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader";
-  private static final String DEFAULT_PARQUET_RECORD_READER_CLASS =
+  static final String DEFAULT_PARQUET_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader";
+  static final String DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS =
+      "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReaderConfig";
 
   public static void register(String fileFormat, String recordReaderClassName, String recordReaderConfigClassName) {
     DEFAULT_RECORD_READER_CLASS_MAP.put(fileFormat.toUpperCase(), recordReaderClassName);
@@ -71,7 +73,7 @@ public class RecordReaderFactory {
     register(FileFormat.JSON, DEFAULT_JSON_RECORD_READER_CLASS, null);
     register(FileFormat.THRIFT, DEFAULT_THRIFT_RECORD_READER_CLASS, DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
     register(FileFormat.ORC, DEFAULT_ORC_RECORD_READER_CLASS, null);
-    register(FileFormat.PARQUET, DEFAULT_PARQUET_RECORD_READER_CLASS, null);
+    register(FileFormat.PARQUET, DEFAULT_PARQUET_RECORD_READER_CLASS, DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data.readers;
+
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.*;
+import static org.testng.Assert.*;
+
+public class RecordReaderFactoryTest {
+
+  @Test
+  public void testGetRecordReaderClassName() {
+    assertEquals(getRecordReaderClassName("avro"), DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("gzipped_avro"), DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("csv"), DEFAULT_CSV_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("json"), DEFAULT_JSON_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("orc"), DEFAULT_ORC_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CLASS);
+  }
+
+  @Test
+  public void testGetRecordReaderConfigClassName() {
+    assertNull(getRecordReaderConfigClassName("avro"));
+    assertNull(getRecordReaderConfigClassName("gzipped_avro"));
+    assertEquals(getRecordReaderConfigClassName("csv"), DEFAULT_CSV_RECORD_READER_CONFIG_CLASS);
+    assertNull(getRecordReaderConfigClassName("json"));
+    assertEquals(getRecordReaderConfigClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
+    assertNull(getRecordReaderConfigClassName("orc"));
+    assertEquals(getRecordReaderConfigClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);
+  }
+}


### PR DESCRIPTION
## Description
Fixes a bug where `ParquetRecordReaderConfig` could not be provided when creating segments from parquet files.

Related issue: https://github.com/apache/incubator-pinot/issues/6856

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
