### PR TITLE
Update helm to override zk url when zk is disabled

### DIFF
--- a/kubernetes/helm/pinot/templates/_helpers.tpl
+++ b/kubernetes/helm/pinot/templates/_helpers.tpl
@@ -176,9 +176,7 @@ else use user-provided URL
 {{- if .Values.zookeeper.enabled -}}
 {{- printf "%s:%s" (include "pinot.zookeeper.fullname" .) $port }}
 {{- else -}}
-{{- $zookeeperConnect := printf "%s:%s" .Values.zookeeper.url $port }}
-{{- $zookeeperConnectOverride := index .Values "configurationOverrides" "zookeeper.connect" }}
-{{- default $zookeeperConnect $zookeeperConnectOverride }}
+{{- required "Missing 'zookeeper.urlOverride' entry zookeeper is disabled!"  .Values.zookeeper.urlOverride }}
 {{- end -}}
 {{- end -}}
 

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -387,6 +387,12 @@ zookeeper:
   ## ref: https://github.com/kubernetes/charts/tree/master/incubator/zookeeper
   enabled: true
 
+  ## If the Zookeeper Chart is disabled a URL override is required to connect
+  urlOverride: "my-zookeeper:2181/my-pinot"
+
+  ## Zookeeper port
+  port: 2181
+
   ## Configure Zookeeper resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
@@ -408,10 +414,6 @@ zookeeper:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   image:
     PullPolicy: "IfNotPresent"
-
-  ## If the Zookeeper Chart is disabled a URL and port are required to connect
-  url: ""
-  port: 2181
 
   ## Pod scheduling preferences (by default keep pods within a release on separate nodes).
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
## Description
Fix zookeeper URL override when Zookeeper is disabled.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
