### PR TITLE
Compare state of rate limiting with ignoring cases

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotBrokerRestletResource.java
@@ -221,21 +221,22 @@ public class PinotBrokerRestletResource {
       throw new ControllerApplicationException(LOGGER,
           String.format("'%s' is not a valid broker instance name.", brokerInstanceName), Response.Status.BAD_REQUEST);
     }
-    validateQueryQuotaStateChange(state);
+    String stateInUpperCases = state.toUpperCase();
+    validateQueryQuotaStateChange(stateInUpperCases);
     List<String> liveInstances = _pinotHelixResourceManager.getOnlineInstanceList();
     if (!liveInstances.contains(brokerInstanceName)) {
       throw new ControllerApplicationException(LOGGER, String.format("Instance '%s' not found.", brokerInstanceName),
           Response.Status.NOT_FOUND);
     }
-    _pinotHelixResourceManager.toggleQueryQuotaStateForBroker(brokerInstanceName, state);
+    _pinotHelixResourceManager.toggleQueryQuotaStateForBroker(brokerInstanceName, stateInUpperCases);
     String msg =
-        String.format("Set query rate limiting to: %s for all tables in broker: %s", state, brokerInstanceName);
+        String.format("Set query rate limiting to: %s for all tables in broker: %s", stateInUpperCases, brokerInstanceName);
     LOGGER.info(msg);
     return new SuccessResponse(msg);
   }
 
   private void validateQueryQuotaStateChange(String state) {
-    if (!"ENABLE".equalsIgnoreCase(state) && !"DISABLE".equalsIgnoreCase(state)) {
+    if (!"ENABLE".equals(state) && !"DISABLE".equals(state)) {
       throw new ControllerApplicationException(LOGGER, "Invalid query quota state: " + state,
           Response.Status.BAD_REQUEST);
     }


### PR DESCRIPTION
## Description
This PR compares the state of rate limiting in pinot-broker with ignoring the string cases. This helps to accept any input regardless of the case like "ENABLE", "DISABLE", "enable", "disable", etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
