### PR TITLE
Adding a new Controller API to retrieve ingestion status for realtime…

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -608,7 +608,8 @@ public class PinotTableRestletResource {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
       if (TableType.OFFLINE == tableType) {
         // TODO: Support table status for offline table. Currently only supported for realtime.
-        throw new IllegalStateException("Table status for OFFLINE table: " + tableName + " is currently unsupported");
+        throw new UnsupportedOperationException(
+            "Table status for OFFLINE table: " + tableName + " is currently unsupported");
       }
       String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
       ConsumingSegmentInfoReader consumingSegmentInfoReader =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2117,6 +2117,17 @@ public class PinotHelixResourceManager {
     return consumingSegments;
   }
 
+  /**
+   * Utility function to return set of servers corresponding to a given segment.
+   */
+  public Set<String> getServersForSegment(String tableNameWithType, String segmentName) {
+    IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
+    if (idealState == null) {
+      throw new IllegalStateException("Ideal state does not exist for table: " + tableNameWithType);
+    }
+    return new HashSet<>(idealState.getInstanceStateMap(segmentName).keySet());
+  }
+
   public synchronized Map<String, String> getSegmentsCrcForTable(String tableNameWithType) {
     // Get the segment list for this table
     IdealState is = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.BiMap;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,8 +36,8 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
-import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.spi.config.table.TableStatus;
+import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,7 +164,7 @@ public class ConsumingSegmentInfoReader {
 
         for (ConsumingSegmentInfo consumingSegmentInfo : consumingSegmentInfoList) {
           if (consumingSegmentInfo._consumerState
-              .equals(RealtimeSegmentDataManager.ConsumerState.NOT_CONSUMING.toString())) {
+              .equals(ConsumerState.NOT_CONSUMING.toString())) {
             String errorMessage =
                 "Segment: " + segmentName + " is not being consumed on server: " + consumingSegmentInfo._serverName;
             return TableStatus.IngestionStatus.newIngestionStatus(TableStatus.IngestionState.UNHEALTHY, errorMessage);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
@@ -154,7 +155,9 @@ public class ConsumingSegmentInfoReader {
         // Check if any responses are missing
         Set<String> serversForSegment = _pinotHelixResourceManager.getServersForSegment(tableNameWithType, segmentName);
         if (serversForSegment.size() != consumingSegmentInfoList.size()) {
-          serversForSegment.removeAll(consumingSegmentInfoList);
+          Set<String> serversResponded =
+              consumingSegmentInfoList.stream().map(c -> c._serverName).collect(Collectors.toSet());
+          serversForSegment.removeAll(serversResponded);
           String errorMessage =
               "Not all servers responded for segment: " + segmentName + " Missing servers : " + serversForSegment;
           return TableStatus.IngestionStatus.newIngestionStatus(TableStatus.IngestionState.UNHEALTHY, errorMessage);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
@@ -43,8 +43,8 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
-import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.ConsumerState;
 import org.apache.pinot.spi.config.table.TableStatus;
+import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
@@ -242,14 +242,14 @@ public class ConsumingSegmentInfoReaderTest {
         consumingSegmentsInfoMap._segmentToConsumingInfoMap.get(SEGMENT_NAME_PARTITION_0);
     Assert.assertEquals(consumingSegmentInfos.size(), 2);
     for (ConsumingSegmentInfoReader.ConsumingSegmentInfo info : consumingSegmentInfos) {
-      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server1"), ConsumerState.CONSUMING.toString(), "0",
-          "150");
+      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server1"),
+          ConsumerState.CONSUMING.toString(), "0", "150");
     }
     consumingSegmentInfos = consumingSegmentsInfoMap._segmentToConsumingInfoMap.get(SEGMENT_NAME_PARTITION_1);
     Assert.assertEquals(consumingSegmentInfos.size(), 2);
     for (ConsumingSegmentInfoReader.ConsumingSegmentInfo info : consumingSegmentInfos) {
-      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server1"), ConsumerState.CONSUMING.toString(), "1",
-          "150");
+      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server1"),
+          ConsumerState.CONSUMING.toString(), "1", "150");
     }
   }
 
@@ -270,16 +270,18 @@ public class ConsumingSegmentInfoReaderTest {
     Assert.assertEquals(consumingSegmentInfos.size(), 2);
     for (ConsumingSegmentInfoReader.ConsumingSegmentInfo info : consumingSegmentInfos) {
       if (info._serverName.equals("server0")) {
-        checkConsumingSegmentInfo(info, Sets.newHashSet("server0"), ConsumerState.CONSUMING.toString(), "0", "150");
+        checkConsumingSegmentInfo(info, Sets.newHashSet("server0"), ConsumerState.CONSUMING.toString(),
+            "0", "150");
       } else {
-        checkConsumingSegmentInfo(info, Sets.newHashSet("server2"), ConsumerState.NOT_CONSUMING.toString(), "0", "150");
+        checkConsumingSegmentInfo(info, Sets.newHashSet("server2"),
+            ConsumerState.NOT_CONSUMING.toString(), "0", "150");
       }
     }
     consumingSegmentInfos = consumingSegmentsInfoMap._segmentToConsumingInfoMap.get(SEGMENT_NAME_PARTITION_1);
     Assert.assertEquals(consumingSegmentInfos.size(), 2);
     for (ConsumingSegmentInfoReader.ConsumingSegmentInfo info : consumingSegmentInfos) {
-      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server2"), ConsumerState.CONSUMING.toString(), "1",
-          "150");
+      checkConsumingSegmentInfo(info, Sets.newHashSet("server0", "server2"),
+          ConsumerState.CONSUMING.toString(), "1", "150");
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -55,6 +55,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
 import org.apache.pinot.spi.stream.StreamLevelConsumer;
+import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.SegmentType;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -84,6 +84,7 @@ import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
 import org.apache.pinot.spi.stream.TransientConsumerException;
+import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.CompletionMode;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.joda.time.DateTime;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -25,17 +25,10 @@ import org.apache.pinot.segment.local.io.readerwriter.PinotDataBufferMemoryManag
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.io.writer.impl.MmapMemoryManager;
 import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 
 
 public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
-
-  /**
-   * The state of the consumer of this segment
-   */
-  public enum ConsumerState {
-    CONSUMING,
-    NOT_CONSUMING // In error state
-  }
 
   @Override
   public abstract MutableSegment getSegment();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.spi.config.table;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
@@ -35,6 +36,7 @@ public class TableStatus {
     UNHEALTHY
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class IngestionStatus {
     private IngestionState _ingestionState;
     private String _errorMessage;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ * Container object to encapsulate table status which contains
+ * - Ingestion status: specifies if the table is ingesting properly or not
+ */
+public class TableStatus {
+
+  private IngestionStatus _ingestionStatus;
+
+  public enum IngestionState {
+    HEALTHY,
+    UNHEALTHY
+  }
+
+  public static class IngestionStatus {
+    private IngestionState _ingestionState;
+    private String _errorMessage;
+
+    public IngestionStatus(@JsonProperty("ingestionState") String ingestionState,
+        @JsonProperty("errorMessage") String errorMessage) {
+      _ingestionState = IngestionState.valueOf(ingestionState);
+      _errorMessage = errorMessage;
+    }
+
+    public static IngestionStatus newIngestionStatus(IngestionState state, String errorMessage) {
+      return new IngestionStatus(state.toString(), errorMessage);
+    }
+
+    public IngestionState getIngestionState() {
+      return _ingestionState;
+    }
+
+    public String getErrorMessage() {
+      return _errorMessage;
+    }
+  }
+
+  public TableStatus(@JsonProperty("ingestionStatus") IngestionStatus ingestionStatus) {
+    _ingestionStatus =  ingestionStatus;
+  }
+
+  public IngestionStatus getIngestionStatus() {
+    return _ingestionStatus;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -29,6 +29,14 @@ public class CommonConstants {
 
   public static final String KEY_OF_AUTH_TOKEN = "auth.token";
 
+  /**
+   * The state of the consumer for a given segment
+   */
+  public enum ConsumerState {
+    CONSUMING,
+    NOT_CONSUMING // In error state
+  }
+
   public static class Table {
     public static final String PUSH_FREQUENCY_HOURLY = "hourly";
     public static final String PUSH_FREQUENCY_DAILY = "daily";


### PR DESCRIPTION
… table

## Description
This is part 1 of #6524 . This PR provides an overall ingestion status for Pinot realtime table. The status is HEALTHY if all consuming segments are in the CONSUMING state. UNHEALTHY otherwise.

Part 2 (in another PR) will cover retrieving detailed stack trace for consuming segments in ERROR state.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade?
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes?
No
