### PR TITLE
Move maxBurstQps broker metric in createRateLimiter method

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
@@ -79,7 +79,7 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
       try {
         _routingManager.buildRouting(tableNameWithType);
         TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
-        _queryQuotaManager.initTableQueryQuota(tableConfig,
+        _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig,
             _helixDataAccessor.getProperty(_helixDataAccessor.keyBuilder().externalView(BROKER_RESOURCE_INSTANCE)));
       } catch (Exception e) {
         LOGGER.error("Caught exception while processing transition from OFFLINE to ONLINE for table: {}",

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -149,7 +149,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ZKMetadataProvider
         .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, TableConfigUtils.toZNRecord(tableConfig));
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
 
     // All the request should be passed.
@@ -164,7 +164,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -181,7 +181,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
 
     // Nothing happened since it doesn't have qps quota.
@@ -202,7 +202,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
 
     // Drop the offline table won't have any affect since it is table type specific.
@@ -233,9 +233,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
         .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, TableConfigUtils.toZNRecord(offlineTableConfig));
 
     // Since each table has 2 online brokers, per broker rate becomes 100.0 / 2 = 50.0
-    _queryQuotaManager.initTableQueryQuota(offlineTableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(offlineTableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
-    _queryQuotaManager.initTableQueryQuota(realtimeTableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(realtimeTableConfig, brokerResource);
     // The hash map now contains 2 entries for both of the tables.
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 2);
 
@@ -259,7 +259,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ZKMetadataProvider
         .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, TableConfigUtils.toZNRecord(tableConfig));
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
 
     runQueries(70, 10L);
@@ -276,7 +276,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ZKMetadataProvider
         .setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, TableConfigUtils.toZNRecord(tableConfig));
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
 
     runQueries(70, 10L);
@@ -291,7 +291,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -308,7 +308,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -325,7 +325,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
 
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -334,7 +334,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
       throws Exception {
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, null);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, null);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
   }
 
@@ -346,7 +346,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ZKMetadataProvider
         .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, TableConfigUtils.toZNRecord(tableConfig));
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
     Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
   }
 
@@ -359,7 +359,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ZKMetadataProvider
         .setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, TableConfigUtils.toZNRecord(tableConfig));
     setQps(tableConfig);
-    _queryQuotaManager.initTableQueryQuota(tableConfig, brokerResource);
+    _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
 
     // For the 1st version we don't check the number of online brokers.
     // Thus the expected size now is 1. It'll be 0 when we bring dynamic rate back.


### PR DESCRIPTION
## Description
Currently when a quota config gets updated, `RefreshTableConfigMessageHandler` will trigger the `initOrUpdateTableQueryQuota` method, which will create a new QueryQuotaEntity object for the table. This makes our callback function emit the wrong value, since the old one is kept in the callback but no qps is updated on the old object.

This PR moves maxBurstQps broker metric in `createRateLimiter` method, so that whenever the quota config gets updated, the callback function can always get the correct QueryQuotaEntity object and emit the correct value.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
