### PR TITLE
add complex-type support to avro-to-pinot schema inference

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -64,7 +64,6 @@ public class AvroSchemaUtil {
       case BOOLEAN:
       case STRING:
       case ENUM:
-      case BYTES:
         return true;
       default:
         return false;

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -52,6 +52,25 @@ public class AvroSchemaUtil {
     }
   }
 
+  /**
+   * @return if the given avro type is a primitive type.
+   */
+  public static boolean isPrimitiveType(Schema.Type avroType) {
+    switch (avroType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case STRING:
+      case ENUM:
+      case BYTES:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static ObjectNode toAvroSchemaJsonObject(FieldSpec fieldSpec) {
     ObjectNode jsonSchema = JsonUtils.newObjectNode();
     jsonSchema.put("name", fieldSpec.getName());

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -67,38 +67,32 @@ public class AvroUtils {
       String fieldName = field.name();
       DataType dataType = extractFieldDataType(field);
       boolean isSingleValueField = isSingleValueField(field);
-      if (fieldTypeMap == null) {
-        pinotSchema.addField(new DimensionFieldSpec(fieldName, dataType, isSingleValueField));
-      } else {
-        FieldSpec.FieldType fieldType = fieldTypeMap.get(fieldName);
-        Preconditions.checkNotNull(fieldType, "Field type not specified for field: %s", fieldName);
-        switch (fieldType) {
-          case DIMENSION:
-            pinotSchema.addField(new DimensionFieldSpec(fieldName, dataType, isSingleValueField));
-            break;
-          case METRIC:
-            Preconditions.checkState(isSingleValueField, "Metric field: %s cannot be multi-valued", fieldName);
-            pinotSchema.addField(new MetricFieldSpec(fieldName, dataType));
-            break;
-          case TIME:
-            Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", fieldName);
-            Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
-            pinotSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, field.name())));
-            break;
-          case DATE_TIME:
-            Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", fieldName);
-            Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
-            pinotSchema.addField(new DateTimeFieldSpec(field.name(), dataType,
-                new DateTimeFormatSpec(1, timeUnit.toString(), DateTimeFieldSpec.TimeFormat.EPOCH.toString())
-                    .getFormat(), new DateTimeGranularitySpec(1, timeUnit).getGranularity()));
-            break;
-          default:
-            throw new UnsupportedOperationException(
-                "Unsupported field type: " + fieldType + " for field: " + fieldName);
-        }
-      }
+      addFieldToPinotSchema(pinotSchema, dataType, fieldName, isSingleValueField, fieldTypeMap, timeUnit);
     }
+    return pinotSchema;
+  }
 
+  /**
+   * Given an Avro schema, flatten/unnest the complex types based on the config, and then map from column to field type
+   * and time unit, return the equivalent Pinot schema.
+   *
+   * @param avroSchema Avro schema
+   * @param fieldTypeMap Map from column to field type
+   * @param timeUnit Time unit
+   * @param unnestFields the fields to unnest
+   * @param delimiter the delimiter to separate components in nested structure
+   *
+   * @return Pinot schema
+   */
+  public static Schema getPinotSchemaFromAvroSchemaWithComplexTypeHandling(org.apache.avro.Schema avroSchema,
+      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, List<String> unnestFields,
+      String delimiter) {
+    Schema pinotSchema = new Schema();
+
+    for (Field field : avroSchema.getFields()) {
+      extractSchemaWithComplexTypeHandling(field.schema(), unnestFields, delimiter, field.name(), pinotSchema,
+          fieldTypeMap, timeUnit);
+    }
     return pinotSchema;
   }
 
@@ -137,13 +131,22 @@ public class AvroUtils {
    * @param avroSchemaFile Avro schema file
    * @param fieldTypeMap Map from column to field type
    * @param timeUnit Time unit
+   * @param complexType if allows complex-type handling
+   * @param unnestFields the fields to unnest
+   * @param delimiter the delimiter separating components in nested structure
    * @return Pinot schema
    */
   public static Schema getPinotSchemaFromAvroSchemaFile(File avroSchemaFile,
-      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit)
+      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, boolean complexType,
+      List<String> unnestFields, String delimiter)
       throws IOException {
     org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(avroSchemaFile);
-    return getPinotSchemaFromAvroSchema(avroSchema, fieldTypeMap, timeUnit);
+    if (!complexType) {
+      return getPinotSchemaFromAvroSchema(avroSchema, fieldTypeMap, timeUnit);
+    } else {
+      return getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, fieldTypeMap, timeUnit, unnestFields,
+          delimiter);
+    }
   }
 
   /**
@@ -276,5 +279,87 @@ public class AvroUtils {
     } else {
       return fieldSchema;
     }
+  }
+
+  private static void extractSchemaWithComplexTypeHandling(org.apache.avro.Schema fieldSchema,
+      List<String> unnestFields, String delimiter, String path, Schema pinotSchema,
+      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit) {
+    org.apache.avro.Schema.Type fieldType = fieldSchema.getType();
+    if (fieldType == org.apache.avro.Schema.Type.UNION) {
+      org.apache.avro.Schema nonNullSchema = null;
+      for (org.apache.avro.Schema childFieldSchema : fieldSchema.getTypes()) {
+        if (childFieldSchema.getType() != org.apache.avro.Schema.Type.NULL) {
+          if (nonNullSchema == null) {
+            nonNullSchema = childFieldSchema;
+          } else {
+            throw new IllegalStateException("More than one non-null schema in UNION schema");
+          }
+        }
+      }
+      if (nonNullSchema != null) {
+        extractSchemaWithComplexTypeHandling(nonNullSchema, unnestFields, delimiter, path, pinotSchema, fieldTypeMap,
+            timeUnit);
+      } else {
+        throw new IllegalStateException("Cannot find non-null schema in UNION schema");
+      }
+    } else if (fieldType == org.apache.avro.Schema.Type.RECORD) {
+      for (Field innerField : fieldSchema.getFields()) {
+        extractSchemaWithComplexTypeHandling(innerField.schema(), unnestFields, delimiter,
+            concat(delimiter, path, innerField.name()), pinotSchema, fieldTypeMap, timeUnit);
+      }
+    } else if (fieldType == org.apache.avro.Schema.Type.ARRAY) {
+      org.apache.avro.Schema elementType = fieldSchema.getElementType();
+      if (unnestFields.contains(path)) {
+        extractSchemaWithComplexTypeHandling(elementType, unnestFields, delimiter, path, pinotSchema, fieldTypeMap,
+            timeUnit);
+      } else if (AvroSchemaUtil.isPrimitiveType(elementType.getType())) {
+        addFieldToPinotSchema(pinotSchema, AvroSchemaUtil.valueOf(elementType.getType()), path, false, fieldTypeMap,
+            timeUnit);
+      } else {
+        addFieldToPinotSchema(pinotSchema, DataType.STRING, path, true, fieldTypeMap, timeUnit);
+      }
+    } else {
+      DataType dataType = AvroSchemaUtil.valueOf(fieldType);
+      addFieldToPinotSchema(pinotSchema, dataType, path, true, fieldTypeMap, timeUnit);
+    }
+  }
+
+  private static void addFieldToPinotSchema(Schema pinotSchema, DataType dataType, String name,
+      boolean isSingleValueField, @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap,
+      @Nullable TimeUnit timeUnit) {
+    if (fieldTypeMap == null) {
+      pinotSchema.addField(new DimensionFieldSpec(name, dataType, isSingleValueField));
+    } else {
+      FieldSpec.FieldType fieldType =
+          fieldTypeMap.containsKey(name) ? fieldTypeMap.get(name) : FieldSpec.FieldType.DIMENSION;
+      Preconditions.checkNotNull(fieldType, "Field type not specified for field: %s", name);
+      switch (fieldType) {
+        case DIMENSION:
+          pinotSchema.addField(new DimensionFieldSpec(name, dataType, isSingleValueField));
+          break;
+        case METRIC:
+          Preconditions.checkState(isSingleValueField, "Metric field: %s cannot be multi-valued", name);
+          pinotSchema.addField(new MetricFieldSpec(name, dataType));
+          break;
+        case TIME:
+          Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", name);
+          Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
+          pinotSchema.addField(new TimeFieldSpec(new TimeGranularitySpec(dataType, timeUnit, name)));
+          break;
+        case DATE_TIME:
+          Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", name);
+          Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
+          pinotSchema.addField(new DateTimeFieldSpec(name, dataType,
+              new DateTimeFormatSpec(1, timeUnit.toString(), DateTimeFieldSpec.TimeFormat.EPOCH.toString()).getFormat(),
+              new DateTimeGranularitySpec(1, timeUnit).getGranularity()));
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported field type: " + fieldType + " for field: " + name);
+      }
+    }
+  }
+
+  private static String concat(String delimiter, String path, String component) {
+    return String.join(delimiter, path, component);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/resources/fake_avro_nested_schema.avsc
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/resources/fake_avro_nested_schema.avsc
@@ -1,0 +1,70 @@
+{
+    "fields": [
+        {
+            "doc": "array",
+            "name": "entries",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "TUPLE_1",
+                    "fields": [
+                        {
+                            "name": "id",
+                            "type": "long"
+                        },
+                        {
+                            "name": "description",
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "doc": "nested record",
+            "name": "tuple",
+            "type": [{
+                "type" : "record",
+                "name" : "address",
+                "fields" : [
+                    {"name": "streetaddress", "type": "string"},
+                    {"name": "city", "type": "string"}
+                ]
+            }]
+        },
+        {
+            "doc": "array1",
+            "name": "d2",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "int"
+                }
+            }
+        },
+        {
+            "doc": "dimension 1",
+            "name": "d1",
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        {
+            "doc": "hours since epoch",
+            "name": "hoursSinceEpoch",
+            "type": "long"
+        },
+        {
+            "doc": "metric 1",
+            "name": "m1",
+            "type": [
+                "null",
+                "int"
+            ]
+        }
+    ],
+    "name": "TUPLE_0",
+    "type": "record"
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -77,7 +77,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  *
  */
 public class ComplexTypeTransformer implements RecordTransformer {
-  private static final String DEFAULT_DELIMITER = ".";
+  public static final String DEFAULT_DELIMITER = ".";
   private final List<String> _unnestFields;
   private final String _delimiter;
 


### PR DESCRIPTION
## Description
Part of https://github.com/apache/incubator-pinot/issues/6904

Add complex-type support to avro-to-pinot schema inference. Now users can use the command like the following to infer Pinot schema from Avro schema with complex-structure

```
AvroSchemaToPinotSchema -timeColumnName fields.hoursSinceEpoch -avroSchemaFile  pinot-plugins/pinot-input-format/pinot-avro-base/src/test/resources/fake_avro_nested_schema.avsc -pinotSchemaName schema -outputDir /tmp/test -unnestFields=entries 
```
