### PR TITLE
Allow overriding delimiter in Complex type config

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -278,7 +278,7 @@ public class TableConfigSerDeTest {
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
-              new ComplexTypeConfig(unnestFields));
+              new ComplexTypeConfig(unnestFields, "."));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -77,19 +77,20 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  *
  */
 public class ComplexTypeTransformer implements RecordTransformer {
-  // TODO: make configurable
-  private static final CharSequence DEFAULT_DELIMITER = ".";
+  private static final String DEFAULT_DELIMITER = ".";
   private final List<String> _unnestFields;
-  private final CharSequence _delimiter;
+  private final String _delimiter;
 
   public ComplexTypeTransformer(TableConfig tableConfig) {
     this(parseUnnestFields(tableConfig), parseDelimiter(tableConfig));
   }
 
   @VisibleForTesting
-  public ComplexTypeTransformer(List<String> unnestFields, CharSequence delimiter) {
+  public ComplexTypeTransformer(List<String> unnestFields, String delimiter) {
     _unnestFields = new ArrayList<>(unnestFields);
     _delimiter = delimiter;
+    // the unnest fields are sorted to achieve the topological sort of the collections, so that the parent collection
+    // (e.g. foo) is unnested before the child collection (e.g. foo.bar)
     Collections.sort(_unnestFields);
   }
 
@@ -102,7 +103,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     }
   }
 
-  private static CharSequence parseDelimiter(TableConfig tableConfig) {
+  private static String parseDelimiter(TableConfig tableConfig) {
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
         && tableConfig.getIngestionConfig().getComplexTypeConfig().getDelimiter() != null) {
       return tableConfig.getIngestionConfig().getComplexTypeConfig().getDelimiter();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class ComplexTypeTransformerTest {
   @Test
   public void testFlattenMap() {
-    ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>());
+    ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>(), ".");
 
     // test flatten root-level tuples
     GenericRow genericRow = new GenericRow();
@@ -57,7 +57,7 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals(genericRow.getValue("map2.c"), 3);
 
     // test flattening the tuple inside the collection
-    transformer = new ComplexTypeTransformer(Arrays.asList("l1"));
+    transformer = new ComplexTypeTransformer(Arrays.asList("l1"), ".");
     genericRow = new GenericRow();
     List<Map<String, Object>> list1 = new ArrayList<>();
     list1.add(map1);
@@ -70,6 +70,22 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals(map.get("b"), "v");
     Assert.assertEquals(map.get("im1.aa"), 2);
     Assert.assertEquals(map.get("im1.bb"), "u");
+
+    // test overriding delimiter
+    transformer = new ComplexTypeTransformer(Arrays.asList("l1"), "_");
+    genericRow = new GenericRow();
+    innerMap1 = new HashMap<>();
+    innerMap1.put("aa", 2);
+    innerMap1.put("bb", "u");
+    map1 = new HashMap<>();
+    map1.put("im1", innerMap1);
+    list1 = new ArrayList<>();
+    list1.add(map1);
+    genericRow.putValue("l1", list1);
+    transformer.flattenMap(genericRow, new ArrayList<>(genericRow.getFieldToValueMap().keySet()));
+    map = (Map<String, Object>) ((Collection) genericRow.getValue("l1")).iterator().next();
+    Assert.assertEquals(map.get("im1_aa"), 2);
+    Assert.assertEquals(map.get("im1_bb"), "u");
   }
 
   @Test
@@ -91,7 +107,7 @@ public class ComplexTypeTransformerTest {
     //    {
     //      "array.a":"v2"
     //    }]
-    ComplexTypeTransformer transformer = new ComplexTypeTransformer(Arrays.asList("array"));
+    ComplexTypeTransformer transformer = new ComplexTypeTransformer(Arrays.asList("array"), ".");
     GenericRow genericRow = new GenericRow();
     Object[] array = new Object[2];
     Map<String, Object> map1 = new HashMap<>();
@@ -141,7 +157,7 @@ public class ComplexTypeTransformerTest {
     //      "array.a":"v2","array2.b":"v4"
     //   }]
     //
-    transformer = new ComplexTypeTransformer(Arrays.asList("array", "array2"));
+    transformer = new ComplexTypeTransformer(Arrays.asList("array", "array2"), ".");
     genericRow = new GenericRow();
     Object[] array2 = new Object[2];
     Map<String, Object> map3 = new HashMap<>();
@@ -202,7 +218,7 @@ public class ComplexTypeTransformerTest {
     //   {
     //      "array.a":"v2"
     //   }]
-    transformer = new ComplexTypeTransformer(Arrays.asList("array", "array.array2"));
+    transformer = new ComplexTypeTransformer(Arrays.asList("array", "array.array2"), ".");
     genericRow = new GenericRow();
     genericRow.putValue("array", array);
     map1.put("array2", array2);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -34,13 +34,23 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The fields to unnest")
   private final List<String> _unnestFields;
 
+  @JsonPropertyDescription("The delimiter used to separate components in a path")
+  private final String _delimiter;
+
   @JsonCreator
-  public ComplexTypeConfig(@JsonProperty("unnestFields") @Nullable List<String> unnestFields) {
+  public ComplexTypeConfig(@JsonProperty("unnestFields") @Nullable List<String> unnestFields,
+      @JsonProperty("delimiter") @Nullable String delimiter) {
     _unnestFields = unnestFields;
+    _delimiter = delimiter;
   }
 
   @Nullable
   public List<String> getUnnestFields() {
     return _unnestFields;
+  }
+
+  @Nullable
+  public String getDelimiter() {
+    return _delimiter;
   }
 }


### PR DESCRIPTION
## Description
Part of https://github.com/apache/incubator-pinot/issues/6904



## Upgrade Notes
This PR adds a configuration option `delimiter` in `ComplexTypeConfig` to override the delimiter (default to dot).

