### PR TITLE
[fix] update table config show error msg on exception

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -367,7 +367,7 @@ public class PinotTableRestletResource {
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
-      String msg = String.format("Invalid table config: %s", tableName);
+      String msg = String.format("Invalid table config: %s with error: %s", tableName, e.getMessage());
       throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
     }
 


### PR DESCRIPTION
Problem to solve:
Currently when updating a table config, api only return invalid table config, not showing any useful error msg, it's hard for user to debug without first request table validation api first.

Fix:
Add exception error msg in the constructed msg to show errors in api response.