### PR TITLE
Changes in rule engine to handle DateTime column (#6937)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -229,9 +229,8 @@ public class InputManager {
     _metricNames = new HashSet<>(_schema.getMetricNames());
     _dateTimeNames = new HashSet<>(_schema.getDateTimeNames());
 
-    String primaryTimeCol;
-    if ((primaryTimeCol = getPrimaryTimeCol()) != null) {
-      _dateTimeNames.add(primaryTimeCol);
+    if (_schema.getTimeFieldSpec() != null) {
+      _dateTimeNames.add(_schema.getTimeFieldSpec().getName());
     }
 
     _intToColNameMap = new String[_dimNames.size() + _metricNames.size() + _dateTimeNames.size()];
@@ -444,15 +443,10 @@ public class InputManager {
     return _colNameToIntMap.size();
   }
 
-  //TODO: Currently Pinot is using only ONE time column specified by TimeFieldSpec
-  // Change the implementation after the new schema with multiple _dateTimeNames is in use
-  // Return the time column used in server level filtering
-  public String getPrimaryTimeCol() {
-    if (_schema.getTimeFieldSpec() != null) {
-      return _schema.getTimeFieldSpec().getName();
-    } else {
-      return null;
-    }
+  // Provides set of time columns.
+  // This could be at most 1 from TimeFieldSpec and 1 or more from DatetimeFieldSpec
+  public Set<String> getTimeColumns() {
+    return _dateTimeNames;
   }
 
   public Set<String> getColNamesNoDictionary() {
@@ -580,8 +574,8 @@ public class InputManager {
     return _dimNames.contains(colName);
   }
 
-  public boolean isPrimaryDateTime(String colName) {
-    return colName != null && colName.equalsIgnoreCase(getPrimaryTimeCol());
+  public boolean isTimeOrDateTimeColumn(String colName) {
+    return colName != null && getTimeColumns().stream().anyMatch(d -> colName.equalsIgnoreCase(d));
   }
 
   public void estimateSizePerRecord()

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/BloomFilterRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/BloomFilterRule.java
@@ -48,8 +48,8 @@ public class  BloomFilterRule extends AbstractRule {
 
   @Override
   public void run() {
-    int numDims = _input.getNumDims();
-    double[] weights = new double[numDims];
+    int numCols = _input.getNumCols();
+    double[] weights = new double[numCols];
     AtomicDouble totalWeight = new AtomicDouble(0);
 
     // For each query, find out the dimensions used in 'EQ'
@@ -65,7 +65,7 @@ public class  BloomFilterRule extends AbstractRule {
     });
     LOGGER.debug("Weight: {}, Total {}", weights, totalWeight);
 
-    for (int i = 0; i < numDims; i++) {
+    for (int i = 0; i < numCols; i++) {
       String dimName = _input.intToColName(i);
       if (((weights[i] / totalWeight.get()) > _params.THRESHOLD_MIN_PERCENT_EQ_BLOOMFILTER)
           //The partitioned dimension should be frequently > P used
@@ -108,10 +108,6 @@ public class  BloomFilterRule extends AbstractRule {
       String colName = lhs.toString();
       if (lhs.getType() == ExpressionContext.Type.FUNCTION) {
         LOGGER.trace("Skipping the function {}", colName);
-      } else if (_input.isPrimaryDateTime(colName)) {
-        LOGGER.trace("Skipping the DateTime column {}", colName);
-      } else if (!_input.isDim(colName)) {
-        LOGGER.error("Error: Column {} should not appear in filter", colName);
       } else if (filterContext.getPredicate().getType() == Predicate.Type.EQ) {
         ret.add(_input.colNameToInt(colName));
       }
@@ -120,6 +116,6 @@ public class  BloomFilterRule extends AbstractRule {
   }
 
   private FixedLenBitset MUTABLE_EMPTY_SET() {
-    return new FixedLenBitset(_input.getNumDims());
+    return new FixedLenBitset(_input.getNumCols());
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/FlagQueryRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/FlagQueryRule.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pinot.controller.recommender.rules.impl;
 
 import java.util.HashSet;
@@ -36,7 +37,7 @@ import static org.apache.pinot.controller.recommender.rules.io.params.Recommende
  * Flag the queries that are not valid:
  *    Flag the queries with LIMIT value higher than a threshold.
  *    Flag the queries that are not using any filters.
- *    Flag the queries that are not using any filters.
+ *    Flag the queries that are not using any time filters.
  */
 public class FlagQueryRule extends AbstractRule {
   private final Logger LOGGER = LoggerFactory.getLogger(FlagQueryRule.class);
@@ -61,11 +62,15 @@ public class FlagQueryRule extends AbstractRule {
         //Flag the queries that are not using any filters.
         _output.getFlaggedQueries().add(query, WARNING_NO_FILTERING);
       }
-      else { //Flag the queries that are not using any filters.
+      else { //Flag the queries that are not using any time filters.
         Set<String> usedCols = new HashSet<>();
         queryContext.getFilter().getColumns(usedCols);
-        if (!usedCols.contains(_input.getPrimaryTimeCol())){
-          _output.getFlaggedQueries().add(query, WARNING_NO_TIME_COL);
+        Set<String> timeCols = _input.getTimeColumns();
+        if(!timeCols.isEmpty()) {
+          usedCols.retainAll(timeCols);
+          if (usedCols.isEmpty()) {
+            _output.getFlaggedQueries().add(query, WARNING_NO_TIME_COL);
+          }
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/NoDictionaryOnHeapDictionaryJointRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/NoDictionaryOnHeapDictionaryJointRule.java
@@ -222,7 +222,7 @@ public class NoDictionaryOnHeapDictionaryJointRule extends AbstractRule {
       Predicate predicate = filterContext.getPredicate();
       ExpressionContext lhs = predicate.getLhs();
       String colName = lhs.toString();
-      if (lhs.getType() == ExpressionContext.Type.FUNCTION || _input.isPrimaryDateTime(colName)) {
+      if (lhs.getType() == ExpressionContext.Type.FUNCTION || _input.isTimeOrDateTimeColumn(colName)) {
         LOGGER.trace("Skipping this column {}", colName);
       } else if (!_input.isDim(colName)) {
         LOGGER.error("Error: Column {} should not appear in filter", colName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/PinotTablePartitionRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/PinotTablePartitionRule.java
@@ -217,7 +217,7 @@ public class PinotTablePartitionRule extends AbstractRule {
       String colName = lhs.toString();
       if (lhs.getType() == ExpressionContext.Type.FUNCTION) {
         LOGGER.trace("Skipping the function {}", colName);
-      } else if (_input.isPrimaryDateTime(colName)) {
+      } else if (_input.isTimeOrDateTimeColumn(colName)) {
         LOGGER.trace("Skipping the DateTime column {}", colName);
         return null;
       } else if (!_input.isDim(colName)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
@@ -77,10 +77,10 @@ public class RecommenderConstants {
 
   public static class FlagQueryRuleParams{
     public static final long DEFAULT_THRESHOLD_MAX_LIMIT_SIZE = 100000;
-    public static final String WARNING_NO_FILTERING = "Warning: No filtering in ths query";
-    public static final String WARNING_NO_TIME_COL = "Warning: No time column used in ths query";
-    public static final String WARNING_TOO_LONG_LIMIT = "Warning: The size of LIMIT is longer than " + DEFAULT_THRESHOLD_MAX_LIMIT_SIZE;
-    public static final String ERROR_INVALID_QUERY = "Error: query not able to parse, skipped";
+    public static final String WARNING_NO_FILTERING = "Warning: Query seems to scan the entire table. No filters are used in the query. Please verify if filters are not needed.";
+    public static final String WARNING_NO_TIME_COL = "Warning: No time column used in filter in the query. Table with time columns typically use it in filters to make the queries more selective.";
+    public static final String WARNING_TOO_LONG_LIMIT = "Warning: Please verify if you need to pull out huge number of records for this query. Consider using smaller limit than " + DEFAULT_THRESHOLD_MAX_LIMIT_SIZE;
+    public static final String ERROR_INVALID_QUERY = "Error: Invalid query syntax. Please fix the query";
   }
 
   public static class RealtimeProvisioningRule {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
@@ -531,10 +531,6 @@ public class QueryInvertedSortedIndexRecommender {
           .setRecommendationPriorityEnum(RecommendationPriorityEnum.NON_CANDIDATE_SCAN) // won't recommend index
           .setnESI(nESI).setPercentSelected(_params.PERCENT_SELECT_FOR_FUNCTION).setnESIWithIdx(nESI).build();
     }
-    // Skip time columns
-    else if (_inputManager.isPrimaryDateTime(colName)) {
-      return null;
-    }
     // Not a valid dimension name
     else if (!_inputManager.isDim(colName)) {
       LOGGER.error("Error: Column {} should not appear in filter", colName);

--- a/pinot-controller/src/test/resources/recommenderInput/BloomFilterInputWithDateTimeColumn.json
+++ b/pinot-controller/src/test/resources/recommenderInput/BloomFilterInputWithDateTimeColumn.json
@@ -1,0 +1,64 @@
+{
+  "schema":{
+    "schemaName": "tableSchema",
+    "dimensionFieldSpecs": [
+      {
+        "name": "b",
+        "dataType": "DOUBLE",
+        "cardinality":6,
+        "singleValueField": false,
+        "numValuesPerEntry":1.5
+      },
+      {
+        "name": "c",
+        "dataType": "FLOAT",
+        "cardinality":7,
+        "numValuesPerEntry":1
+      },
+      {
+        "name": "d",
+        "dataType": "STRING",
+        "cardinality": 41,
+        "singleValueField": false,
+        "numValuesPerEntry": 2,
+        "averageLength": 27
+      }
+    ],
+    "metricFieldSpecs": [
+      {
+        "name": "p",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      }
+    ],
+    "dateTimeFieldSpecs": [
+      {
+        "name": "x",
+        "dataType": "INT",
+        "format": "1:DAYS:EPOCH",
+        "granularity": "1:DAYS",
+        "cardinality": 3
+      }
+    ],
+    "timeFieldSpec": {
+      "incomingGranularitySpec": {
+        "dataType": "INT",
+        "name": "t",
+        "cardinality": 1,
+        "timeType": "DAYS",
+        "numValuesPerEntry":1
+      }
+    }
+  },
+  "queriesWithWeights":{
+    "select d from tableName where (x=0 and b=1) or t=16": 3.5,
+    "select d from tableName where (x=12 and p=4) ": 3,
+    "select d from tableName where (t=7 and b=12) ": 1.5
+  },
+  "qps": 250,
+  "numMessagesPerSecInKafkaTopic":1000,
+  "numRecordsPerPush":1000000000,
+  "tableType": "HYBRID",
+  "latencySLA": 500
+}

--- a/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
@@ -115,6 +115,15 @@
         "numValuesPerEntry":1
       }
     ],
+    "dateTimeFieldSpecs": [
+      {
+        "name": "x",
+        "dataType": "INT",
+        "format": "1:DAYS:EPOCH",
+        "granularity": "1:DAYS",
+        "cardinality": 1000
+      }
+    ],
     "timeFieldSpec": {
       "incomingGranularitySpec": {
         "dataType": "INT",
@@ -128,8 +137,10 @@
   "queriesWithWeights":{
     "select f from tableName": 0.1,
     "select f from tableName where a =3": 0.1,
-    "not a valid query": 0.1,
-    "select g from tableName LIMIT 1000000000": 0.1
+    "select * from tableName": 0.1,
+    "select g from tableName LIMIT 1000000000": 0.1,
+    "select f from tableName where x = 2": 0.2,
+    "select f from tableName where t = 3": 0.3
   },
   "numRecordsPerPush":1000000000
 }


### PR DESCRIPTION
FlagQueryRule - Flags queries with tables that have time column (deprecated) or one or more DateTime columns (new way of specifying time columns) but don't use it in queries in the filter clause as a feedback to the user that they should consider using the time column as a filter. Two things need to be fixed in this rule

Should also consider DateTime columns in addition to the Time column
Fix a bug - if the schema of the table doesn't have a time/datetime column(s), it is stored as null and thus flags queries even for the tables that don't have such columns in the schema because it checks the presence of null in the set of filter columns. 
This will also require some cleanup in InputManager.

Issue(#6937 )