### PR TITLE
Feature/segment.size.rule

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/StringGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/StringGenerator.java
@@ -19,12 +19,9 @@
 package org.apache.pinot.controller.recommender.data.generator;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -38,30 +35,28 @@ public class StringGenerator implements Generator {
   private final int cardinality;
   private final Random rand;
   private final double numberOfValuesPerEntry;
-  private final int lengthOfEachString;
 
-  private List<String> vals;
+  private final String initialValue;
+  private final int counterLength;
   private int counter = 0;
 
   public StringGenerator(Integer cardinality, Double numberOfValuesPerEntry, Integer lengthOfEachString) {
     this.cardinality = cardinality;
     this.numberOfValuesPerEntry =
         numberOfValuesPerEntry != null ? numberOfValuesPerEntry : DEFAULT_NUMBER_OF_VALUES_PER_ENTRY;
-    this.lengthOfEachString = lengthOfEachString != null ? lengthOfEachString : DEFAULT_LENGTH_OF_EACH_STRING;
+    lengthOfEachString = lengthOfEachString != null ? lengthOfEachString : DEFAULT_LENGTH_OF_EACH_STRING;
     Preconditions.checkState(this.numberOfValuesPerEntry >= 1,
         "Number of values per entry (should be >= 1): " + this.numberOfValuesPerEntry);
+    counterLength = String.valueOf(this.cardinality).length();
+    int initValueSize = lengthOfEachString - counterLength;
+    Preconditions.checkState(initValueSize >= 0,
+        String.format("Cannot generate %d unique string with length %d", this.cardinality, lengthOfEachString));
+    initialValue = RandomStringUtils.randomAlphabetic(initValueSize);
     rand = new Random(System.currentTimeMillis());
   }
 
   @Override
   public void init() {
-    final Set<String> uniqueStrings = new HashSet<>();
-    for (int i = 0; i < cardinality; i++) {
-      while (!uniqueStrings.add(RandomStringUtils.randomAlphabetic(lengthOfEachString))) {
-        uniqueStrings.add(RandomStringUtils.randomAlphabetic(lengthOfEachString));
-      }
-    }
-    vals = new ArrayList<>(uniqueStrings);
   }
 
   @Override
@@ -76,7 +71,8 @@ public class StringGenerator implements Generator {
     if (counter == cardinality) {
       counter = 0;
     }
-    return vals.get(counter++);
+    counter++;
+    return initialValue + StringUtils.leftPad(String.valueOf(counter), counterLength, '0');
   }
 
   public static void main(String[] args) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/ConfigManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/ConfigManager.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.pinot.controller.recommender.rules.io.FlaggedQueries;
 import org.apache.pinot.controller.recommender.rules.io.configs.IndexConfig;
 import org.apache.pinot.controller.recommender.rules.io.configs.PartitionConfig;
+import org.apache.pinot.controller.recommender.rules.io.configs.SegmentSizeRecommendations;
 
 
 /**
@@ -37,11 +38,17 @@ import org.apache.pinot.controller.recommender.rules.io.configs.PartitionConfig;
  * The engine will do it's job of recommending by taking into account the overwritten config and honoring it.
  */
 public class ConfigManager {
+  SegmentSizeRecommendations _segmentSizeRecommendations;
   IndexConfig _indexConfig = new IndexConfig();
   PartitionConfig _partitionConfig = new PartitionConfig();
   FlaggedQueries _flaggedQueries = new FlaggedQueries();
   Map<String, Map<String, String>> _realtimeProvisioningRecommendations = new HashMap<>();
   boolean _aggregateMetrics = false;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  public void setSegmentSizeRecommendations(SegmentSizeRecommendations segmentSizeRecommendations) {
+    _segmentSizeRecommendations = segmentSizeRecommendations;
+  }
 
   @JsonSetter(nulls = Nulls.SKIP)
   public void setIndexConfig(IndexConfig indexConfig) {
@@ -67,6 +74,10 @@ public class ConfigManager {
   @JsonSetter(nulls = Nulls.SKIP)
   public void setAggregateMetrics(boolean aggregateMetrics) {
     _aggregateMetrics = aggregateMetrics;
+  }
+
+  public SegmentSizeRecommendations getSegmentSizeRecommendations() {
+    return _segmentSizeRecommendations;
   }
 
   public IndexConfig getIndexConfig() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/RulesToExecute.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/RulesToExecute.java
@@ -72,7 +72,7 @@ public class RulesToExecute {
     }
   }
   // All rules will execute by default unless explicitly specifying "recommendInvertedSortedIndexJoint" = "false"
-  boolean _recommendSegmentSize = DEFAULT_RECOMMEND_KAFKA_PARTITION;
+  boolean _recommendSegmentSize = DEFAULT_RECOMMEND_SEGMENT_SIZE;
   boolean _recommendKafkaPartition = DEFAULT_RECOMMEND_KAFKA_PARTITION;
   boolean _recommendPinotTablePartition = DEFAULT_RECOMMEND_PINOT_TABLE_PARTITION;
   boolean _recommendInvertedSortedIndexJoint = DEFAULT_RECOMMEND_INVERTED_SORTED_INDEX_JOINT;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/PinotTablePartitionRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/PinotTablePartitionRule.java
@@ -63,16 +63,12 @@ public class PinotTablePartitionRule extends AbstractRule {
 
   public PinotTablePartitionRule(InputManager input, ConfigManager output) {
     super(input, output);
-    this._params = input.getPartitionRuleParams();
+    _params = input.getPartitionRuleParams();
   }
 
   @Override
   public void run()
       throws InvalidInputException {
-    //**********Calculate size per record***************/
-    _input.estimateSizePerRecord();
-    //**************************************************/
-
     LOGGER.info("Recommending partition configurations");
 
     if (_input.getQps()
@@ -105,8 +101,7 @@ public class PinotTablePartitionRule extends AbstractRule {
 
     LOGGER.info("*Recommending number of partitions ");
     int numKafkaPartitions = _output.getPartitionConfig().getNumKafkaPartitions();
-    long offLineDataSizePerPush = _input.getNumRecordsPerPush() * _input.getSizePerRecord();
-    int optimalOfflinePartitions = (int) Math.ceil((double) offLineDataSizePerPush / _params.OPTIMAL_SIZE_PER_SEGMENT);
+    int optimalOfflinePartitions = (int) _output.getSegmentSizeRecommendations().getNumSegments();
     if (_input.getTableType().equalsIgnoreCase(REALTIME) || _input.getTableType().equalsIgnoreCase(HYBRID)) {
       //real time num of partitions should be the same value as the number of kafka partitions
       if (!_input.getOverWrittenConfigs().getPartitionConfig().isNumPartitionsRealtimeOverwritten()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRule.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.rules.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.recommender.exceptions.InvalidInputException;
+import org.apache.pinot.controller.recommender.io.ConfigManager;
+import org.apache.pinot.controller.recommender.io.InputManager;
+import org.apache.pinot.controller.recommender.realtime.provisioning.MemoryEstimator;
+import org.apache.pinot.controller.recommender.rules.AbstractRule;
+import org.apache.pinot.controller.recommender.rules.io.configs.SegmentSizeRecommendations;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+
+
+/**
+ * This rule generates a segment based on the provided schema characteristics and then recommends the followings
+ * using the size and number of records in the generated segments:
+ *   - number of segments
+ *   - number of records in each segment
+ *   - size of each segment
+ */
+public class SegmentSizeRule extends AbstractRule {
+
+  static final int MEGA_BYTE = 1024 * 1024;
+
+  public SegmentSizeRule(InputManager input, ConfigManager output) {
+    super(input, output);
+  }
+
+  @Override
+  public void run()
+      throws InvalidInputException {
+
+    if (_input.getTableType().equalsIgnoreCase("REALTIME")) {
+      // no need to estimate segment size & optimal number of segments for realtime only tables;
+      // RT Provisioning Rule will have a comprehensive analysis on that
+      return;
+    }
+
+    // generate a segment
+    TableConfig tableConfig = createTableConfig(_input.getSchema());
+    int numRowsInGeneratedSegment = _input.getSegmentSizeRuleParams().getNumRowsInGeneratedSegment();
+    File generatedSegmentDir =
+        new MemoryEstimator.SegmentGenerator(_input._schemaWithMetaData, _input._schema, tableConfig,
+            numRowsInGeneratedSegment, true).generate();
+
+    // estimate optimal segment count & size parameters
+    SegmentSizeRecommendations params = estimate(FileUtils.sizeOfDirectory(generatedSegmentDir),
+        _input.getSegmentSizeRuleParams().getDesiredSegmentSizeMb() * MEGA_BYTE, numRowsInGeneratedSegment,
+        _input.getNumRecordsPerPush());
+
+    // wire the recommendations
+    _output.setSegmentSizeRecommendations(params);
+    _input.capCardinalities((int) params.getNumRows());
+
+    // cleanup
+    try {
+      FileUtils.deleteDirectory(generatedSegmentDir);
+    } catch (IOException e) {
+      throw new RuntimeException("Cannot delete the generated segment directory", e);
+    }
+  }
+
+  /**
+   * Estimate optimal segment size parameters
+   * @param GSS  generated segment size
+   * @param DSS  desired segment size
+   * @param NRGS num records of generated segment
+   * @param NRPP num records per push
+   * @return recommendations on optimal segment count, size, and number of records
+   */
+  @VisibleForTesting
+  SegmentSizeRecommendations estimate(long GSS, int DSS, int NRGS, long NRPP) {
+
+    // calc num rows in desired segment
+    double sizeRatio = (double) DSS / GSS;
+    long numRowsInDesiredSegment = Math.round(NRGS * sizeRatio);
+
+    // calc optimal num segment
+    long optimalNumSegments = Math.round(NRPP / (double) numRowsInDesiredSegment);
+    optimalNumSegments = Math.max(optimalNumSegments, 1);
+
+    // revise optimal num rows in segment
+    long optimalNumRowsInSegment = Math.round(NRPP / (double) optimalNumSegments);
+
+    // calc optimal segment size
+    double rowRatio = (double) optimalNumRowsInSegment / NRGS;
+    long optimalSegmentSize = Math.round(GSS * rowRatio);
+
+    return new SegmentSizeRecommendations(optimalNumRowsInSegment, optimalNumSegments, optimalSegmentSize);
+  }
+
+  private TableConfig createTableConfig(Schema schema) {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(schema.getSchemaName())
+        .setNoDictionaryColumns(schema.getMetricNames())
+        .build();
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/configs/SegmentSizeRecommendations.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/configs/SegmentSizeRecommendations.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.rules.io.configs;
+
+
+/**
+ * The recommendations proposed by SegmentSizeRule
+ */
+public class SegmentSizeRecommendations {
+
+  private long numRows;
+  private long numSegments;
+  private long segmentSize;
+
+  public SegmentSizeRecommendations(long numRows, long numSegments, long segmentSize) {
+    this.numRows = numRows;
+    this.numSegments = numSegments;
+    this.segmentSize = segmentSize;
+  }
+
+  public SegmentSizeRecommendations() {
+  }
+
+  public long getNumRows() {
+    return numRows;
+  }
+
+  public void setNumRows(long numRows) {
+    this.numRows = numRows;
+  }
+
+  public long getNumSegments() {
+    return numSegments;
+  }
+
+  public void setNumSegments(long numSegments) {
+    this.numSegments = numSegments;
+  }
+
+  public long getSegmentSize() {
+    return segmentSize;
+  }
+
+  public void setSegmentSize(long segmentSize) {
+    this.segmentSize = segmentSize;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
@@ -37,6 +37,7 @@ public class RecommenderConstants {
   }
 
   public static class RulesToExecute {
+    public static final boolean DEFAULT_RECOMMEND_SEGMENT_SIZE = true;
     public static final boolean DEFAULT_RECOMMEND_FLAG_QUERY = true;
     public static final boolean DEFAULT_RECOMMEND_VARIED_LENGTH_DICTIONARY = true;
     public static final boolean DEFAULT_RECOMMEND_KAFKA_PARTITION = true;
@@ -87,6 +88,12 @@ public class RecommenderConstants {
     public static final String DEFAULT_MAX_USABLE_HOST_MEMORY = "48G";
     public static final int[] DEFAULT_NUM_HOURS = {2, 4, 6, 8, 10, 12};
     public static final int[] DEFAULT_NUM_HOSTS = {3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  }
+
+  public static class SegmentSizeRule {
+    public static final int DEFAULT_NUM_SEGMENTS = 1;
+    public static final int DEFAULT_DESIRED_SEGMENT_SIZE_MB = 500;
+    public static final int DEFAULT_NUM_ROWS_IN_GENERATED_SEGMENT = 50_000;
   }
 
   public static final String PQL = "pql";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/SegmentSizeRuleParams.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/SegmentSizeRuleParams.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.rules.io.params;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+
+/**
+ * Parameters used in SegmentSizeRule
+ */
+public class SegmentSizeRuleParams {
+
+  // Desired segment size in MB
+  private int desiredSegmentSizeMb = RecommenderConstants.SegmentSizeRule.DEFAULT_DESIRED_SEGMENT_SIZE_MB;
+
+  // Number for rows in the generated segment
+  private int numRowsInGeneratedSegment = RecommenderConstants.SegmentSizeRule.DEFAULT_NUM_ROWS_IN_GENERATED_SEGMENT;
+
+  public int getDesiredSegmentSizeMb() {
+    return desiredSegmentSizeMb;
+  }
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  public void setDesiredSegmentSizeMb(int desiredSegmentSizeMb) {
+    this.desiredSegmentSizeMb = desiredSegmentSizeMb;
+  }
+
+  public int getNumRowsInGeneratedSegment() {
+    return numRowsInGeneratedSegment;
+  }
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  public void setNumRowsInGeneratedSegment(int numRowsInGeneratedSegment) {
+    this.numRowsInGeneratedSegment = numRowsInGeneratedSegment;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRuleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRuleTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.rules.impl;
+
+import org.apache.pinot.controller.recommender.rules.io.configs.SegmentSizeRecommendations;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.recommender.rules.impl.SegmentSizeRule.MEGA_BYTE;
+import static org.testng.Assert.*;
+
+
+public class SegmentSizeRuleTest {
+
+  private static final SegmentSizeRule RULE = new SegmentSizeRule(null, null);
+  private static final int MILLION = 1_000_000;
+
+  @Test
+  public void testEstimate() {
+
+    /*
+     * NRPP -> num records per push
+     * NRGS -> num records of generated segment
+     * GSS  -> generated segment size
+     * DSS  -> desired segment size
+     */
+
+    long NRPP = 20 * MILLION;
+    int NRGS = 5 * MILLION;
+    long GSS = 50 * MEGA_BYTE;
+    int DSS = 120 * MEGA_BYTE;
+    SegmentSizeRecommendations params = RULE.estimate(GSS, DSS, NRGS, NRPP);
+    assertEquals(params.getNumSegments(), 2);
+    assertEquals(params.getSegmentSize(), 100 * MEGA_BYTE);
+    assertEquals(params.getNumRows(), 10 * MILLION);
+
+    NRPP = 22 * MILLION;
+    NRGS = 5 * MILLION;
+    GSS = 50 * MEGA_BYTE;
+    DSS = 120 * MEGA_BYTE;
+    params = RULE.estimate(GSS, DSS, NRGS, NRPP);
+    assertEquals(params.getNumSegments(), 2);
+    assertEquals(params.getSegmentSize(), 110 * MEGA_BYTE);
+    assertEquals(params.getNumRows(), 11 * MILLION);
+
+    NRPP = 18 * MILLION;
+    NRGS = 5 * MILLION;
+    GSS = 50 * MEGA_BYTE;
+    DSS = 120 * MEGA_BYTE;
+    params = RULE.estimate(GSS, DSS, NRGS, NRPP);
+    assertEquals(params.getNumSegments(), 2);
+    assertEquals(params.getSegmentSize(), 90 * MEGA_BYTE);
+    assertEquals(params.getNumRows(), 9 * MILLION);
+
+    NRPP = 16 * MILLION;
+    NRGS = 5 * MILLION;
+    GSS = 50 * MEGA_BYTE;
+    DSS = 120 * MEGA_BYTE;
+    params = RULE.estimate(GSS, DSS, NRGS, NRPP);
+    assertEquals(params.getNumSegments(), 1);
+    assertEquals(params.getSegmentSize(), 160 * MEGA_BYTE);
+    assertEquals(params.getNumRows(), 16 * MILLION);
+
+    NRPP = 2 * MILLION;
+    NRGS = 5 * MILLION;
+    GSS = 50 * MEGA_BYTE;
+    DSS = 120 * MEGA_BYTE;
+    params = RULE.estimate(GSS, DSS, NRGS, NRPP);
+    assertEquals(params.getNumSegments(), 1);
+    assertEquals(params.getSegmentSize(), 20 * MEGA_BYTE);
+    assertEquals(params.getNumRows(), 2 * MILLION);
+  }
+}

--- a/pinot-controller/src/test/resources/recommenderInput/DataSizeCalculationInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/DataSizeCalculationInput.json
@@ -18,12 +18,14 @@
         "name": "c",
         "dataType": "DOUBLE",
         "cardinality":2000,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "d",
         "dataType": "STRING",
         "cardinality":1000,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       }

--- a/pinot-controller/src/test/resources/recommenderInput/EmptyQueriesInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/EmptyQueriesInput.json
@@ -24,6 +24,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,6 +32,7 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       }
     ],
@@ -39,7 +41,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
@@ -12,6 +12,7 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
@@ -24,6 +25,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,18 +33,21 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":13,
+        "singleValueField": false,
         "numValuesPerEntry":3
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -73,7 +78,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidInput1.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidInput1.json
@@ -12,6 +12,7 @@
         "name": "b",
         "dataType": "BYTES",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2
       },
       {
@@ -24,6 +25,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,6 +33,7 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       }
     ],
@@ -39,7 +42,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidInput2.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidInput2.json
@@ -24,6 +24,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,6 +32,7 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       }
     ],
@@ -39,7 +41,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput.json
@@ -12,6 +12,7 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
@@ -24,6 +25,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -72,7 +74,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput2.json
+++ b/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput2.json
@@ -12,6 +12,7 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
@@ -24,6 +25,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,18 +33,21 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":13,
+        "singleValueField": false,
         "numValuesPerEntry":3
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -72,7 +77,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/NoDictionaryOnHeapDictionaryJointRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/NoDictionaryOnHeapDictionaryJointRuleInput.json
@@ -12,12 +12,14 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
         "name": "c",
         "dataType": "STRING",
         "cardinality": 100000000,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -32,18 +34,21 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":10000000,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":20,
+        "singleValueField": false,
         "numValuesPerEntry":3
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },

--- a/pinot-controller/src/test/resources/recommenderInput/PinotTablePartitionRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/PinotTablePartitionRuleInput.json
@@ -12,12 +12,14 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
         "name": "c",
         "dataType": "STRING",
         "cardinality": 100000000,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -32,18 +34,21 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":10000000,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":20,
+        "singleValueField": false,
         "numValuesPerEntry":3
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -73,7 +78,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput.json
@@ -5,15 +5,15 @@
       {
         "name": "a",
         "dataType": "INT",
-        "cardinality":1000001,
+        "cardinality":70000,
         "numValuesPerEntry":1
       },
       {
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
-        "singleValueField": false,
-        "numValuesPerEntry":1.5
+        "numValuesPerEntry":1.5,
+        "singleValueField": false
       },
       {
         "name": "c",
@@ -25,31 +25,31 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
-        "singleValueField": false,
         "numValuesPerEntry":2,
-        "averageLength" : 27
+        "averageLength" : 27,
+        "singleValueField": false
       },
       {
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
-        "singleValueField": false,
-        "numValuesPerEntry":4
+        "numValuesPerEntry":4,
+        "singleValueField": false
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":13,
-        "singleValueField": false,
-        "numValuesPerEntry":3
+        "numValuesPerEntry":3,
+        "singleValueField": false
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
-        "singleValueField": false,
         "numValuesPerEntry":2,
-        "averageLength" : 100
+        "averageLength" : 100,
+        "singleValueField": false
       },
       {
         "name": "h",
@@ -63,78 +63,113 @@
         "dataType": "STRING",
         "cardinality":7,
         "numValuesPerEntry":1,
-        "averageLength" : 25
+        "averageLength" : 25,
+        "singleValueField": false
       },
       {
         "name": "j",
         "dataType": "DOUBLE",
         "cardinality":4,
-        "numValuesPerEntry":1
+        "numValuesPerEntry":1.00000001,
+        "singleValueField": false
       }
     ],
     "metricFieldSpecs": [
       {
         "name": "k",
         "dataType": "DOUBLE",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {
         "name": "l",
         "dataType": "STRING",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10
       },
       {
         "name": "m",
         "dataType": "BYTES",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 25
       },
       {
         "name": "n",
         "dataType": "DOUBLE",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1
       },
       {
         "name": "o",
         "dataType": "DOUBLE",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 25
       },
       {
         "name": "p",
         "dataType": "DOUBLE",
-        "cardinality":10000,
+        "cardinality":1000,
         "numValuesPerEntry":1
       }
     ],
-    "timeFieldSpec": {
-      "incomingGranularitySpec": {
-        "dataType": "INT",
+    "dateTimeFieldSpecs": [
+      {
         "name": "t",
-        "timeType": "DAYS",
-        "cardinality":10000,
-        "numValuesPerEntry":1
+        "dataType": "INT",
+        "format": "1:DAYS:EPOCH",
+        "granularity": "1:DAYS",
+        "cardinality": 1000
       }
-    }
+    ]
   },
   "queriesWithWeights":{
     "select i from tableName where b in (2,4) and ((a in (1,2,3) and e = 4) or c = 7) and d in ('#VALUES', 23) and t > 500": 1,
     "select j from tableName where (a=3 and (h = 5 or f >34) and REGEXP_LIKE(i, 'as*')) or ((f = 3  or j in ('#VALUES', 4)) and REGEXP_LIKE(d, 'fl*'))": 2,
     "select f from tableName where (a=0 or (b=1 and (e in ('#VALUES',2) or c=7))) and TEXT_MATCH(d, 'dasd') and MAX(MAX(h,i),j)=4 and t<3": 4,
     "select f from tableName where (a=0 and b=1) or c=7 or (d = 7 and e =1)": 2,
-    "select f from tableName where t between 1 and 1000": 2,
-    "select f from tableName where a in (1,2,3) and b in ('#VALUES',4) and c in ('#VALUES',5) and t between 1 and 1000": 2
+    "select f from tableName where t between 1 and 1000": 2
   },
-  "qps": 250,
+  "qps": 400,
   "numMessagesPerSecInKafkaTopic":1000,
-  "numRecordsPerPush":1000000000,
+  "numRecordsPerPush":100000,
   "tableType": "HYBRID",
-  "latencySLA": 500
+  "latencySLA": 500,
+  "rulesToExecute": {
+    "recommendSegmentSize": true,
+    "recommendRealtimeProvisioning": false
+  },
+  "segmentSizeRuleParams": {
+    "desiredSegmentSizeMb": 5,
+    "numRowsInGeneratedSegment": 50000
+  },
+  "partitionRuleParams": {
+    "THRESHOLD_MAX_LATENCY_SLA_PARTITION": 1001
+  },
+  "bloomFilterRuleParams": {
+    "THRESHOLD_MIN_PERCENT_EQ_BLOOMFILTER" : 0.51
+  },
+  "invertedSortedIndexJointRuleParams": {
+    "THRESHOLD_RATIO_MIN_GAIN_DIFF_BETWEEN_ITERATION" : 0.06
+  },
+  "noDictionaryOnHeapDictionaryJointRuleParams": {
+    "THRESHOLD_MIN_PERCENT_DICTIONARY_STORAGE_SAVE" : 0.96
+  },
+  "realtimeProvisioningRuleParams": {
+    "numPartitions": 10,
+    "numReplicas": 3,
+    "realtimeTableRetentionHours": 72,
+    "maxUsableHostMemory": "60G",
+    "numHours": [2, 4, 6, 8, 10, 12],
+    "numHosts": [3, 6, 9, 12, 15, 18, 21]
+  },
+  "overWrittenConfigs": {
+    "indexConfig": {
+      "invertedIndexColumns": ["a","b"],
+      "rangeIndexColumns": ["f"]
+    }
+  }
 }

--- a/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
@@ -12,6 +12,7 @@
         "name": "b",
         "dataType": "DOUBLE",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":1.5
       },
       {
@@ -24,6 +25,7 @@
         "name": "d",
         "dataType": "STRING",
         "cardinality":41,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 27
       },
@@ -31,18 +33,21 @@
         "name": "e",
         "dataType": "LONG",
         "cardinality":18,
+        "singleValueField": false,
         "numValuesPerEntry":4
       },
       {
         "name": "f",
         "dataType": "DOUBLE",
         "cardinality":13,
+        "singleValueField": false,
         "numValuesPerEntry":3
       },
       {
         "name": "g",
         "dataType": "STRING",
         "cardinality":6,
+        "singleValueField": false,
         "numValuesPerEntry":2,
         "averageLength" : 100
       },
@@ -73,7 +78,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {

--- a/pinot-controller/src/test/resources/recommenderInput/VariedLengthDictionaryInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/VariedLengthDictionaryInput.json
@@ -39,7 +39,7 @@
         "name": "k",
         "dataType": "DOUBLE",
         "cardinality":10000,
-        "numValuesPerEntry":2,
+        "numValuesPerEntry":1,
         "averageLength" : 100
       },
       {


### PR DESCRIPTION
## Description
This PR adds a new rule to Rule Engine. This rule recommend some parameters related to segment size for offline tables. The rule generates a segment based on the provided schema characteristics and then recommends the followings using the size and number of records in the generated segments:
- number of segments 
- number of records in each segment
- size of each segment

## Testing Done
Unit & integration tests

