### PR TITLE
Adjust threadCpuTime calculation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -23,7 +23,6 @@ import org.apache.pinot.common.utils.DataTable.MetadataKey;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
-import org.apache.pinot.core.query.request.context.ThreadTimer;
 
 
 public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock> {
@@ -45,34 +44,41 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
     long multipleThreadCpuTimeNs = intermediateResultsBlock.getExecutionThreadCpuTimeNs();
     long totalWallClockTimeNs = endWallClockTimeNs - startWallClockTimeNs;
-    /*
-     * System activities time such as OS paging, GC, context switching are not captured by
-     * totalThreadCpuTimeNs. For example, let's divide query processing into 4 phases.
-     * - phase 1: single thread preparing. Time used: T1
-     * - phase 2: N threads processing segments in parallel, each thread use time T2
-     * - phase 3: GC/OS paging. Time used: T3
-     * - phase 4: single thread merging intermediate results blocks. Time used: T4
-     *
-     * Then we have following equations:
-     * - singleThreadCpuTimeNs = T1 + T4
-     * - multipleThreadCpuTimeNs = T2 * N
-     * - totalWallClockTimeNs = T1 + T2 + T3 + T4 = singleThreadCpuTimeNs + T2 + T3
-     * - totalThreadCpuTimeNsWithoutSystemActivities = T1 + T2 * N + T4 = singleThreadCpuTimeNs + T2 * N
-     * - systemActivitiesTimeNs = T3 = (totalWallClockTimeNs - totalThreadCpuTimeNsWithoutSystemActivities) + T2 * (N - 1)
-     *
-     * Thus:
-     * totalThreadCpuTimeNsWithSystemActivities = totalThreadCpuTimeNsWithoutSystemActivities + systemActivitiesTimeNs
-     * = totalThreadCpuTimeNsWithoutSystemActivities + T3
-     * = totalThreadCpuTimeNsWithoutSystemActivities + (totalWallClockTimeNs - totalThreadCpuTimeNsWithoutSystemActivities) + T2 * (N - 1)
-     * = totalWallClockTimeNs + T2 * (N - 1)
-     * = totalWallClockTimeNs + (multipleThreadCpuTimeNs / N) * (N - 1)
-     */
+
     int numServerThreads = intermediateResultsBlock.getNumServerThreads();
-    long totalThreadCpuTimeNs = totalWallClockTimeNs + multipleThreadCpuTimeNs * (numServerThreads - 1) / numServerThreads;
+    long totalThreadCpuTimeNs =
+        calTotalThreadCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs, numServerThreads);
 
     dataTable.getMetadata().put(MetadataKey.THREAD_CPU_TIME_NS.getName(), String.valueOf(totalThreadCpuTimeNs));
 
     return instanceResponseBlock;
+  }
+
+  /*
+   * Calculate totalThreadCpuTimeNs based on totalWallClockTimeNs, multipleThreadCpuTimeNs, and numServerThreads.
+   * System activities time such as OS paging, GC, context switching are not captured by totalThreadCpuTimeNs.
+   * For example, let's divide query processing into 4 phases:
+   * - phase 1: single thread preparing. Time used: T1
+   * - phase 2: N threads processing segments in parallel, each thread use time T2
+   * - phase 3: GC/OS paging. Time used: T3
+   * - phase 4: single thread merging intermediate results blocks. Time used: T4
+   *
+   * Then we have following equations:
+   * - singleThreadCpuTimeNs = T1 + T4
+   * - multipleThreadCpuTimeNs = T2 * N
+   * - totalWallClockTimeNs = T1 + T2 + T3 + T4 = singleThreadCpuTimeNs + T2 + T3
+   * - totalThreadCpuTimeNsWithoutSystemActivities = T1 + T2 * N + T4 = singleThreadCpuTimeNs + T2 * N
+   * - systemActivitiesTimeNs = T3 = (totalWallClockTimeNs - totalThreadCpuTimeNsWithoutSystemActivities) + T2 * (N - 1)
+   *
+   * Thus:
+   * totalThreadCpuTimeNsWithSystemActivities = totalThreadCpuTimeNsWithoutSystemActivities + systemActivitiesTimeNs
+   * = totalThreadCpuTimeNsWithoutSystemActivities + T3
+   * = totalThreadCpuTimeNsWithoutSystemActivities + (totalWallClockTimeNs - totalThreadCpuTimeNsWithoutSystemActivities) + T2 * (N - 1)
+   * = totalWallClockTimeNs + T2 * (N - 1)
+   * = totalWallClockTimeNs + (multipleThreadCpuTimeNs / N) * (N - 1)
+   */
+  public static long calTotalThreadCpuTimeNs(long totalWallClockTimeNs, long multipleThreadCpuTimeNs, int numServerThreads) {
+    return totalWallClockTimeNs + multipleThreadCpuTimeNs * (numServerThreads - 1) / numServerThreads;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -43,6 +43,11 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
     long endWallClockTimeNs = System.nanoTime();
 
     long multipleThreadCpuTimeNs = intermediateResultsBlock.getExecutionThreadCpuTimeNs();
+    /*
+     * If/when the threadCpuTime based instrumentation is done for other parts of execution (planning, pruning etc),
+     * we will have to change the wallClockTime computation accordingly. Right now everything under
+     * InstanceResponseOperator is the one that is instrumented with threadCpuTime.
+     */
     long totalWallClockTimeNs = endWallClockTimeNs - startWallClockTimeNs;
 
     int numServerThreads = intermediateResultsBlock.getNumServerThreads();
@@ -78,7 +83,8 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
    * = totalWallClockTimeNs + (multipleThreadCpuTimeNs / N) * (N - 1)
    */
   public static long calTotalThreadCpuTimeNs(long totalWallClockTimeNs, long multipleThreadCpuTimeNs, int numServerThreads) {
-    return totalWallClockTimeNs + multipleThreadCpuTimeNs * (numServerThreads - 1) / numServerThreads;
+    double perThreadCpuTimeNs = multipleThreadCpuTimeNs * 1.0 / numServerThreads;
+    return Math.round(totalWallClockTimeNs + perThreadCpuTimeNs * (numServerThreads - 1));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -67,6 +67,7 @@ public class IntermediateResultsBlock implements Block {
   private int _numResizes;
   private long _resizeTimeMs;
   private long _executionThreadCpuTimeNs;
+  private int _numServerThreads;
 
   private Table _table;
 
@@ -207,6 +208,14 @@ public class IntermediateResultsBlock implements Block {
 
   public void setExecutionThreadCpuTimeNs(long executionThreadCpuTimeNs) {
     _executionThreadCpuTimeNs = executionThreadCpuTimeNs;
+  }
+
+  public void setNumServerThreads(int numServerThreads) {
+    _numServerThreads = numServerThreads;
+  }
+
+  public int getNumServerThreads() {
+    return _numServerThreads;
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -127,7 +127,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       // Deregister the main thread and wait for all threads done
       phaser.awaitAdvance(phaser.arriveAndDeregister());
     }
-    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators, totalWorkerThreadCpuTimeNs.get());
+    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators, totalWorkerThreadCpuTimeNs.get(), _numThreads);
     return mergedBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -33,6 +33,7 @@ import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.ThreadTimer;
+import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
@@ -54,21 +55,21 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
   protected final QueryContext _queryContext;
   protected final ExecutorService _executorService;
   protected final long _endTimeMs;
-  protected final int _numThreads;
+  protected final int _numTasks;
   protected final Future[] _futures;
   // Use a _blockingQueue to store the intermediate results blocks
   protected final BlockingQueue<IntermediateResultsBlock> _blockingQueue = new LinkedBlockingQueue<>();
   protected final AtomicLong totalWorkerThreadCpuTimeNs = new AtomicLong(0);
 
   protected BaseCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int numThreads) {
+      long endTimeMs, int numTasks) {
     _operators = operators;
     _numOperators = _operators.size();
     _queryContext = queryContext;
     _executorService = executorService;
     _endTimeMs = endTimeMs;
-    _numThreads = numThreads;
-    _futures = new Future[_numThreads];
+    _numTasks = numTasks;
+    _futures = new Future[_numTasks];
   }
 
   protected BaseCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
@@ -85,7 +86,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     // behavior (even JVM crash) when processing queries against it.
     Phaser phaser = new Phaser(1);
 
-    for (int i = 0; i < _numThreads; i++) {
+    for (int i = 0; i < _numTasks; i++) {
       int threadIndex = i;
       _futures[i] = _executorService.submit(new TraceRunnable() {
         @Override
@@ -127,7 +128,15 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       // Deregister the main thread and wait for all threads done
       phaser.awaitAdvance(phaser.arriveAndDeregister());
     }
-    CombineOperatorUtils.setExecutionStatistics(mergedBlock, _operators, totalWorkerThreadCpuTimeNs.get(), _numThreads);
+    /*
+     * _numTasks are number of async tasks submitted to the _executorService, but it does not mean Pinot server
+     * use those number of threads to concurrently process segments. Instead, if _executorService thread pool has
+     * less number of threads than _numTasks, the number of threads that used to concurrently process segments equals
+     * to the pool size.
+     */
+    int numServerThreads = Math.min(_numTasks, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
+    CombineOperatorUtils
+        .setExecutionStatistics(mergedBlock, _operators, totalWorkerThreadCpuTimeNs.get(), numServerThreads);
     return mergedBlock;
   }
 
@@ -135,7 +144,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
    * Executes query on one or more segments in a worker thread.
    */
   protected void processSegments(int threadIndex) {
-    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
+    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numTasks) {
       try {
         IntermediateResultsBlock resultsBlock = (IntermediateResultsBlock) _operators.get(operatorIndex).nextBlock();
         if (isQuerySatisfied(resultsBlock)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -48,7 +48,7 @@ public class CombineOperatorUtils {
    * Sets the execution statistics into the results block.
    */
   public static void setExecutionStatistics(IntermediateResultsBlock resultsBlock, List<Operator> operators,
-      long threadCpuTimeNs) {
+      long threadCpuTimeNs, int numServerThreads) {
     int numSegmentsProcessed = operators.size();
     int numSegmentsMatched = 0;
     long numDocsScanned = 0;
@@ -72,5 +72,6 @@ public class CombineOperatorUtils {
     resultsBlock.setNumEntriesScannedPostFilter(numEntriesScannedPostFilter);
     resultsBlock.setNumTotalDocs(numTotalDocs);
     resultsBlock.setExecutionThreadCpuTimeNs(threadCpuTimeNs);
+    resultsBlock.setNumServerThreads(numServerThreads);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -140,7 +140,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
     //       segment result is merged.
     Comparable threadBoundaryValue = null;
 
-    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
+    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numTasks) {
       // Calculate the boundary value from global boundary and thread boundary
       Comparable boundaryValue = _globalBoundaryValue.get();
       if (boundaryValue == null) {
@@ -168,7 +168,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
           if (minMaxValueContext._minValue != null) {
             int result = minMaxValueContext._minValue.compareTo(boundaryValue);
             if (result > 0 || (result == 0 && numOrderByExpressions == 1)) {
-              _numOperatorsSkipped.getAndAdd((_numOperators - operatorIndex - 1) / _numThreads);
+              _numOperatorsSkipped.getAndAdd((_numOperators - operatorIndex - 1) / _numTasks);
               _blockingQueue.offer(LAST_RESULTS_BLOCK);
               return;
             }
@@ -179,7 +179,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
           if (minMaxValueContext._maxValue != null) {
             int result = minMaxValueContext._maxValue.compareTo(boundaryValue);
             if (result < 0 || (result == 0 && numOrderByExpressions == 1)) {
-              _numOperatorsSkipped.getAndAdd((_numOperators - operatorIndex - 1) / _numThreads);
+              _numOperatorsSkipped.getAndAdd((_numOperators - operatorIndex - 1) / _numTasks);
               _blockingQueue.offer(LAST_RESULTS_BLOCK);
               return;
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
@@ -60,7 +60,7 @@ public class SelectionOnlyCombineOperator extends BaseCombineOperator {
     // For LIMIT 0 query, only process one segment to get the data schema
     if (_numRowsToKeep == 0) {
       IntermediateResultsBlock resultsBlock = (IntermediateResultsBlock) _operators.get(0).nextBlock();
-      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators, 0);
+      CombineOperatorUtils.setExecutionStatistics(resultsBlock, _operators, 0, 1);
       return resultsBlock;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -71,7 +71,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
 
   @Override
   protected void processSegments(int threadIndex) {
-    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
+    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numTasks) {
       Operator<IntermediateResultsBlock> operator = _operators.get(operatorIndex);
       try {
         IntermediateResultsBlock resultsBlock;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 public class ThreadCpuTimeMeasurementTest {
 
   @Test
-  public void testAdditionTransformFunction() {
+  public void testCalTotalThreadCpuTimeNs() {
     class testCase {
       final long totalWallClockTimeNs;
       final long multipleThreadCpuTimeNs;
@@ -47,9 +47,9 @@ public class ThreadCpuTimeMeasurementTest {
             new testCase(4245673, 7124487, 3, 8995331),
             new testCase(21500000, 10962161, 2, 26981081),
             new testCase(59000000, 23690790, 1, 59000000),
-            new testCase(5123, 11321792, 5, 9062557),
-            new testCase(79000, 35537324, 7, 30539563),
-            new testCase(2056, 2462128, 4, 1848652)
+            new testCase(59124358, 11321792, 5, 68181792),
+            new testCase(79888780, 35537324, 7, 110349343),
+            new testCase(915432, 2462128, 4, 2762028)
         };
 
     for (testCase testCase : testCases) {
@@ -59,7 +59,7 @@ public class ThreadCpuTimeMeasurementTest {
       long expectedTotalThreadCpuTimeNs = testCase.totalThreadCpuTimeNs;
       long actualTotalThreadCpuTimeNs = InstanceResponseOperator
           .calTotalThreadCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs, numServerThreads);
-      Assert.equals(actualTotalThreadCpuTimeNs, expectedTotalThreadCpuTimeNs);
+      Assert.equals(expectedTotalThreadCpuTimeNs, actualTotalThreadCpuTimeNs);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
@@ -45,9 +45,9 @@ public class ThreadCpuTimeMeasurementTest {
     testCase[] testCases =
         new testCase[]{
             new testCase(4245673, 7124487, 3, 8995331),
-            new testCase(21500000, 10962161, 2, 26981080),
+            new testCase(21500000, 10962161, 2, 26981081),
             new testCase(59000000, 23690790, 1, 59000000),
-            new testCase(5123, 11321792, 5, 9062556),
+            new testCase(5123, 11321792, 5, 9062557),
             new testCase(79000, 35537324, 7, 30539563),
             new testCase(2056, 2462128, 4, 1848652)
         };
@@ -59,7 +59,7 @@ public class ThreadCpuTimeMeasurementTest {
       long expectedTotalThreadCpuTimeNs = testCase.totalThreadCpuTimeNs;
       long actualTotalThreadCpuTimeNs = InstanceResponseOperator
           .calTotalThreadCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs, numServerThreads);
-      Assert.equals(expectedTotalThreadCpuTimeNs, actualTotalThreadCpuTimeNs);
+      Assert.equals(actualTotalThreadCpuTimeNs, expectedTotalThreadCpuTimeNs);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/ThreadCpuTimeMeasurementTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.operator;
+
+import org.locationtech.jts.util.Assert;
+import org.testng.annotations.Test;
+
+
+public class ThreadCpuTimeMeasurementTest {
+
+  @Test
+  public void testAdditionTransformFunction() {
+    class testCase {
+      final long totalWallClockTimeNs;
+      final long multipleThreadCpuTimeNs;
+      final int numServerThreads;
+      final long totalThreadCpuTimeNs;
+
+      testCase(long totalWallClockTimeNs, long multipleThreadCpuTimeNs, int numServerThreads,
+          long totalThreadCpuTimeNs) {
+        this.totalWallClockTimeNs = totalWallClockTimeNs;
+        this.multipleThreadCpuTimeNs = multipleThreadCpuTimeNs;
+        this.numServerThreads = numServerThreads;
+        this.totalThreadCpuTimeNs = totalThreadCpuTimeNs;
+      }
+    }
+
+    testCase[] testCases =
+        new testCase[]{
+            new testCase(4245673, 7124487, 3, 8995331),
+            new testCase(21500000, 10962161, 2, 26981080),
+            new testCase(59000000, 23690790, 1, 59000000),
+            new testCase(5123, 11321792, 5, 9062556),
+            new testCase(79000, 35537324, 7, 30539563),
+            new testCase(2056, 2462128, 4, 1848652)
+        };
+
+    for (testCase testCase : testCases) {
+      long totalWallClockTimeNs = testCase.totalWallClockTimeNs;
+      long multipleThreadCpuTimeNs = testCase.multipleThreadCpuTimeNs;
+      int numServerThreads = testCase.numServerThreads;
+      long expectedTotalThreadCpuTimeNs = testCase.totalThreadCpuTimeNs;
+      long actualTotalThreadCpuTimeNs = InstanceResponseOperator
+          .calTotalThreadCpuTimeNs(totalWallClockTimeNs, multipleThreadCpuTimeNs, numServerThreads);
+      Assert.equals(expectedTotalThreadCpuTimeNs, actualTotalThreadCpuTimeNs);
+    }
+  }
+}


### PR DESCRIPTION
It's possible that `totalThreadCpuTimeNs < totalWallClockTimeNs` when GC or OS paging happens during query processing. This PR make totalThreadCuTimeNs also capture time spending on GC/OC paging, etc.

Please refer the comments for how the time was calculated. @siddharthteotia 

cc @mcvsubbu 

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
