### PR TITLE
Make zookeeper, kafka, controller, broker use random port for integration tests

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Unit Test
         env:
           RUN_INTEGRATION_TESTS: false
+          MAVEN_OPTS: -Xmx2G -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         run: |
@@ -65,6 +66,7 @@ jobs:
       - name: Integration Test
         env:
           RUN_INTEGRATION_TESTS: true
+          MAVEN_OPTS: -Xmx2G -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         run: |

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -29,7 +29,6 @@ import org.apache.pinot.broker.routing.RoutingTable;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.helix.ControllerTest;
@@ -79,7 +78,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, 18099);
     
     _brokerStarter =
-        new HelixBrokerStarter(new PinotConfiguration(properties), getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR);
+        new HelixBrokerStarter(new PinotConfiguration(properties), getHelixClusterName(), getZkUrl());
     _brokerStarter.start();
 
     addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKERS - 1, true);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -78,7 +78,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
   private HelixManager initHelixManager(String helixClusterName) {
     return new FakeHelixManager(helixClusterName, BROKER_INSTANCE_ID, InstanceType.PARTICIPANT,
-        ZkStarter.DEFAULT_ZK_STR);
+        _zookeeperInstance.getZkUrl());
   }
 
   public class FakeHelixManager extends ZKHelixManager {
@@ -86,7 +86,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     FakeHelixManager(String clusterName, String instanceName, InstanceType instanceType, String zkAddress) {
       super(clusterName, instanceName, instanceType, zkAddress);
-      super._zkclient = new ZkClient(StringUtil.join("/", StringUtils.chomp(ZkStarter.DEFAULT_ZK_STR, "/")),
+      super._zkclient = new ZkClient(StringUtil.join("/", StringUtils.chomp(_zookeeperInstance.getZkUrl(), "/")),
           ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, new ZNRecordSerializer());
       _zkclient.deleteRecursively("/" + clusterName + "/PROPERTYSTORE");
       _zkclient.createPersistent("/" + clusterName + "/PROPERTYSTORE", true);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -104,7 +104,7 @@ public class SegmentPrunerTest {
   public void setUp() {
     _zkInstance = ZkStarter.startLocalZkServer();
     _zkClient =
-        new ZkClient(ZkStarter.DEFAULT_ZK_STR, ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZkClient(_zkInstance.getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
             new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/SegmentPrunerTest/PROPERTYSTORE", null);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -59,7 +59,7 @@ public class TimeBoundaryManagerTest {
   public void setUp() {
     _zkInstance = ZkStarter.startLocalZkServer();
     _zkClient =
-        new ZkClient(ZkStarter.DEFAULT_ZK_STR, ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZkClient(_zkInstance.getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
             new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/TimeBoundaryManagerTest/PROPERTYSTORE", null);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 import org.I0Itec.zkclient.ZkClient;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
 import org.apache.zookeeper.server.admin.AdminServer;
@@ -34,16 +35,22 @@ import org.slf4j.LoggerFactory;
 public class ZkStarter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZkStarter.class);
   public static final int DEFAULT_ZK_TEST_PORT = 2191;
-  public static final String DEFAULT_ZK_STR = "localhost:" + DEFAULT_ZK_TEST_PORT;
   private static final int DEFAULT_ZK_CLIENT_RETRIES = 10;
+  private static int ZK_TEST_PORT = 2191;
 
   public static class ZookeeperInstance {
     private PublicZooKeeperServerMain _serverMain;
     private String _dataDirPath;
+    private int _port;
 
-    private ZookeeperInstance(PublicZooKeeperServerMain serverMain, String dataDirPath) {
+    private ZookeeperInstance(PublicZooKeeperServerMain serverMain, String dataDirPath, int port) {
       _serverMain = serverMain;
       _dataDirPath = dataDirPath;
+      _port = port;
+    }
+
+    public String getZkUrl() {
+      return "localhost:" + _port;
     }
   }
 
@@ -130,7 +137,11 @@ public class ZkStarter {
    * Starts an empty local Zk instance on the default port
    */
   public static ZookeeperInstance startLocalZkServer() {
-    return startLocalZkServer(DEFAULT_ZK_TEST_PORT);
+    return startLocalZkServer(NetUtils.findOpenPort(DEFAULT_ZK_TEST_PORT));
+  }
+
+  public static String getDefaultZkStr() {
+    return "localhost:" + ZK_TEST_PORT;
   }
 
   /**
@@ -180,7 +191,7 @@ public class ZkStarter {
           }
         }
       }
-      return new ZookeeperInstance(zookeeperServerMain, dataDirPath);
+      return new ZookeeperInstance(zookeeperServerMain, dataDirPath, port);
     } catch (Exception e) {
       LOGGER.warn("Caught exception while starting ZK", e);
       throw new RuntimeException(e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ZkStarter.java
@@ -36,7 +36,6 @@ public class ZkStarter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ZkStarter.class);
   public static final int DEFAULT_ZK_TEST_PORT = 2191;
   private static final int DEFAULT_ZK_CLIENT_RETRIES = 10;
-  private static int ZK_TEST_PORT = 2191;
 
   public static class ZookeeperInstance {
     private PublicZooKeeperServerMain _serverMain;
@@ -141,7 +140,7 @@ public class ZkStarter {
   }
 
   public static String getDefaultZkStr() {
-    return "localhost:" + ZK_TEST_PORT;
+    return "localhost:" + DEFAULT_ZK_TEST_PORT;
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/http/MultiGetRequestTest.java
@@ -145,6 +145,10 @@ public class MultiGetRequestTest {
         }
       } catch (IOException e) {
         ++errors;
+      } finally {
+        if (getMethod != null) {
+          getMethod.releaseConnection();
+        }
       }
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -147,7 +147,7 @@ public abstract class ControllerTestUtils {
     properties.put(ControllerConf.CONTROLLER_HOST, LOCAL_HOST);
     properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT);
     properties.put(ControllerConf.DATA_DIR, DEFAULT_DATA_DIR);
-    properties.put(ControllerConf.ZK_STR, ZkStarter.DEFAULT_ZK_STR);
+    properties.put(ControllerConf.ZK_STR, _zookeeperInstance.getZkUrl());
     properties.put(ControllerConf.HELIX_CLUSTER_NAME, getHelixClusterName());
 
     return properties;
@@ -234,7 +234,7 @@ public abstract class ControllerTestUtils {
       throws Exception {
     HelixManager helixManager =
         HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            ZkStarter.DEFAULT_ZK_STR);
+            _zookeeperInstance.getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeBrokerResourceOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeBrokerResourceOnlineOfflineStateModelFactory.FACTORY_INSTANCE);
@@ -333,7 +333,7 @@ public abstract class ControllerTestUtils {
       int adminPort) throws Exception {
     HelixManager helixManager =
         HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            ZkStarter.DEFAULT_ZK_STR);
+            _zookeeperInstance.getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeSegmentOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeSegmentOnlineOfflineStateModelFactory.FACTORY_INSTANCE);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
@@ -42,11 +42,12 @@ public class ControllerPeriodicTaskStarterStatelessTest extends ControllerTest {
   @Test
   public void testHelixResourceManagerDuringControllerStart() {
     startController();
+    stopController();
   }
 
   @AfterClass
   public void teardown() {
-    stopController();
+    stopZk();
   }
 
   @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -75,6 +75,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,13 +133,17 @@ public abstract class ControllerTest {
     }
   }
 
+  protected String getZkUrl() {
+    return _zookeeperInstance.getZkUrl();
+  }
+
   public Map<String, Object> getDefaultControllerConfiguration() {
     Map<String, Object> properties = new HashMap<>();
 
     properties.put(ControllerConf.CONTROLLER_HOST, LOCAL_HOST);
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT);
+    properties.put(ControllerConf.CONTROLLER_PORT, NetUtils.findOpenPort(DEFAULT_CONTROLLER_PORT));
     properties.put(ControllerConf.DATA_DIR, DEFAULT_DATA_DIR);
-    properties.put(ControllerConf.ZK_STR, ZkStarter.DEFAULT_ZK_STR);
+    properties.put(ControllerConf.ZK_STR, getZkUrl());
     properties.put(ControllerConf.HELIX_CLUSTER_NAME, getHelixClusterName());
 
     return properties;
@@ -193,6 +198,10 @@ public abstract class ControllerTest {
     return new ControllerStarter(config);
   }
 
+  protected int getControllerPort() {
+    return _controllerPort;
+  }
+
   protected void stopController() {
     _controllerStarter.stop();
     _controllerStarter = null;
@@ -210,7 +219,7 @@ public abstract class ControllerTest {
       throws Exception {
     HelixManager helixManager =
         HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            ZkStarter.DEFAULT_ZK_STR);
+            getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeBrokerResourceOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeBrokerResourceOnlineOfflineStateModelFactory.FACTORY_INSTANCE);
@@ -295,7 +304,7 @@ public abstract class ControllerTest {
       throws Exception {
     HelixManager helixManager =
         HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            ZkStarter.DEFAULT_ZK_STR);
+            getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeSegmentOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeSegmentOnlineOfflineStateModelFactory.FACTORY_INSTANCE);
@@ -394,7 +403,7 @@ public abstract class ControllerTest {
       throws Exception {
     HelixManager helixManager =
         HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            ZkStarter.DEFAULT_ZK_STR);
+            getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeMinionResourceOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeMinionResourceOnlineOfflineStateModelFactory.FACTORY_INSTANCE);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeStatelessTest.java
@@ -28,7 +28,6 @@ import org.apache.helix.model.ConstraintItem;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Message;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerStarter;
@@ -114,7 +113,6 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
     // Start the second dual-mode controller
     properties = getDefaultControllerConfiguration();
     properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.DUAL);
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
     ControllerStarter secondDualModeController = getControllerStarter(new ControllerConf(properties));
     secondDualModeController.start();
     TestUtils
@@ -153,7 +151,7 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
       return result;
     }, TIMEOUT_IN_MS, "No one should be the partition leader for tables");
 
-    ZkClient zkClient = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
+    ZkClient zkClient = new ZkClient(getZkUrl());
     TestUtils
         .waitForCondition(aVoid -> !zkClient.exists("/" + getHelixClusterName() + "/CONTROLLER/LEADER"), TIMEOUT_IN_MS,
             "No cluster leader should be shown in Helix cluster");
@@ -161,7 +159,6 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
 
     properties = getDefaultControllerConfiguration();
     properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.DUAL);
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 2);
 
     ControllerStarter thirdDualModeController = getControllerStarter(new ControllerConf(properties));
     thirdDualModeController.start();
@@ -215,7 +212,6 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
     // Start a Helix-only controller
     properties = getDefaultControllerConfiguration();
     properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.HELIX_ONLY);
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
 
     ControllerStarter helixOnlyController = new ControllerStarter(new ControllerConf(properties));
     helixOnlyController.start();
@@ -235,7 +231,6 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
     // Start the second Pinot-only controller
     properties = getDefaultControllerConfiguration();
     properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.PINOT_ONLY);
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 2);
 
     ControllerStarter secondPinotOnlyController = getControllerStarter(new ControllerConf(properties));
     secondPinotOnlyController.start();
@@ -291,7 +286,7 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
 
   @AfterMethod
   public void cleanUpCluster() {
-    ZkClient zkClient = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
+    ZkClient zkClient = new ZkClient(getZkUrl());
     if (zkClient.exists("/" + getHelixClusterName())) {
       zkClient.deleteRecursive("/" + getHelixClusterName());
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -244,6 +244,9 @@ public class SegmentDeletionManagerTest {
       createTestFileWithAge(dummyDir2.getAbsolutePath() + File.separator + "file" + i, i);
     }
 
+    // Sleep 1 second to ensure the clock moves.
+    Thread.sleep(1000L);
+
     // Check that dummy directories and files are successfully created.
     Assert.assertEquals(dummyDir1.list().length, 3);
     Assert.assertEquals(dummyDir2.list().length, 3);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -30,12 +30,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.Request;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
@@ -74,6 +74,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected static final long DEFAULT_COUNT_STAR_RESULT = 115545L;
   protected static final int DEFAULT_LLC_SEGMENT_FLUSH_SIZE = 5000;
   protected static final int DEFAULT_HLC_SEGMENT_FLUSH_SIZE = 20000;
+  protected static final int DEFAULT_TRANSACTION_NUM_KAFKA_BROKERS = 3;
   protected static final int DEFAULT_LLC_NUM_KAFKA_BROKERS = 2;
   protected static final int DEFAULT_HLC_NUM_KAFKA_BROKERS = 1;
   protected static final int DEFAULT_LLC_NUM_KAFKA_PARTITIONS = 2;
@@ -147,6 +148,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected int getNumKafkaBrokers() {
+    if (useKafkaTransaction()) {
+      return DEFAULT_TRANSACTION_NUM_KAFKA_BROKERS;
+    }
     if (useLlc()) {
       return DEFAULT_LLC_NUM_KAFKA_BROKERS;
     } else {
@@ -159,7 +163,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected String getKafkaZKAddress() {
-    return KafkaStarterUtils.DEFAULT_ZK_STR;
+    return getZkUrl() + "/kafka";
   }
 
   protected int getNumKafkaPartitions() {
@@ -315,7 +319,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
               StreamConfig.ConsumerType.LOWLEVEL.toString());
       streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST),
-          KafkaStarterUtils.DEFAULT_KAFKA_BROKER);
+          "localhost:" + _kafkaStarters.get(0).getPort());
       if (useKafkaTransaction()) {
         streamConfigMap.put(KafkaStreamConfigProperties
                 .constructStreamProperty(KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL),
@@ -328,10 +332,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
               StreamConfig.ConsumerType.HIGHLEVEL.toString());
       streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_ZK_CONNECTION_STRING),
-          KafkaStarterUtils.DEFAULT_ZK_STR);
+          getKafkaZKAddress());
       streamConfigMap.put(KafkaStreamConfigProperties
               .constructStreamProperty(KafkaStreamConfigProperties.HighLevelConsumer.KAFKA_HLC_BOOTSTRAP_SERVER),
-          KafkaStarterUtils.DEFAULT_KAFKA_BROKER);
+          "localhost:" + _kafkaStarters.get(0).getPort());
     }
     streamConfigMap.put(StreamConfigProperties
             .constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
@@ -398,7 +402,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    */
   protected org.apache.pinot.client.Connection getPinotConnection() {
     if (_pinotConnection == null) {
-      _pinotConnection = ConnectionFactory.fromZookeeper(ZkStarter.DEFAULT_ZK_STR + "/" + getHelixClusterName());
+      _pinotConnection = ConnectionFactory.fromZookeeper(getZkUrl() + "/" + getHelixClusterName());
     }
     return _pinotConnection;
   }
@@ -500,8 +504,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected void startKafka() {
+    Properties kafkaConfig = KafkaStarterUtils.getDefaultKafkaConfiguration();
     _kafkaStarters = KafkaStarterUtils.startServers(getNumKafkaBrokers(), getBaseKafkaPort(), getKafkaZKAddress(),
-        KafkaStarterUtils.getDefaultKafkaConfiguration());
+        kafkaConfig);
     _kafkaStarters.get(0)
         .createTopic(getKafkaTopic(), KafkaStarterUtils.getTopicCreationProps(getNumKafkaPartitions()));
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -100,7 +100,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   public void testBrokerNoAuth()
       throws Exception {
     JsonNode response =
-        JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT now()\"}"));
+        JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT now()\"}"));
     Assert.assertFalse(response.has("resultTable"), "must not return result table");
     Assert.assertTrue(response.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
   }
@@ -109,7 +109,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   public void testBroker()
       throws Exception {
     JsonNode response = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
+        sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
     Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
         "must return result with LONG value");
     Assert.assertTrue(response.get("exceptions").isEmpty(), "must not return exception");
@@ -165,7 +165,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
 
     // admin with full access
     JsonNode response = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+        sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
             AUTH_HEADER));
     Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
         "must return result with LONG value");
@@ -177,7 +177,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
 
     // user with valid auth but no table access
     JsonNode responseUser = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+        sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
             AUTH_HEADER_USER));
     Assert.assertFalse(responseUser.has("resultTable"), "must not return result table");
     Assert.assertTrue(responseUser.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -57,7 +57,9 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    // Start Zookeeper
     startZk();
+    // Start the Pinot cluster
     startController();
     startBroker();
     startServer();
@@ -98,7 +100,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   public void testBrokerNoAuth()
       throws Exception {
     JsonNode response =
-        JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}"));
+        JsonUtils.stringToJsonNode(sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT now()\"}"));
     Assert.assertFalse(response.has("resultTable"), "must not return result table");
     Assert.assertTrue(response.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
   }
@@ -107,7 +109,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   public void testBroker()
       throws Exception {
     JsonNode response = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
+        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT now()\"}", AUTH_HEADER));
     Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
         "must return result with LONG value");
     Assert.assertTrue(response.get("exceptions").isEmpty(), "must not return exception");
@@ -116,7 +118,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   @Test
   public void testControllerGetTables()
       throws Exception {
-    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest("http://localhost:18998/tables", AUTH_HEADER));
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest("http://localhost:" + getControllerPort() + "/tables", AUTH_HEADER));
     Assert.assertTrue(response.get("tables").isArray(), "must return table array");
   }
 
@@ -125,7 +127,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
       throws Exception {
     try {
       // NOTE: the endpoint is protected implicitly (without annotation) by BasicAuthAccessControlFactory
-      sendGetRequest("http://localhost:18998/tables");
+      sendGetRequest("http://localhost:" + getControllerPort() + "/tables");
     } catch (IOException e) {
       Assert.assertTrue(e.getMessage().contains("HTTP"));
       Assert.assertTrue(e.getMessage().contains("403"));
@@ -153,17 +155,17 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
 
     // patch ingestion job file
     String jobFileContents = IOUtils.toString(new FileInputStream(jobFile));
-    IOUtils.write(jobFileContents.replaceAll("9000", String.valueOf(DEFAULT_CONTROLLER_PORT)),
+    IOUtils.write(jobFileContents.replaceAll("9000", String.valueOf(getControllerPort())),
         new FileOutputStream(jobFile));
 
-    new BootstrapTableTool("http", "localhost", DEFAULT_CONTROLLER_PORT, baseDir.getAbsolutePath(), AUTH_TOKEN)
+    new BootstrapTableTool("http", "localhost", getControllerPort(), baseDir.getAbsolutePath(), AUTH_TOKEN)
         .execute();
 
     Thread.sleep(5000);
 
     // admin with full access
     JsonNode response = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
             AUTH_HEADER));
     Assert.assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(0).asText(), "LONG",
         "must return result with LONG value");
@@ -175,7 +177,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
 
     // user with valid auth but no table access
     JsonNode responseUser = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:18099/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
+        sendPostRequest("http://localhost:" + getBrokerPort(0) + "/query/sql", "{\"sql\":\"SELECT count(*) FROM baseballStats\"}",
             AUTH_HEADER_USER));
     Assert.assertFalse(responseUser.has("resultTable"), "must not return result table");
     Assert.assertTrue(responseUser.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
@@ -32,7 +32,6 @@ import org.apache.pinot.client.Connection;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.Request;
 import org.apache.pinot.client.ResultSetGroup;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
@@ -55,7 +54,9 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
       throws Exception {
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
 
+    // Start Zookeeper
     startZk();
+    // Start Pinot cluster
     startKafka();
     startController();
     startBroker();
@@ -141,7 +142,7 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
   protected Connection getPinotConnection() {
     if (_pinotConnection == null) {
       _pinotConnection =
-          ConnectionFactory.fromZookeeper(ZkStarter.DEFAULT_ZK_STR + "/" + getHelixClusterName(), AUTH_HEADER);
+          ConnectionFactory.fromZookeeper(getZkUrl() + "/" + getHelixClusterName(), AUTH_HEADER);
     }
     return _pinotConnection;
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -82,6 +83,7 @@ import static org.testng.Assert.assertTrue;
 public abstract class ClusterTest extends ControllerTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterTest.class);
   private static final int DEFAULT_BROKER_PORT = 18099;
+  private static final Random RANDOM = new Random(System.currentTimeMillis());
 
   protected String _brokerBaseApiUrl;
 
@@ -129,6 +131,10 @@ public abstract class ClusterTest extends ControllerTest {
       _brokerStarters.add(brokerStarter);
     }
     _brokerBaseApiUrl = "http://localhost:" + _brokerPorts.get(0);
+  }
+
+  protected int getRandomBrokerPort() {
+    return _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
   }
 
   protected int getBrokerPort(int index) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -22,7 +22,9 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -65,6 +67,22 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Wait for all documents loaded
     waitForAllDocsLoaded(10_000L);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropRealtimeTable(getTableName());
+
+    // Stop the Pinot cluster
+    stopServer();
+    stopBroker();
+    stopController();
+    // Stop Kafka
+    stopKafka();
+    // Stop Zookeeper
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.integration.tests;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.server.starter.helix.HelixServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -56,7 +55,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
       int expectedPort)
       throws Exception {
     HelixServerStarter helixServerStarter =
-        new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, serverConf);
+        new HelixServerStarter(getHelixClusterName(), getZkUrl(), serverConf);
     helixServerStarter.start();
     helixServerStarter.stop();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
@@ -66,7 +66,6 @@ public class ControllerLeaderLocatorIntegrationTest extends ControllerTest {
     validateResultSet(controllerLeaderLocator, resultSet, 1, "Failed to get only one pair of controller");
 
     Map<String, Object> properties = getDefaultControllerConfiguration();
-    properties.put(ControllerConf.CONTROLLER_PORT, DEFAULT_CONTROLLER_PORT + 1);
     ControllerStarter secondControllerStarter = new ControllerStarter(new ControllerConf(properties));
     secondControllerStarter.start();
 
@@ -93,7 +92,7 @@ public class ControllerLeaderLocatorIntegrationTest extends ControllerTest {
         _partitionToTableMap.get(new Random().nextInt(Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE)));
 
     Assert.assertEquals(pair.getFirst(), ControllerTest.LOCAL_HOST);
-    Assert.assertEquals((int) pair.getSecond(), ControllerTest.DEFAULT_CONTROLLER_PORT);
+    Assert.assertEquals((int) pair.getSecond(), getControllerPort());
 
     // Stop the second controller.
     secondControllerStarter.stop();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataServerStartable.java
@@ -95,4 +95,9 @@ public class KafkaDataServerStartable implements StreamDataServerStartable {
     Collection<NewTopic> topicList = Arrays.asList(new NewTopic(topic, partition, (short) 1));
     adminClient.createTopics(topicList);
   }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataServerStartable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataServerStartable.java
@@ -53,4 +53,9 @@ public interface StreamDataServerStartable {
    * @param topicProps
    */
   void createTopic(String topic, Properties topicProps);
+
+  /**
+   * Get the port of the server.
+   */
+  int getPort();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
@@ -73,19 +73,15 @@ public class NetUtils {
   }
 
   /**
-   * Find an open port，otherwise use given default port.
-   * @param defaultPort
-   * @return an open port otherwise default port
+   * Find the first open port from default port in an incremental order.
+   * @param basePort
+   * @return an open port
    */
-  public static int findOpenPort(int defaultPort) {
-    if (available(defaultPort)) {
-      return defaultPort;
+  public static int findOpenPort(int basePort) {
+    while (!available(basePort)) {
+      basePort++;
     }
-    int port = defaultPort;
-    while (available(++port)) {
-      return port;
-    }
-    throw new RuntimeException("Unable to find an open port from range: [ " + defaultPort + ", " + port + " ]");
+    return basePort;
   }
 
   /**
@@ -103,6 +99,7 @@ public class NetUtils {
       ds.setReuseAddress(true);
       return true;
     } catch (IOException e) {
+      return false;
     } finally {
       if (ds != null) {
         ds.close();
@@ -115,6 +112,5 @@ public class NetUtils {
         }
       }
     }
-    return false;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GenericQuickstart.java
@@ -72,7 +72,7 @@ public class GenericQuickstart {
     _zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
       _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
-          KafkaStarterUtils.getDefaultKafkaConfiguration());
+          KafkaStarterUtils.getDefaultKafkaConfiguration(_zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
@@ -52,7 +52,7 @@ public class GitHubEventsQuickstart {
     _zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
       _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
-          KafkaStarterUtils.getDefaultKafkaConfiguration());
+          KafkaStarterUtils.getDefaultKafkaConfiguration(_zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -91,7 +91,7 @@ public class HybridQuickstart {
     _zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
       _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
-          KafkaStarterUtils.getDefaultKafkaConfiguration());
+          KafkaStarterUtils.getDefaultKafkaConfiguration(_zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -70,7 +70,7 @@ public class RealtimeJsonIndexQuickStart {
     ZkStarter.ZookeeperInstance zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
       _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
-          KafkaStarterUtils.getDefaultKafkaConfiguration());
+          KafkaStarterUtils.getDefaultKafkaConfiguration(zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -70,7 +70,8 @@ public class RealtimeQuickStart {
     printStatus(Color.CYAN, "***** Starting Kafka *****");
     final ZkStarter.ZookeeperInstance zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
-      _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, KafkaStarterUtils.getDefaultKafkaConfiguration());
+      _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
+          KafkaStarterUtils.getDefaultKafkaConfiguration(zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -70,7 +70,7 @@ public class UpsertQuickStart {
     final ZkStarter.ZookeeperInstance zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
       _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
-          KafkaStarterUtils.getDefaultKafkaConfiguration());
+          KafkaStarterUtils.getDefaultKafkaConfiguration(zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
@@ -46,7 +46,7 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
   private int _brokerId = KafkaStarterUtils.DEFAULT_BROKER_ID;
 
   @Option(name = "-zkAddress", required = false, metaVar = "<string>", usage = "Address of Zookeeper.")
-  private String _zkAddress = KafkaStarterUtils.DEFAULT_ZK_STR;
+  private String _zkAddress = KafkaStarterUtils.getDefaultKafkaZKAddress();
   private StreamDataServerStartable _kafkaStarter;
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KafkaStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KafkaStarterUtils.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.ServiceLoader;
+import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
@@ -29,8 +30,6 @@ import org.apache.pinot.spi.stream.StreamDataServerStartable;
 
 public class KafkaStarterUtils {
   public static final int DEFAULT_BROKER_ID = 0;
-  public static final int DEFAULT_ZK_TEST_PORT = 2191;
-  public static final String DEFAULT_ZK_STR = "localhost:" + DEFAULT_ZK_TEST_PORT + "/kafka";
   public static int DEFAULT_KAFKA_PORT = 19092;
   public static final String DEFAULT_KAFKA_BROKER = "localhost:" + DEFAULT_KAFKA_PORT;
 
@@ -69,7 +68,7 @@ public class KafkaStarterUtils {
     configureOffsetsTopicReplicationFactor(configuration, (short) 1);
     configuration.put(PORT, DEFAULT_KAFKA_PORT);
     configuration.put(BROKER_ID, DEFAULT_BROKER_ID);
-    configuration.put(ZOOKEEPER_CONNECT, DEFAULT_ZK_STR);
+    configuration.put(ZOOKEEPER_CONNECT, getDefaultKafkaZKAddress());
     configuration.put(LOG_DIRS, "/tmp/kafka-" + Double.toHexString(Math.random()));
 
     return configuration;
@@ -91,6 +90,10 @@ public class KafkaStarterUtils {
     configuration.put("host.name", hostName);
   }
 
+  public static String getDefaultKafkaZKAddress() {
+    return ZkStarter.getDefaultZkStr() + "/kafka";
+  }
+
   public static Properties getTopicCreationProps(int numKafkaPartitions) {
     Properties topicProps = new Properties();
     topicProps.put("partition", numKafkaPartitions);
@@ -108,8 +111,9 @@ public class KafkaStarterUtils {
   }
 
   public static StreamDataServerStartable startServer(final int port, final int brokerId, final String zkStr,
-      final Properties configuration) {
+      final Properties baseConf) {
     StreamDataServerStartable kafkaStarter;
+    Properties configuration = new Properties(baseConf);
     try {
       configureOffsetsTopicReplicationFactor(configuration, (short) 1);
       configuration.put(KafkaStarterUtils.PORT, port);
@@ -122,5 +126,11 @@ public class KafkaStarterUtils {
     }
     kafkaStarter.start();
     return kafkaStarter;
+  }
+
+  public static Properties getDefaultKafkaConfiguration(ZkStarter.ZookeeperInstance zookeeperInstance) {
+    Properties kafkaConfiguration = getDefaultKafkaConfiguration();
+    kafkaConfiguration.put(ZOOKEEPER_CONNECT, zookeeperInstance.getZkUrl() + "/kafka");
+    return kafkaConfiguration;
   }
 }


### PR DESCRIPTION
## Description
To improve the integration test stability:
1. Adding methods in NetUtils class to find an open port
2. Make zookeeper/Kafka/controller/broker use the random ports for integration tests.
3. Use 3 Kafka brokers for ExactlyOnceKafkaRealtimeClusterIntegrationTest.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
