### PR TITLE
update default presto pinot image configs

### DIFF
--- a/docker/images/pinot-presto/etc/catalog/pinot.properties
+++ b/docker/images/pinot-presto/etc/catalog/pinot.properties
@@ -20,10 +20,3 @@
 connector.name=pinot
 pinot.controller-urls=pinot-controller:9000
 pinot.controller-rest-service=pinot-controller:9000
-
-pinot.limit-large-for-segment=1
-pinot.allow-multiple-aggregations=true
-pinot.use-date-trunc=true
-pinot.infer-date-type-in-schema=true
-pinot.infer-timestamp-type-in-schema=true
-

--- a/docker/images/pinot-presto/etc/catalog/pinot_quickstart.properties
+++ b/docker/images/pinot-presto/etc/catalog/pinot_quickstart.properties
@@ -20,9 +20,3 @@
 connector.name=pinot
 pinot.controller-urls=pinot-quickstart:9000
 pinot.controller-rest-service=pinot-quickstart:9000
-
-pinot.limit-large-for-segment=1
-pinot.allow-multiple-aggregations=true
-pinot.use-date-trunc=true
-pinot.infer-date-type-in-schema=true
-pinot.infer-timestamp-type-in-schema=true


### PR DESCRIPTION
## Description
Update presto docker example configs to use default values.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
