### PR TITLE
TableConfigs toJsonObject fix

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/TableConfigs.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/TableConfigs.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -68,6 +69,24 @@ public class TableConfigs extends BaseJsonConfig {
   @Nullable
   public TableConfig getRealtime() {
     return _realtime;
+  }
+
+  @Override
+  public String toJsonString() {
+    try {
+      ObjectNode tableConfigs = JsonUtils.newObjectNode();
+      tableConfigs.put("tableName", _tableName);
+      tableConfigs.set("schema", _schema.toJsonObject());
+      if (_offline != null) {
+        tableConfigs.set("offline", _offline.toJsonNode());
+      }
+      if (_realtime != null) {
+        tableConfigs.set("realtime", _realtime.toJsonNode());
+      }
+      return JsonUtils.objectToString(tableConfigs);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public String toPrettyJsonString() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/TableConfigs.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/TableConfigs.java
@@ -71,19 +71,23 @@ public class TableConfigs extends BaseJsonConfig {
     return _realtime;
   }
 
+  private ObjectNode toJsonObject() {
+    ObjectNode tableConfigsObjectNode = JsonUtils.newObjectNode();
+    tableConfigsObjectNode.put("tableName", _tableName);
+    tableConfigsObjectNode.set("schema", _schema.toJsonObject());
+    if (_offline != null) {
+      tableConfigsObjectNode.set("offline", _offline.toJsonNode());
+    }
+    if (_realtime != null) {
+      tableConfigsObjectNode.set("realtime", _realtime.toJsonNode());
+    }
+    return tableConfigsObjectNode;
+  }
+
   @Override
   public String toJsonString() {
     try {
-      ObjectNode tableConfigs = JsonUtils.newObjectNode();
-      tableConfigs.put("tableName", _tableName);
-      tableConfigs.set("schema", _schema.toJsonObject());
-      if (_offline != null) {
-        tableConfigs.set("offline", _offline.toJsonNode());
-      }
-      if (_realtime != null) {
-        tableConfigs.set("realtime", _realtime.toJsonNode());
-      }
-      return JsonUtils.objectToString(tableConfigs);
+      return JsonUtils.objectToString(toJsonObject());
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
@@ -91,7 +95,7 @@ public class TableConfigs extends BaseJsonConfig {
 
   public String toPrettyJsonString() {
     try {
-      return JsonUtils.objectToPrettyString(this);
+      return JsonUtils.objectToPrettyString(toJsonObject());
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Making this backward compatible with how the `GET schema` call is.
Without this fix, the `GET tableConfigs` call returns the fields like "defaultNullValue", "maxLength" etc, even if user hadn't set them while creating the config. This interferes with the update call.