### PR TITLE
Add reason of creation to StreamMetadataProvider name.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -149,11 +149,12 @@ public class PinotTableIdealStateBuilder {
    * @param partitionGroupConsumptionStatusList List of {@link PartitionGroupConsumptionStatus} for the current partition groups.
    *                                          The size of this list is equal to the number of partition groups,
    *                                          and is created using the latest segment zk metadata.
+   * @param reason the reason to get partition group metadata
    */
   public static List<PartitionGroupMetadata> getPartitionGroupMetadataList(StreamConfig streamConfig,
-      List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList) {
+      List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList, String reason) {
     PartitionGroupMetadataFetcher partitionGroupMetadataFetcher =
-        new PartitionGroupMetadataFetcher(streamConfig, partitionGroupConsumptionStatusList);
+        new PartitionGroupMetadataFetcher(streamConfig, partitionGroupConsumptionStatusList, reason);
     try {
       DEFAULT_IDEALSTATE_UPDATE_RETRY_POLICY.attempt(partitionGroupMetadataFetcher);
       return partitionGroupMetadataFetcher.getPartitionGroupMetadataList();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -254,7 +254,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     // committing segment's partitionGroupId no longer in the newPartitionGroupMetadataList
     List<PartitionGroupMetadata> partitionGroupMetadataListWithout0 =
-        segmentManager.getNewPartitionGroupMetadataList(segmentManager._streamConfig, Collections.emptyList());
+        segmentManager.getNewPartitionGroupMetadataList(segmentManager._streamConfig, Collections.emptyList(), "TEST_TABLE_CREATION");
     partitionGroupMetadataListWithout0.remove(0);
     segmentManager._partitionGroupMetadataList = partitionGroupMetadataListWithout0;
 
@@ -565,7 +565,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
      */
     // 1 reached end of shard.
     List<PartitionGroupMetadata> partitionGroupMetadataListWithout1 =
-        segmentManager.getNewPartitionGroupMetadataList(segmentManager._streamConfig, Collections.emptyList());
+        segmentManager.getNewPartitionGroupMetadataList(segmentManager._streamConfig, Collections.emptyList(),
+            "TEST_TABLE_CREATION");
     partitionGroupMetadataListWithout1.remove(1);
     segmentManager._partitionGroupMetadataList = partitionGroupMetadataListWithout1;
     // noop
@@ -962,7 +963,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     public void ensureAllPartitionsConsuming() {
       ensureAllPartitionsConsuming(_tableConfig, _streamConfig, _idealState,
-          getNewPartitionGroupMetadataList(_streamConfig, Collections.emptyList()));
+          getNewPartitionGroupMetadataList(_streamConfig, Collections.emptyList(), "TEST_PERIODIC_SEGMENT_VALIDATION"));
     }
 
     @Override
@@ -1029,7 +1030,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     @Override
     List<PartitionGroupMetadata> getNewPartitionGroupMetadataList(StreamConfig streamConfig,
-        List<PartitionGroupConsumptionStatus> currentPartitionGroupConsumptionStatusList) {
+        List<PartitionGroupConsumptionStatus> currentPartitionGroupConsumptionStatusList, String reason) {
       if (_partitionGroupMetadataList != null) {
         return _partitionGroupMetadataList;
       } else {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.stream;
 
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,18 +33,27 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionGroupMetadataFetcher.class);
 
+  public enum Reason {
+    TABLE_CREATION, SEGMENT_COMMITMENT, PERIODIC_SEGMENT_VALIDATION, PERIODIC_PARTITION_GROUP_SMALLEST_OFFSET_FETCHER
+  }
+
   private List<PartitionGroupMetadata> _newPartitionGroupMetadataList;
   private final StreamConfig _streamConfig;
   private final List<PartitionGroupConsumptionStatus> _partitionGroupConsumptionStatusList;
   private final StreamConsumerFactory _streamConsumerFactory;
   private Exception _exception;
   private final String _topicName;
+  private final String _reason;
 
-  public PartitionGroupMetadataFetcher(StreamConfig streamConfig, List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList) {
+  public PartitionGroupMetadataFetcher(
+      StreamConfig streamConfig,
+      List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList,
+      String reason) {
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     _topicName = streamConfig.getTopicName();
     _streamConfig = streamConfig;
     _partitionGroupConsumptionStatusList = partitionGroupConsumptionStatusList;
+    _reason = reason;
   }
 
   public List<PartitionGroupMetadata> getPartitionGroupMetadataList() {
@@ -61,7 +71,10 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   @Override
   public Boolean call()
       throws Exception {
-    String clientId = PartitionGroupMetadataFetcher.class.getSimpleName() + "-" + _topicName;
+    String clientId = PartitionGroupMetadataFetcher.class.getSimpleName()
+        + "-" + _topicName
+        + "-" + TableNameBuilder.extractRawTableName(_streamConfig.getTableNameWithType())
+        + "-" + _reason;
     try (
         StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createStreamMetadataProvider(clientId)) {
       _newPartitionGroupMetadataList = streamMetadataProvider


### PR DESCRIPTION
Because of the kinesis pr (#6776 ), StreamMetadataProvider gets constructed in multiple places, including controller periodic task, realtime segment commit, realtime table creation, etc. Currently kafka metric name is the clienId (`PartitionGroupMetadataFetcher` + `topicName`) in pinot-controller. In order to avoid duplicate metric names, this pr bring in two factors during the initialization:
- table name
- reason of constructing `StreamMetadataProvider`

Table name helps eliminate the scenarios when two different tables consume the same kafka topic. While that’s not enough; segment commit for two different partitions for the same table can also invoke the StreamMetadataProvider creation. That’s why we need to bring in the reason as well. For segment commits by different partitions, the partitionId needs to be appended to the reason as well.