### PR TITLE
Add support for Long in Modulo partition function.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/partition/ModuloPartitionFunction.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/partition/ModuloPartitionFunction.java
@@ -53,8 +53,12 @@ public class ModuloPartitionFunction implements PartitionFunction {
   public int getPartition(Object value) {
     if (value instanceof Integer) {
       return ((Integer) value) % _numPartitions;
+    } else if (value instanceof Long) {
+      // Since _numPartitions is int, the modulo should also be int.
+      return (int) (((Long) value) % _numPartitions);
     } else if (value instanceof String) {
-      return ((Integer.parseInt((String) value)) % _numPartitions);
+      // Parse String as Long, to support both Integer and Long.
+      return (int) ((Long.parseLong((String) value)) % _numPartitions);
     } else {
       throw new IllegalArgumentException(
           "Illegal argument for partitioning, expected Integer, got: " + value.getClass().getName());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/partition/PartitionFunctionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/partition/PartitionFunctionTest.java
@@ -57,9 +57,28 @@ public class PartitionFunctionTest {
       Assert.assertEquals(partitionFunction.toString().toLowerCase(), functionName.toLowerCase());
       Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
 
+      // Test int values.
       for (int j = 0; j < 1000; j++) {
         int value = random.nextInt();
         Assert.assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
+      }
+
+      // Test long values.
+      for (int j = 0; j < 1000; j++) {
+        long value = random.nextLong();
+        Assert.assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
+      }
+
+      // Test Integer represented as String.
+      for (int j = 0; j < 1000; j++) {
+        int value = random.nextInt();
+        Assert.assertEquals(partitionFunction.getPartition(Integer.toString(value)), (value % expectedNumPartitions));
+      }
+
+      // Test Long represented as String.
+      for (int j = 0; j < 1000; j++) {
+        long value = random.nextLong();
+        Assert.assertEquals(partitionFunction.getPartition(Long.toString(value)), (value % expectedNumPartitions));
       }
     }
   }
@@ -92,9 +111,10 @@ public class PartitionFunctionTest {
       Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
 
       for (int j = 0; j < 1000; j++) {
-        Integer value = random.nextInt();
-        Assert.assertTrue(partitionFunction.getPartition(value.toString()) < expectedNumPartitions,
-            "Illegal: " + partitionFunction.getPartition(value.toString()) + " " + expectedNumPartitions);
+        int value = random.nextInt();
+        String stringValue = Integer.toString(value);
+        Assert.assertTrue(partitionFunction.getPartition(stringValue) < expectedNumPartitions,
+            "Illegal: " + partitionFunction.getPartition(stringValue) + " " + expectedNumPartitions);
       }
     }
   }
@@ -169,8 +189,7 @@ public class PartitionFunctionTest {
     // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied org.apache.kafka.common.utils.Utils::murmur2 to those values and stored in expectedMurmurValues
     int[] expectedMurmurValues =
-        new int[]{-1044832774, -594851693, 1441878663, 1766739604, 1034724141, -296671913, 443511156, 1483601453,
-            1819695080, -931669296};
+        new int[]{-1044832774, -594851693, 1441878663, 1766739604, 1034724141, -296671913, 443511156, 1483601453, 1819695080, -931669296};
 
     long seed = 100;
     Random random = new Random(seed);


### PR DESCRIPTION
- Currently, the `ModuloPartitionFunction` class only supports `int` and `String`,
  with this PR, we also add support for `long`.

- Unrelated, but small change, also added `examples/` in the `.gitignore` file, as it
  gets generated when running quick-start.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
