### PR TITLE
Fix compileToBrokerRequest function by calling PinotQuery2BrokerRequestConverter

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlCompiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlCompiler.java
@@ -19,10 +19,9 @@
 package org.apache.pinot.sql.parsers;
 
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.PinotQuery;
-import org.apache.pinot.common.request.QuerySource;
 import org.apache.pinot.parsers.QueryCompiler;
+import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
 
 
 /**
@@ -33,15 +32,7 @@ public class CalciteSqlCompiler implements QueryCompiler {
   @Override
   public BrokerRequest compileToBrokerRequest(String query) {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BrokerRequest brokerRequest = new BrokerRequest();
-    brokerRequest.setPinotQuery(pinotQuery);
-    // Set table name in broker request because it is used for access control, query routing etc.
-    DataSource dataSource = pinotQuery.getDataSource();
-    if (dataSource != null) {
-      QuerySource querySource = new QuerySource();
-      querySource.setTableName(dataSource.getTableName());
-      brokerRequest.setQuerySource(querySource);
-    }
-    return brokerRequest;
+    PinotQuery2BrokerRequestConverter converter = new PinotQuery2BrokerRequestConverter();
+    return converter.convert(pinotQuery);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1774,34 +1774,35 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testCaseInsensitiveFilter() {
+    CalciteSqlCompiler calciteSqlCompiler = new CalciteSqlCompiler();
+
     String query = "SELECT count(*) FROM foo where text_match(col, 'expr')";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    PinotQuery2BrokerRequestConverter converter = new PinotQuery2BrokerRequestConverter();
-    BrokerRequest brokerRequest = converter.convert(pinotQuery);
+    BrokerRequest brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "TEXT_MATCH");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.TEXT_MATCH);
 
     query = "SELECT count(*) FROM foo where TEXT_MATCH(col, 'expr')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "TEXT_MATCH");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.TEXT_MATCH);
 
     query = "SELECT count(*) FROM foo where regexp_like(col, 'expr')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "REGEXP_LIKE");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.REGEXP_LIKE);
 
     query = "SELECT count(*) FROM foo where REGEXP_LIKE(col, 'expr')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "REGEXP_LIKE");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.REGEXP_LIKE);
 
     query = "SELECT count(*) FROM foo where col is not null";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
     Assert
         .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -1811,7 +1812,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT count(*) FROM foo where col IS NOT NULL";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
     Assert
         .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -1821,7 +1822,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT count(*) FROM foo where col is null";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
     Assert
         .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -1831,7 +1832,7 @@ public class CalciteSqlCompilerTest {
 
     query = "SELECT count(*) FROM foo where col IS NULL";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    brokerRequest = converter.convert(pinotQuery);
+    brokerRequest = calciteSqlCompiler.compileToBrokerRequest(query);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
     Assert
         .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),


### PR DESCRIPTION


## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

Existing compileToBrokerRequest() implementation just set dataSource, but missing some logic such as:

```
     //Handle filter
    convertFilter(pinotQuery, brokerRequest);

    //Handle select list
    convertSelectList(pinotQuery, brokerRequest);

    //Handle order by
    convertOrderBy(pinotQuery, brokerRequest);

    //Handle group by
    convertGroupBy(pinotQuery, brokerRequest);

```
So, if I call `new CalciteSqlCompiler().compileToBrokerRequest(query)` to get a BrokerRequest, it will return an incomplete BrokerRequest (`filterQuery==null, groupBy==null, selections==null`, etc).

This PR fix this issue by call `PinotQuery2BrokerRequestConverter.convert()` to do the conversion.

cc @siddharthteotia 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
