### PR TITLE
Convert collections not unnested to json

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -229,8 +229,8 @@ public class TableConfigSerDeTest {
       properties.put("foo", "bar");
       properties.put("foobar", "potato");
       List<FieldConfig> fieldConfigList = Arrays.asList(
-          new FieldConfig("column1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, properties),
-          new FieldConfig("column2", null, null, null, null));
+          new FieldConfig("column1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null,
+              properties), new FieldConfig("column2", null, null, null, null));
       TableConfig tableConfig = tableConfigBuilder.setFieldConfigList(fieldConfigList).build();
 
       checkFieldConfig(tableConfig);
@@ -278,7 +278,7 @@ public class TableConfigSerDeTest {
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
-              new ComplexTypeConfig(unnestFields, "."));
+              new ComplexTypeConfig(unnestFields, ".", ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -284,6 +284,10 @@ public class ComplexTypeTransformer implements RecordTransformer {
     return !(element instanceof Map || element instanceof Collection || isArray(element));
   }
 
+  /**
+   * This function assumes the collection is a homogeneous data structure that elements have same data type.
+   * So it checks the first element only.
+   */
   private boolean containPrimitives(Collection value) {
     if (value.isEmpty()) {
       return true;
@@ -292,7 +296,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     return !(element instanceof Map || element instanceof Collection || isArray(element));
   }
 
-  static boolean isArray(Object obj) {
+  private static boolean isArray(Object obj) {
     if (obj == null) {
       return false;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -296,7 +296,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     return !(element instanceof Map || element instanceof Collection || isArray(element));
   }
 
-  private static boolean isArray(Object obj) {
+  protected static boolean isArray(Object obj) {
     if (obj == null) {
       return false;
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.recordtransformer;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -236,5 +237,77 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals("v4", next.getValue("array.array2.b"));
     next = itr.next();
     Assert.assertEquals("v2", next.getValue("array.a"));
+  }
+
+  @Test
+  public void testConvertCollectionToString() {
+    // json convert inner collections
+    // {
+    //   "array":[
+    //      {
+    //         "array1":[
+    //            {
+    //               "b":"v1"
+    //            }
+    //         ]
+    //      }
+    //   ]
+    // }
+    // is converted to
+    // [{
+    //   "array.array1":"[
+    //            {
+    //               "b":"v1"
+    //            }
+    //         ]"
+    // }]
+    ComplexTypeTransformer transformer = new ComplexTypeTransformer(Arrays.asList("array"), ".");
+    GenericRow genericRow = new GenericRow();
+    Map<String, Object> map = new HashMap<>();
+    Object[] array1 = new Object[1];
+    array1[0] = ImmutableMap.of("b", "v1");
+    map.put("array1", array1);
+    Object[] array = new Object[1];
+    array[0] = map;
+    genericRow.putValue("array", array);
+    transformer.transform(genericRow);
+    Assert.assertNotNull(genericRow.getValue(GenericRow.MULTIPLE_RECORDS_KEY));
+    Collection<GenericRow> collection = (Collection<GenericRow>) genericRow.getValue(GenericRow.MULTIPLE_RECORDS_KEY);
+    GenericRow row = collection.iterator().next();
+    Assert.assertTrue(row.getValue("array.array1") instanceof String);
+
+    // primitive array not converted
+    // {
+    //   "array":[1,2]
+    // }
+    transformer = new ComplexTypeTransformer(Arrays.asList(), ".");
+    genericRow = new GenericRow();
+    array = new Object[]{1, 2};
+    genericRow.putValue("array", array);
+    transformer.transform(genericRow);
+    Assert.assertTrue(genericRow.getValue("array") instanceof Object[]);
+
+    // array under tuple converted
+    // {
+    //   "t": {
+    //         "array1":[
+    //            {
+    //               "b":"v1"
+    //            }
+    //         ]
+    //      }
+    // to
+    // {
+    //   "t": "{
+    //         "array1":[
+    //            {
+    //               "b":"v1"
+    //            }
+    //         ]
+    //  }"
+    genericRow = new GenericRow();
+    genericRow.putValue("t", map);
+    transformer.transform(genericRow);
+    Assert.assertTrue(genericRow.getValue("t.array1") instanceof String);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -31,17 +31,26 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  */
 public class ComplexTypeConfig extends BaseJsonConfig {
 
+  public enum CollectionToJsonMode {
+    NONE, NON_PRIMITIVE, ALL
+  }
+
   @JsonPropertyDescription("The fields to unnest")
   private final List<String> _unnestFields;
 
   @JsonPropertyDescription("The delimiter used to separate components in a path")
   private final String _delimiter;
 
+  @JsonPropertyDescription("The mode of converting collection to JSON string")
+  private final CollectionToJsonMode _collectionToJsonMode;
+
   @JsonCreator
   public ComplexTypeConfig(@JsonProperty("unnestFields") @Nullable List<String> unnestFields,
-      @JsonProperty("delimiter") @Nullable String delimiter) {
+      @JsonProperty("delimiter") @Nullable String delimiter,
+      @JsonProperty("collectionToJsonMode") @Nullable CollectionToJsonMode collectionToJsonMode) {
     _unnestFields = unnestFields;
     _delimiter = delimiter;
+    _collectionToJsonMode = collectionToJsonMode;
   }
 
   @Nullable
@@ -52,5 +61,9 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @Nullable
   public String getDelimiter() {
     return _delimiter;
+  }
+
+  public CollectionToJsonMode getCollectionToJsonMode() {
+    return _collectionToJsonMode;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -63,6 +63,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
     return _delimiter;
   }
 
+  @Nullable
   public CollectionToJsonMode getCollectionToJsonMode() {
     return _collectionToJsonMode;
   }


### PR DESCRIPTION
## Description
Part of https://github.com/apache/incubator-pinot/issues/6904

This PR converts the collections that are not marked in `unnestFields` to JSON string. Note that this conversion does not apply on collections of primitive values.


