### PR TITLE
Fix log4j2 for Quickstart.

### DIFF
--- a/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/quickstart-log4j2.xml
@@ -20,71 +20,29 @@
 
 -->
 <Configuration>
+  <Properties>
+    <Property name="LOG_ROOT">logs</Property>
+    <Property name="LOG_PATTERN">%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Property>
+    <Property name="PINOT_COMPONENT">quickstart</Property>
+  </Properties>
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT"/>
-    <RandomAccessFile name="controllerLog" fileName="pinotController.log" immediateFlush="false">
-      <PatternLayout>
-        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
-      </PatternLayout>
-    </RandomAccessFile>
-    <RandomAccessFile name="brokerLog" fileName="pinotBroker.log" immediateFlush="false">
-      <PatternLayout>
-        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
-      </PatternLayout>
-    </RandomAccessFile>
-    <RandomAccessFile name="serverLog" fileName="pinotServer.log" immediateFlush="false">
-      <PatternLayout>
-        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
-      </PatternLayout>
-    </RandomAccessFile>
-    <RandomAccessFile name="minionLog" fileName="pinotMinion.log" immediateFlush="false">
-      <PatternLayout>
-        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
-      </PatternLayout>
-    </RandomAccessFile>
-
+    <Console name="console" target="SYSTEM_OUT" />
+    <RollingFile name="pinotLog" fileName="${env:LOG_ROOT}/pinot-${env:PINOT_COMPONENT}.log"
+                 filePattern="${env:LOG_ROOT}/pinot-${env:PINOT_COMPONENT}.log.%i.gz" immediateFlush="false">
+      <PatternLayout pattern="${env:LOG_PATTERN}"/>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="19500KB" />
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
   </Appenders>
   <Loggers>
-    <Root level="error" additivity="false">
-      <AppenderRef ref="console"/>
+    <Root level="info" additivity="false">
+      <AppenderRef ref="pinotLog"/>
     </Root>
-    <Logger name="org.apache.pinot" level="error" additivity="false"/>
-    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+    <Logger name="org.apache.pinot.tools" level="error" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
-
-    <!-- Direct controller package log to the controller log file -->
-    <AsyncLogger name="org.apache.pinot.controller" level="info" additivity="false">
-      <AppenderRef ref="controllerLog"/>
-    </AsyncLogger>
-
-    <!-- Direct broker package log to the broker log file -->
-    <AsyncLogger name="org.apache.pinot.broker" level="info" additivity="false">
-      <AppenderRef ref="brokerLog"/>
-    </AsyncLogger>
-
-    <!-- Including server related package log to the server log file -->
-    <AsyncLogger name="org.apache.pinot.server" level="info" additivity="false">
-      <AppenderRef ref="serverLog"/>
-    </AsyncLogger>
-    <AsyncLogger name="org.apache.pinot.core.plan" level="info" additivity="false">
-      <AppenderRef ref="serverLog"/>
-    </AsyncLogger>
-    <AsyncLogger name="org.apache.pinot.core.realtime" level="info" additivity="false">
-      <AppenderRef ref="serverLog"/>
-    </AsyncLogger>
-    <AsyncLogger name="org.apache.pinot.core.query" level="info" additivity="false">
-      <AppenderRef ref="serverLog"/>
-    </AsyncLogger>
-
-    <!-- Direct minion package log to the broker log file -->
-    <AsyncLogger name="org.apache.pinot.minion" level="info" additivity="false">
-      <AppenderRef ref="minionLog"/>
-    </AsyncLogger>
-
     <AsyncLogger name="org.reflections" level="error" additivity="false"/>
-    <AsyncLogger name="org.apache.pinot.spi.plugin" level="error" additivity="false">
-      <AppenderRef ref="console"/>
-    </AsyncLogger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
In QuickStart, we start all Pinot components in a single JVM. And the existing
log4j2 config for it directs package specific logs to different components.
This is broken because packages can be shared across components (eg pinot-core).

During debugging recent problems reported in OSS, we found that realtime
consumption would stop in Pinot, but no errors/exceptions would appear in
the logs. This was due to the fact that the exceptions were thrown by packages
that were not part of any component's log, and were missed.

In this PR we address the problem as:
- We create a single log file (logs/pinot-quickstart.log) with log level `info` for quick-start, as it
  starts all components in single JVM.
- We set the log level to error for console.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
