### PR TITLE
Allow multiple alias for the same selection column.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -91,8 +91,8 @@ public class BrokerReduceService {
     if (resultTable == null) {
       return;
     }
-    Map<ExpressionContext, String> aliasMap = queryContext.getAliasMap();
-    if (aliasMap.isEmpty()) {
+    List<String> aliasList = queryContext.getAliasList();
+    if (aliasList.isEmpty()) {
       return;
     }
 
@@ -104,7 +104,7 @@ public class BrokerReduceService {
       return;
     }
     for (int i = 0; i < numSelectExpressions; i++) {
-      String alias = aliasMap.get(selectExpressions.get(i));
+      String alias = aliasList.get(i);
       if (alias != null) {
         columnNames[i] = alias;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -110,7 +110,7 @@ public class SelectionDataTableReducer implements DataTableReducer {
         List<Object[]> reducedRows = SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), limit);
         if (_responseFormatSql) {
           brokerResponseNative
-              .setResultTable(SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, dataSchema));
+              .setResultTable(SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, dataSchema, selectionColumns));
         } else {
           brokerResponseNative.setSelectionResults(SelectionOperatorUtils
               .renderSelectionResultsWithoutOrdering(reducedRows, dataSchema, selectionColumns, _preserveType));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -65,7 +65,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFacto
 public class QueryContext {
   private final String _tableName;
   private final List<ExpressionContext> _selectExpressions;
-  private final Map<ExpressionContext, String> _aliasMap;
+  private final List<String> _aliasList;
   private final FilterContext _filter;
   private final List<ExpressionContext> _groupByExpressions;
   private final FilterContext _havingFilter;
@@ -85,14 +85,14 @@ public class QueryContext {
   private Set<String> _columns;
 
   private QueryContext(String tableName, List<ExpressionContext> selectExpressions,
-      Map<ExpressionContext, String> aliasMap, @Nullable FilterContext filter,
+      List<String> aliasList, @Nullable FilterContext filter,
       @Nullable List<ExpressionContext> groupByExpressions, @Nullable FilterContext havingFilter,
       @Nullable List<OrderByExpressionContext> orderByExpressions, int limit, int offset,
       @Nullable Map<String, String> queryOptions, @Nullable Map<String, String> debugOptions,
       BrokerRequest brokerRequest) {
     _tableName = tableName;
     _selectExpressions = selectExpressions;
-    _aliasMap = Collections.unmodifiableMap(aliasMap);
+    _aliasList = Collections.unmodifiableList(aliasList);
     _filter = filter;
     _groupByExpressions = groupByExpressions;
     _havingFilter = havingFilter;
@@ -119,10 +119,10 @@ public class QueryContext {
   }
 
   /**
-   * Returns an unmodifiable map from the expression to its alias.
+   * Returns an unmodifiable list from the expression to its alias.
    */
-  public Map<ExpressionContext, String> getAliasMap() {
-    return _aliasMap;
+  public List<String> getAliasList() {
+    return _aliasList;
   }
 
   /**
@@ -224,7 +224,7 @@ public class QueryContext {
   @Override
   public String toString() {
     return "QueryContext{" + "_tableName='" + _tableName + '\'' + ", _selectExpressions=" + _selectExpressions
-        + ", _aliasMap=" + _aliasMap + ", _filter=" + _filter + ", _groupByExpressions=" + _groupByExpressions
+        + ", _aliasList=" + _aliasList + ", _filter=" + _filter + ", _groupByExpressions=" + _groupByExpressions
         + ", _havingFilter=" + _havingFilter + ", _orderByExpressions=" + _orderByExpressions + ", _limit=" + _limit
         + ", _offset=" + _offset + ", _queryOptions=" + _queryOptions + ", _debugOptions=" + _debugOptions
         + ", _brokerRequest=" + _brokerRequest + '}';
@@ -233,7 +233,7 @@ public class QueryContext {
   public static class Builder {
     private String _tableName;
     private List<ExpressionContext> _selectExpressions;
-    private Map<ExpressionContext, String> _aliasMap;
+    private List<String> _aliasList;
     private FilterContext _filter;
     private List<ExpressionContext> _groupByExpressions;
     private FilterContext _havingFilter;
@@ -254,8 +254,8 @@ public class QueryContext {
       return this;
     }
 
-    public Builder setAliasMap(Map<ExpressionContext, String> aliasMap) {
-      _aliasMap = aliasMap;
+    public Builder setAliasList(List<String> aliasList) {
+      _aliasList = aliasList;
       return this;
     }
 
@@ -308,7 +308,7 @@ public class QueryContext {
       // TODO: Add validation logic here
 
       QueryContext queryContext =
-          new QueryContext(_tableName, _selectExpressions, _aliasMap, _filter, _groupByExpressions, _havingFilter,
+          new QueryContext(_tableName, _selectExpressions, _aliasList, _filter, _groupByExpressions, _havingFilter,
               _orderByExpressions, _limit, _offset, _queryOptions, _debugOptions, _brokerRequest);
 
       // Pre-calculate the aggregation functions and columns for the query

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -46,6 +46,16 @@ import static org.testng.Assert.*;
 
 public class BrokerRequestToQueryContextConverterTest {
 
+  private int getAliasCount(List<String> aliasList) {
+    int count = 0;
+    for (String alias : aliasList) {
+      if (alias != null) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   @Test
   public void testHardcodedQueries() {
     // Select *
@@ -58,7 +68,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forIdentifier("*"));
         assertEquals(selectExpressions.get(0).toString(), "*");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         assertNull(queryContext.getGroupByExpressions());
         assertNull(queryContext.getOrderByExpressions());
@@ -84,7 +94,7 @@ public class BrokerRequestToQueryContextConverterTest {
             new FunctionContext(FunctionContext.Type.AGGREGATION, "count",
                 Collections.singletonList(ExpressionContext.forIdentifier("*")))));
         assertEquals(selectExpressions.get(0).toString(), "count(*)");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         assertNull(queryContext.getGroupByExpressions());
         assertNull(queryContext.getOrderByExpressions());
@@ -110,7 +120,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(selectExpressions.get(0).toString(), "foo");
         assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
         assertEquals(selectExpressions.get(1).toString(), "bar");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
         assertNotNull(orderByExpressions);
@@ -143,7 +153,7 @@ public class BrokerRequestToQueryContextConverterTest {
                 .asList(ExpressionContext.forIdentifier("foo"), ExpressionContext.forIdentifier("bar"),
                     ExpressionContext.forIdentifier("foobar")))));
         assertEquals(selectExpressions.get(0).toString(), "distinct(foo,bar,foobar)");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         assertNull(queryContext.getGroupByExpressions());
         List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
@@ -184,7 +194,7 @@ public class BrokerRequestToQueryContextConverterTest {
             new FunctionContext(FunctionContext.Type.TRANSFORM, "sub",
                 Arrays.asList(ExpressionContext.forLiteral("456"), ExpressionContext.forIdentifier("foobar")))));
         assertEquals(selectExpressions.get(1).toString(), "sub('456',foobar)");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         assertNull(queryContext.getGroupByExpressions());
         List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
@@ -230,7 +240,7 @@ public class BrokerRequestToQueryContextConverterTest {
           assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
           assertEquals(selectExpressions.get(1).toString(), "bar");
         }
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         assertNull(queryContext.getFilter());
         List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
         assertNotNull(groupByExpressions);
@@ -276,7 +286,7 @@ public class BrokerRequestToQueryContextConverterTest {
         assertEquals(selectExpressions.size(), 1);
         assertEquals(selectExpressions.get(0), ExpressionContext.forIdentifier("*"));
         assertEquals(selectExpressions.get(0).toString(), "*");
-        assertTrue(queryContext.getAliasMap().isEmpty());
+        assertEquals(getAliasCount(queryContext.getAliasList()), 0);
         FilterContext filter = queryContext.getFilter();
         assertNotNull(filter);
         assertEquals(filter.getType(), FilterContext.Type.AND);
@@ -322,12 +332,10 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(selectExpressions.get(0).toString(), "sum(foo)");
       assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
       assertEquals(selectExpressions.get(1).toString(), "bar");
-      Map<ExpressionContext, String> aliasMap = queryContext.getAliasMap();
-      assertEquals(aliasMap.size(), 2);
-      assertEquals(aliasMap.get(ExpressionContext.forFunction(
-          new FunctionContext(FunctionContext.Type.AGGREGATION, "sum",
-              Collections.singletonList(ExpressionContext.forIdentifier("foo"))))), "a");
-      assertEquals(aliasMap.get(ExpressionContext.forIdentifier("bar")), "b");
+      List<String> aliasList = queryContext.getAliasList();
+      assertEquals(aliasList.size(), 2);
+      assertEquals(aliasList.get(0), "a");
+      assertEquals(aliasList.get(1), "b");
       FilterContext filter = queryContext.getFilter();
       assertNotNull(filter);
       assertEquals(filter, new FilterContext(FilterContext.Type.PREDICATE, null,
@@ -367,7 +375,7 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(selectExpressions.get(0).toString(), "sum(foo)");
       assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
       assertEquals(selectExpressions.get(1).toString(), "bar");
-      assertTrue(queryContext.getAliasMap().isEmpty());
+      assertEquals(getAliasCount(queryContext.getAliasList()), 0);
       assertNull(queryContext.getFilter());
       List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
       assertNotNull(groupByExpressions);
@@ -572,7 +580,7 @@ public class BrokerRequestToQueryContextConverterTest {
     assertEquals(selectExpressions.get(0).toString(), "foo");
     assertEquals(selectExpressions.get(1), ExpressionContext.forIdentifier("bar"));
     assertEquals(selectExpressions.get(1).toString(), "bar");
-    assertTrue(queryContext.getAliasMap().isEmpty());
+    assertEquals(getAliasCount(queryContext.getAliasList()), 0);
     assertNull(queryContext.getFilter());
     List<OrderByExpressionContext> orderByExpressions = queryContext.getOrderByExpressions();
     assertNull(orderByExpressions);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1185,22 +1185,50 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
-  public void testQueryWithSameAlias()
+  public void testQueryWithAlias()
       throws Exception {
-    //test repeated columns in selection query
-    String query =
-        "SELECT ArrTime AS ArrTime, Carrier AS Carrier, DaysSinceEpoch AS DaysSinceEpoch FROM mytable ORDER BY DaysSinceEpoch DESC";
-    testQuery(query, Collections.singletonList(query));
+    {
+      //test same alias name with column name
+      String query =
+          "SELECT ArrTime AS ArrTime, Carrier AS Carrier, DaysSinceEpoch AS DaysSinceEpoch FROM mytable ORDER BY DaysSinceEpoch DESC";
+      testSqlQuery(query, Collections.singletonList(query));
 
-    //test repeated columns in selection query
-    query =
-        "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC";
-    testQuery(query, Collections.singletonList(query));
+      query =
+          "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC";
+      testSqlQuery(query, Collections.singletonList(query));
 
-    //test repeated columns in selection query
-    query =
-        "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC, ArrTime DESC";
-    testQuery(query, Collections.singletonList(query));
+      query =
+          "SELECT ArrTime AS ArrTime, DaysSinceEpoch AS DaysSinceEpoch, Carrier AS Carrier FROM mytable ORDER BY Carrier DESC, ArrTime DESC";
+      testSqlQuery(query, Collections.singletonList(query));
+    }
+    {
+      //test single alias
+      String query =
+          "SELECT ArrTime, Carrier AS CarrierName, DaysSinceEpoch FROM mytable ORDER BY DaysSinceEpoch DESC";
+      testSqlQuery(query, Collections.singletonList(query));
+
+      query =
+          "SELECT count(*) AS cnt, max(ArrTime) as maxArrTime FROM mytable";
+      testSqlQuery(query, Collections.singletonList(query));
+
+      query =
+          "SELECT count(*) AS cnt, Carrier AS CarrierName FROM mytable GROUP BY CarrierName ORDER BY cnt";
+      testSqlQuery(query, Collections.singletonList(query));
+    }
+    {
+      //test multiple alias
+      String query =
+          "SELECT ArrTime, Carrier, Carrier AS CarrierName1, Carrier AS CarrierName2, DaysSinceEpoch FROM mytable ORDER BY DaysSinceEpoch DESC";
+      testSqlQuery(query, Collections.singletonList(query));
+
+      query =
+          "SELECT count(*) AS cnt, max(ArrTime) as maxArrTime1, max(ArrTime) as maxArrTime2 FROM mytable";
+      testSqlQuery(query, Collections.singletonList(query));
+
+      query =
+          "SELECT count(*), count(*) AS cnt1, count(*) AS cnt2, Carrier AS CarrierName FROM mytable GROUP BY CarrierName ORDER BY cnt2";
+      testSqlQuery(query, Collections.singletonList(query));
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
This pr add supports to allow selecting same column multiple times with different alias (#6844 ).
 E.g. `Select colA AS xx, colA AS yy from T`.