### PR TITLE
filter out javaagent from generator.sh JAVA_OPTS

### DIFF
--- a/docker/images/pinot/bin/generator.sh
+++ b/docker/images/pinot/bin/generator.sh
@@ -28,6 +28,8 @@ CONTROLLER_HOST="localhost"
 CONTROLLER_PORT="9000"
 CONTROLLER_SCHEME="http"
 
+export JAVA_OPTS="$(echo $JAVA_OPTS | sed -E 's/-javaagent\S+//')"
+
 USAGE="$(basename "$0") [-h] [-a PATH] [-c HOST:PORT] [-s SCHEME] [-j PATH] [-n ROWS] TEMPLATE_NAME [TABLE_NAME]
 
   where:
@@ -124,7 +126,7 @@ if [ "$TEMPLATE_NAME" = "complexWebsite" ]; then
 fi
 
 echo "Generating data for ${TEMPLATE_NAME} in ${DATA_DIR}"
-JAVA_OPTS="" ${ADMIN_PATH} GenerateData \
+${ADMIN_PATH} GenerateData \
 -numFiles 1 -numRecords $NUM_RECORDS -format csv \
 -schemaFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_schema.json" \
 -schemaAnnotationFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_generator.json" \
@@ -137,7 +139,7 @@ if [ ! -d "${DATA_DIR}" ]; then
 fi
 
 echo "Creating segment for ${TEMPLATE_NAME} in ${SEGMENT_DIR}"
-JAVA_OPTS="" ${ADMIN_PATH} CreateSegment \
+${ADMIN_PATH} CreateSegment \
 -format csv \
 -tableConfigFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_config.json" \
 -schemaFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_schema.json" \
@@ -151,7 +153,7 @@ if [ ! -d "${SEGMENT_DIR}" ]; then
 fi
 
 echo "Adding table ${TABLE_NAME} from template ${TEMPLATE_NAME}"
-JAVA_OPTS="" ${ADMIN_PATH} AddTable -exec \
+${ADMIN_PATH} AddTable -exec \
 -tableConfigFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_config.json" \
 -schemaFile "${TEMPLATE_BASEDIR}/${TEMPLATE_NAME}_schema.json" \
 -controllerHost "${CONTROLLER_HOST}" \
@@ -165,7 +167,7 @@ if [ $? != 0 ]; then
 fi
 
 echo "Uploading segment for ${TEMPLATE_NAME}"
-JAVA_OPTS="" ${ADMIN_PATH} UploadSegment \
+${ADMIN_PATH} UploadSegment \
 -tableName "${TABLE_NAME}" \
 -segmentDir "${SEGMENT_DIR}" \
 -controllerHost "${CONTROLLER_HOST}" \


### PR DESCRIPTION
## Description
Running pinot-admin.sh from within a container with a java-agent already active results in a port binding exception. The existing workaround is to remove all JAVA_OPTS, which is insufficient if keystore or truststore information has to be passed. This PR improves upon the original solution by explicitly removing the java-agent part of the JAVA_OPTS string only. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

## Documentation
