### PR TITLE
Fix validation logic for DISTINCT queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1707,14 +1707,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         }
         List<Expression> orderByList = pinotQuery.getOrderByList();
         if (orderByList != null) {
-          List<Expression> selectOperands = selectList.get(0).getFunctionCall().getOperands();
-          List<Expression> orderByOperands = new LinkedList<>();
-          for (Expression expression : orderByList) {
+          List<Expression> distinctExpressions = function.getOperands();
+          for (Expression orderByExpression : orderByList) {
             // NOTE: Order-by is always a Function with the ordering of the Expression
-            orderByOperands.add(expression.getFunctionCall().getOperands().get(0));
-          }
-          if (!selectOperands.containsAll(orderByOperands)) {
-            throw new IllegalStateException("ORDER-BY columns should be included in the DISTINCT columns");
+            if (!distinctExpressions.contains(orderByExpression.getFunctionCall().getOperands().get(0)))
+              throw new IllegalStateException("ORDER-BY columns should be included in the DISTINCT columns");
           }
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1706,11 +1707,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         }
         List<Expression> orderByList = pinotQuery.getOrderByList();
         if (orderByList != null) {
+          List<Expression> selectOperands = selectList.get(0).getFunctionCall().getOperands();
+          List<Expression> orderByOperands = new LinkedList<>();
           for (Expression expression : orderByList) {
             // NOTE: Order-by is always a Function with the ordering of the Expression
-            if (!selectList.contains(expression.getFunctionCall().getOperands().get(0))) {
-              throw new IllegalStateException("ORDER-BY columns should be included in the DISTINCT columns");
-            }
+            orderByOperands.add(expression.getFunctionCall().getOperands().get(0));
+          }
+          if (!selectOperands.containsAll(orderByOperands)) {
+            throw new IllegalStateException("ORDER-BY columns should be included in the DISTINCT columns");
           }
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -181,7 +181,7 @@ public class QueryValidationTest {
   }
 
   private void testSupportedSQLQuery(String query) {
-      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -125,6 +125,39 @@ public class QueryValidationTest {
 
     sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col3 OPTION(groupByMode=sql,responseFormat=sql)";
     testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
+
+    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY col1, col2, col3 OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
+
+    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY col1, mod(col2, 10) OPTION(groupByMode=sql,responseFormat=sql)";
+    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
+  }
+
+  @Test
+  public void testSupportedDistinctQueries() {
+    String sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1, col2 OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col2, col1 OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1 DESC, col2 OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1, col2 DESC OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1 DESC, col2 DESC OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY add(col1, sub(col2, 3)) OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY mod(col2, 10), add(col1, sub(col2, 3)) OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
+
+    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) DESC OPTION(groupByMode=sql,responseFormat=sql)";
+    testSupportedSQLQuery(sql);
   }
 
   private void testUnsupportedPQLQuery(String query, String errorMessage) {
@@ -145,5 +178,10 @@ public class QueryValidationTest {
     } catch (Exception e) {
       Assert.assertEquals(errorMessage, e.getMessage());
     }
+  }
+
+  private void testSupportedSQLQuery(String query) {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
   }
 }


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

For DISTINCT queries, broker will verify that all ORDER-BY columns (if exist) should be included in the DISTINCT columns. However the existing logic is wrong: it verify that `selectList.containsAll(orderByOperands)`, should be `selectOperands.containsAll(orderByOperands)`

This bug was not caught by unit test since the unit test only test invalid queries. I add some valid query cases.

cc @snleee @siddharthteotia @mcvsubbu 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
