### PR TITLE
Add server tenant to request statistics

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -50,20 +50,20 @@ public class RequestStatistics {
   private boolean _isNumGroupsLimitReached;
   private int _numExceptions;
   private String _brokerId;
-  private String _offlineBrokerTenant;
-  private String _realtimeBrokerTenant;
+  private String _offlineServerTenant;
+  private String _realtimeServerTenant;
   private long _requestId;
 
   public String getBrokerId() {
     return _brokerId;
   }
 
-  public String getOfflineBrokerTenant() {
-    return _offlineBrokerTenant;
+  public String getOfflineServerTenant() {
+    return _offlineServerTenant;
   }
 
-  public String getRealtimeBrokerTenant() {
-    return _realtimeBrokerTenant;
+  public String getRealtimeServerTenant() {
+    return _realtimeServerTenant;
   }
 
   public long getRequestId() {
@@ -128,12 +128,12 @@ public class RequestStatistics {
     _brokerId = brokerId;
   }
 
-  public void setOfflineBrokerTenant(String offlineBrokerTenant) {
-    _offlineBrokerTenant = offlineBrokerTenant;
+  public void setOfflineServerTenant(String offlineServerTenant) {
+    _offlineServerTenant = offlineServerTenant;
   }
 
-  public void setRealtimeBrokerTenant(String realtimeBrokerTenant) {
-    _realtimeBrokerTenant = realtimeBrokerTenant;
+  public void setRealtimeServerTenant(String realtimeServerTenant) {
+    _realtimeServerTenant = realtimeServerTenant;
   }
 
   public void setRequestId(long requestId) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -50,10 +50,20 @@ public class RequestStatistics {
   private boolean _isNumGroupsLimitReached;
   private int _numExceptions;
   private String _brokerId;
+  private String _offlineBrokerTenant;
+  private String _realtimeBrokerTenant;
   private long _requestId;
 
   public String getBrokerId() {
     return _brokerId;
+  }
+
+  public String getOfflineBrokerTenant() {
+    return _offlineBrokerTenant;
+  }
+
+  public String getRealtimeBrokerTenant() {
+    return _realtimeBrokerTenant;
   }
 
   public long getRequestId() {
@@ -116,6 +126,14 @@ public class RequestStatistics {
 
   public void setBrokerId(String brokerId) {
     _brokerId = brokerId;
+  }
+
+  public void setOfflineBrokerTenant(String offlineBrokerTenant) {
+    _offlineBrokerTenant = offlineBrokerTenant;
+  }
+
+  public void setRealtimeBrokerTenant(String realtimeBrokerTenant) {
+    _realtimeBrokerTenant = realtimeBrokerTenant;
   }
 
   public void setRequestId(long requestId) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -84,6 +84,7 @@ import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.QueryOptions;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -342,18 +343,22 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       realtimeBrokerRequest = getRealtimeBrokerRequest(brokerRequest);
       _queryOptimizer.optimize(realtimeBrokerRequest.getPinotQuery(), schema);
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.HYBRID);
+      requestStatistics.setOfflineBrokerTenant(getBrokerTenant(offlineTableName));
+      requestStatistics.setRealtimeBrokerTenant(getBrokerTenant(realtimeTableName));
     } else if (offlineTableName != null) {
       // OFFLINE only
       setTableName(brokerRequest, offlineTableName);
       _queryOptimizer.optimize(pinotQuery, schema);
       offlineBrokerRequest = brokerRequest;
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.OFFLINE);
+      requestStatistics.setOfflineBrokerTenant(getBrokerTenant(offlineTableName));
     } else {
       // REALTIME only
       setTableName(brokerRequest, realtimeTableName);
       _queryOptimizer.optimize(pinotQuery, schema);
       realtimeBrokerRequest = brokerRequest;
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.REALTIME);
+      requestStatistics.setRealtimeBrokerTenant(getBrokerTenant(realtimeTableName));
     }
 
     // Calculate routing table for the query
@@ -483,6 +488,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _numDroppedLog.incrementAndGet();
     }
     return brokerResponse;
+  }
+
+  private String getBrokerTenant(String tableNameWithType) {
+    TableConfig tableConfig = _tableCache.getTableConfig(tableNameWithType);
+    Preconditions.checkNotNull(tableConfig, "Table config is not available for table '%s'", tableNameWithType);
+    return tableConfig.getTenantConfig().getBroker();
   }
 
   @Deprecated


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

This PR adds broker tenant to request statistics.

Since PQL is deprecated, this PR only add for SQL. Let me know if I need to add for PQL.

cc @siddharthteotia @mcvsubbu

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
