### PR TITLE
Validate DISTINCT query when convert Calcite tree into PinotQuery

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -116,48 +116,6 @@ public class QueryValidationTest {
 
     pql = "SELECT DISTINCT(col1, col2), sum(col3), min(col4) FROM foo";
     testUnsupportedPQLQuery(pql, "Aggregation functions cannot be used with DISTINCT");
-
-    String sql = "SELECT DISTINCT col1, col2 FROM foo GROUP BY col1 OPTION(groupByMode=sql,responseFormat=sql)";
-    testUnsupportedSQLQuery(sql, "DISTINCT with GROUP BY is not supported");
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo LIMIT 0 OPTION(groupByMode=sql,responseFormat=sql)";
-    testUnsupportedSQLQuery(sql, "DISTINCT must have positive LIMIT");
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col3 OPTION(groupByMode=sql,responseFormat=sql)";
-    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
-
-    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY col1, col2, col3 OPTION(groupByMode=sql,responseFormat=sql)";
-    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
-
-    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY col1, mod(col2, 10) OPTION(groupByMode=sql,responseFormat=sql)";
-    testUnsupportedSQLQuery(sql, "ORDER-BY columns should be included in the DISTINCT columns");
-  }
-
-  @Test
-  public void testSupportedDistinctQueries() {
-    String sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1, col2 OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col2, col1 OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1 DESC, col2 OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1, col2 DESC OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT col1, col2 FROM foo ORDER BY col1 DESC, col2 DESC OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY add(col1, sub(col2, 3)) OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY mod(col2, 10), add(col1, sub(col2, 3)) OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
-
-    sql = "SELECT DISTINCT add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) FROM foo ORDER BY add(col1, sub(col2, 3)), mod(col2, 10), div(col4, mult(col5, 5)) DESC OPTION(groupByMode=sql,responseFormat=sql)";
-    testSupportedSQLQuery(sql);
   }
 
   private void testUnsupportedPQLQuery(String query, String errorMessage) {
@@ -178,10 +136,5 @@ public class QueryValidationTest {
     } catch (Exception e) {
       Assert.assertEquals(errorMessage, e.getMessage());
     }
-  }
-
-  private void testSupportedSQLQuery(String query) {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
   }
 }


### PR DESCRIPTION
A follow-up PR of https://github.com/apache/incubator-pinot/pull/6880 to do code clean up: move DISTINCT query validation logic in BaseBrokerRequestHandler to CalciteSqlParser.

cc @snleee @siddharthteotia @Jackie-Jiang 

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
