### PR TITLE
Allow empty string in MV column

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
@@ -71,22 +71,22 @@ public class SegmentProcessingFrameworkTest {
   private Schema _pinotSchemaMV;
   private TableConfig _tableConfig;
   private final List<Object[]> _rawDataMultipleDays = Lists
-      .newArrayList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{"pqr", 2000, 1597773600000L},
+      .newArrayList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{null, 2000, 1597773600000L},
           new Object[]{"abc", 1000, 1597777200000L}, new Object[]{"abc", 4000, 1597795200000L},
-          new Object[]{"abc", 3000, 1597802400000L}, new Object[]{"pqr", 1000, 1597838400000L},
-          new Object[]{"xyz", 4000, 1597856400000L}, new Object[]{"pqr", 1000, 1597878000000L},
+          new Object[]{"abc", 3000, 1597802400000L}, new Object[]{null, 1000, 1597838400000L},
+          new Object[]{"xyz", 4000, 1597856400000L}, new Object[]{null, 1000, 1597878000000L},
           new Object[]{"abc", 7000, 1597881600000L}, new Object[]{"xyz", 6000, 1597892400000L});
 
   private final List<Object[]> _rawDataSingleDay = Lists
-      .newArrayList(new Object[]{"abc", 1000, 1597795200000L}, new Object[]{"pqr", 2000, 1597795200000L},
+      .newArrayList(new Object[]{"abc", 1000, 1597795200000L}, new Object[]{null, 2000, 1597795200000L},
           new Object[]{"abc", 1000, 1597795200000L}, new Object[]{"abc", 4000, 1597795200000L},
-          new Object[]{"abc", 3000, 1597795200000L}, new Object[]{"pqr", 1000, 1597795200000L},
-          new Object[]{"xyz", 4000, 1597795200000L}, new Object[]{"pqr", 1000, 1597795200000L},
+          new Object[]{"abc", 3000, 1597795200000L}, new Object[]{null, 1000, 1597795200000L},
+          new Object[]{"xyz", 4000, 1597795200000L}, new Object[]{null, 1000, 1597795200000L},
           new Object[]{"abc", 7000, 1597795200000L}, new Object[]{"xyz", 6000, 1597795200000L});
 
   private final List<Object[]> _multiValue = Lists
       .newArrayList(new Object[]{new String[]{"a", "b"}, 1000, 1597795200000L},
-          new Object[]{new String[]{"a"}, 1000, 1597795200000L}, new Object[]{new String[]{"a"}, 1000, 1597795200000L},
+          new Object[]{null, 1000, 1597795200000L}, new Object[]{null, 1000, 1597795200000L},
           new Object[]{new String[]{"a", "b"}, 1000, 1597795200000L});
 
   @BeforeClass
@@ -95,10 +95,10 @@ public class SegmentProcessingFrameworkTest {
     _tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTimeColumnName("timeValue").build();
     _pinotSchema = new Schema.SchemaBuilder().setSchemaName("mySchema")
-        .addSingleValueDimension("campaign", FieldSpec.DataType.STRING).addMetric("clicks", FieldSpec.DataType.INT)
+        .addSingleValueDimension("campaign", FieldSpec.DataType.STRING, "").addMetric("clicks", FieldSpec.DataType.INT)
         .addDateTime("timeValue", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     _pinotSchemaMV = new Schema.SchemaBuilder().setSchemaName("mySchema")
-        .addMultiValueDimension("campaign", FieldSpec.DataType.STRING).addMetric("clicks", FieldSpec.DataType.INT)
+        .addMultiValueDimension("campaign", FieldSpec.DataType.STRING, "").addMetric("clicks", FieldSpec.DataType.INT)
         .addDateTime("timeValue", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
 
     _baseDir = new File(FileUtils.getTempDirectory(), "segment_processor_framework_test_" + System.currentTimeMillis());

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -91,8 +91,8 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
   @Override
   protected boolean isMultiValue(Object value) {
     ProtoBufFieldInfo protoBufFieldInfo = (ProtoBufFieldInfo) value;
-    return protoBufFieldInfo.getFieldValue() instanceof Collection
-        && !protoBufFieldInfo.getFieldDescriptor().isMapField();
+    return protoBufFieldInfo.getFieldValue() instanceof Collection && !protoBufFieldInfo.getFieldDescriptor()
+        .isMapField();
   }
 
   /**
@@ -101,8 +101,8 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
   @Override
   protected boolean isMap(Object value) {
     ProtoBufFieldInfo protoBufFieldInfo = (ProtoBufFieldInfo) value;
-    return protoBufFieldInfo.getFieldValue() instanceof Collection
-        && protoBufFieldInfo.getFieldDescriptor().isMapField();
+    return protoBufFieldInfo.getFieldValue() instanceof Collection && protoBufFieldInfo.getFieldDescriptor()
+        .isMapField();
   }
 
   /**
@@ -120,10 +120,8 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
       return null;
     }
 
-    List<Descriptors.FieldDescriptor> fieldDescriptors = protoBufFieldInfo
-        .getFieldDescriptor()
-        .getMessageType()
-        .getFields();
+    List<Descriptors.FieldDescriptor> fieldDescriptors =
+        protoBufFieldInfo.getFieldDescriptor().getMessageType().getFields();
     Descriptors.FieldDescriptor keyFieldDescriptor = fieldDescriptors.get(0);
     Descriptors.FieldDescriptor valueFieldDescriptor = fieldDescriptors.get(1);
     Map<Object, Object> convertedMap = new HashMap<>();
@@ -137,10 +135,8 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
         }
 
         if (convertedFieldValue != null) {
-          convertedMap.put(
-              convertSingleValue(new ProtoBufFieldInfo(fieldKey, keyFieldDescriptor)),
-              convertedFieldValue
-          );
+          convertedMap
+              .put(convertSingleValue(new ProtoBufFieldInfo(fieldKey, keyFieldDescriptor)), convertedFieldValue);
         }
       }
     }
@@ -171,7 +167,7 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
       if (fieldValue != null) {
         convertedValue = convert(new ProtoBufFieldInfo(fieldValue, protoBufFieldInfo.getFieldDescriptor()));
       }
-      if (convertedValue != null && !convertedValue.toString().equals("")) {
+      if (convertedValue != null) {
         array[index++] = convertedValue;
       }
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -96,7 +96,7 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
    * {@code null}.
    *
    * This implementation converts the Collection to an Object array. Any elements of the Collection that are
-   * {@code null} or an empty string will be excluded from the returned multi-value object.
+   * {@code null} will be excluded from the returned multi-value object.
    *
    * Override this method if the data format requires a different conversion for its multi-value objects.
    *
@@ -118,7 +118,7 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
       if (element != null) {
         convertedValue = convert(element);
       }
-      if (convertedValue != null && !convertedValue.toString().equals("")) {
+      if (convertedValue != null) {
         array[index++] = convertedValue;
       }
     }


### PR DESCRIPTION
## Description
Currently we allow empty string as SV string value, but not allow it in the MV string value. This inconsistent behavior can cause confusion and unexpected behavior, especially when people sets empty string as the column default value.