### PR TITLE
Fix flaky test

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -187,7 +187,9 @@ public class QueryRoutingTest {
   public void testServerDown()
       throws Exception {
     long requestId = 123;
-    long timeout = 1000L;
+    // To avoid flakyness, set timeout to 2000 msec. For some test runs, it can take up to
+    // 1400 msec to mark request as failed.
+    long timeout = 2000L;
     DataTable dataTable = DataTableBuilder.getEmptyDataTable();
     dataTable.getMetadata().put(MetadataKey.REQUEST_ID.getName(), Long.toString(requestId));
     byte[] responseBytes = dataTable.toBytes();
@@ -211,8 +213,8 @@ public class QueryRoutingTest {
     assertEquals(serverResponse.getResponseDelayMs(), -1);
     assertEquals(serverResponse.getResponseSize(), 0);
     assertEquals(serverResponse.getDeserializationTimeMs(), 0);
-    // Query should early terminate (give 10ms extra to verify timeout)
-    assertTrue(System.currentTimeMillis() - startTimeMs < timeout + 10L);
+    // Query should early terminate
+    assertTrue(System.currentTimeMillis() - startTimeMs < timeout);
 
     // Submit query after server is down
     startTimeMs = System.currentTimeMillis();
@@ -227,8 +229,8 @@ public class QueryRoutingTest {
     assertEquals(serverResponse.getResponseDelayMs(), -1);
     assertEquals(serverResponse.getResponseSize(), 0);
     assertEquals(serverResponse.getDeserializationTimeMs(), 0);
-    // Query should early terminate (give 10ms extra to verify timeout)
-    assertTrue(System.currentTimeMillis() - startTimeMs < timeout + 10L);
+    // Query should early terminate
+    assertTrue(System.currentTimeMillis() - startTimeMs < timeout);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -187,9 +187,9 @@ public class QueryRoutingTest {
   public void testServerDown()
       throws Exception {
     long requestId = 123;
-    // To avoid flakyness, set timeout to 2000 msec. For some test runs, it can take up to
+    // To avoid flakyness, set timeoutMs to 2000 msec. For some test runs, it can take up to
     // 1400 msec to mark request as failed.
-    long timeout = 2000L;
+    long timeoutMs = 2000L;
     DataTable dataTable = DataTableBuilder.getEmptyDataTable();
     dataTable.getMetadata().put(MetadataKey.REQUEST_ID.getName(), Long.toString(requestId));
     byte[] responseBytes = dataTable.toBytes();
@@ -200,7 +200,7 @@ public class QueryRoutingTest {
 
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
-        _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, timeout);
+        _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, timeoutMs);
 
     // Shut down the server before getting the response
     queryServer.shutDown();
@@ -214,12 +214,12 @@ public class QueryRoutingTest {
     assertEquals(serverResponse.getResponseSize(), 0);
     assertEquals(serverResponse.getDeserializationTimeMs(), 0);
     // Query should early terminate
-    assertTrue(System.currentTimeMillis() - startTimeMs < timeout);
+    assertTrue(System.currentTimeMillis() - startTimeMs < timeoutMs);
 
     // Submit query after server is down
     startTimeMs = System.currentTimeMillis();
     asyncQueryResponse =
-        _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, timeout);
+        _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, timeoutMs);
     response = asyncQueryResponse.getResponse();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
@@ -230,7 +230,7 @@ public class QueryRoutingTest {
     assertEquals(serverResponse.getResponseSize(), 0);
     assertEquals(serverResponse.getDeserializationTimeMs(), 0);
     // Query should early terminate
-    assertTrue(System.currentTimeMillis() - startTimeMs < timeout);
+    assertTrue(System.currentTimeMillis() - startTimeMs < timeoutMs);
   }
 
   @AfterClass


### PR DESCRIPTION
## Description
To avoid flakyness, set timeout to 2000 msec. For some test runs, it can take up to 1400 msec to mark request as failed.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
