### PR TITLE
add a metirc of ideal state size after gzip

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -11,8 +11,8 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.idealstateZnodeGzipSize.(\\w+)_(\\w+)\"><>(\\w+)"
-  name: "pinot_controller_idealstateZnodeGzipSize_$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.idealstateZnodeByteSize.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_idealstateZnodeByteSize_$3"
   labels:
     table: "$1"
     tableType: "$2"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -11,6 +11,11 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.idealstateZnodeGzipSize.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_idealstateZnodeGzipSize_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.numberOfReplicas.(\\w+)_(\\w+)\"><>(\\w+)"
   name: "pinot_controller_numberOfReplicas_$3"
   labels:

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -40,7 +40,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   SEGMENT_COUNT("SegmentCount", false),
   IDEALSTATE_ZNODE_SIZE("idealstate", false),
-  IDEALSTATE_ZNODE_GZIP_SIZE("idealstate", false),
+  IDEALSTATE_ZNODE_BYTE_SIZE("idealstate", false),
   REALTIME_TABLE_COUNT("TableCount", true),
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -40,6 +40,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   SEGMENT_COUNT("SegmentCount", false),
   IDEALSTATE_ZNODE_SIZE("idealstate", false),
+  IDEALSTATE_ZNODE_GZIP_SIZE("idealstate", false),
   REALTIME_TABLE_COUNT("TableCount", true),
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -147,7 +147,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     }
 
     _controllerMetrics
-        .setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE,  idealState.toString().length());
+        .setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE, idealState.toString().length());
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_BYTE_SIZE,
         idealState.serialize(_recordSerializer).length);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.util.GZipCompressionUtil;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -149,7 +148,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
     _controllerMetrics
         .setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE,  idealState.toString().length());
-    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_GZIP_SIZE,
+    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_BYTE_SIZE,
         idealState.serialize(_recordSerializer).length);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT,
         (long) (idealState.getPartitionSet().size()));


### PR DESCRIPTION
Today controller emits a metric `pinot.controller.idealstateZnodeSize`. The znode size is useful to monitor znode size is less than 1MB, otherwise Helix cannot process the znode. However, the reported size is before the gzip compression, not the actual size stored in zk.  Add a new metric of the znode size after gzip. Note that the difference of the znode size before and after gzip could be significant (e.g. >100X~1000X).

**<code>release-notes</code>**
Add a new metric `pinot.controller.idealstateZnodeGzipSize` to emit the idealstate znode size after gzip compression.

