### PR TITLE
initialize server tls regardless of uploader https settings

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -132,6 +132,9 @@ public class FileUploadDownloadClient implements Closeable {
    * @param sslContext SSL context
    */
   public FileUploadDownloadClient(@Nullable SSLContext sslContext) {
+    if (sslContext == null) {
+      sslContext = _defaultSSLContext;
+    }
     _httpClient = HttpClients.custom().setSSLContext(sslContext).build();
   }
 


### PR DESCRIPTION
## Description
`Server2ControllerSegmentUploader` doesn't seem to pick up default TLS configs without the dedicated `pinot.server.segment.uploader.https.enabled` flag set. This PR initializes TLS defaults even without any further settings for segment uploader

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

## Documentation
