### PR TITLE
Fix CAST transform function for chained transforms

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -52,17 +52,17 @@ public abstract class BaseTransformFunction implements TransformFunction {
   protected static final TransformResultMetadata BYTES_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, true, false);
 
-  private int[] _intValuesSV;
-  private long[] _longValuesSV;
-  private float[] _floatValuesSV;
-  private double[] _doubleValuesSV;
-  private String[] _stringValuesSV;
-  private byte[][] _byteValuesSV;
-  private int[][] _intValuesMV;
-  private long[][] _longValuesMV;
-  private float[][] _floatValuesMV;
-  private double[][] _doubleValuesMV;
-  private String[][] _stringValuesMV;
+  protected int[] _intValuesSV;
+  protected long[] _longValuesSV;
+  protected float[] _floatValuesSV;
+  protected double[] _doubleValuesSV;
+  protected String[] _stringValuesSV;
+  protected byte[][] _byteValuesSV;
+  protected int[][] _intValuesMV;
+  protected long[][] _longValuesMV;
+  protected float[][] _floatValuesMV;
+  protected double[][] _doubleValuesMV;
+  protected String[][] _stringValuesMV;
 
   @Override
   public Dictionary getDictionary() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -26,12 +26,11 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ArrayCopyUtils;
 
 
 public class CastTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "cast";
-
-  private String[] _stringValuesSV;
 
   private TransformFunction _transformFunction;
   private TransformResultMetadata _resultMetadata;
@@ -72,6 +71,7 @@ public class CastTransformFunction extends BaseTransformFunction {
           break;
         case "TIMESTAMP":
           _resultMetadata = TIMESTAMP_SV_NO_DICTIONARY_METADATA;
+          break;
         case "STRING":
         case "VARCHAR":
           _resultMetadata = STRING_SV_NO_DICTIONARY_METADATA;
@@ -94,51 +94,210 @@ public class CastTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    return _transformFunction.transformToIntValuesSV(projectionBlock);
+    // When casting to types other than INT, need to first read as the result type then convert to int values
+    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
+    if (resultStoredType == DataType.INT) {
+      return _transformFunction.transformToIntValuesSV(projectionBlock);
+    } else {
+      if (_intValuesSV == null) {
+        _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      }
+      int numDocs = projectionBlock.getNumDocs();
+      switch (resultStoredType) {
+        case LONG:
+          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _intValuesSV, numDocs);
+          break;
+        case FLOAT:
+          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _intValuesSV, numDocs);
+          break;
+        case DOUBLE:
+          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _intValuesSV, numDocs);
+          break;
+        case STRING:
+          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _intValuesSV, numDocs);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      return _intValuesSV;
+    }
   }
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-    return _transformFunction.transformToLongValuesSV(projectionBlock);
+    // When casting to types other than LONG, need to first read as the result type then convert to long values
+    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
+    if (resultStoredType == DataType.LONG) {
+      return _transformFunction.transformToLongValuesSV(projectionBlock);
+    } else {
+      if (_longValuesSV == null) {
+        _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      }
+      int numDocs = projectionBlock.getNumDocs();
+      switch (resultStoredType) {
+        case INT:
+          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _longValuesSV, numDocs);
+          break;
+        case FLOAT:
+          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _longValuesSV, numDocs);
+          break;
+        case DOUBLE:
+          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _longValuesSV, numDocs);
+          break;
+        case STRING:
+          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _longValuesSV, numDocs);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      return _longValuesSV;
+    }
   }
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
-    return _transformFunction.transformToFloatValuesSV(projectionBlock);
+    // When casting to types other than FLOAT, need to first read as the result type then convert to float values
+    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
+    if (resultStoredType == DataType.FLOAT) {
+      return _transformFunction.transformToFloatValuesSV(projectionBlock);
+    } else {
+      if (_floatValuesSV == null) {
+        _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      }
+      int numDocs = projectionBlock.getNumDocs();
+      switch (resultStoredType) {
+        case INT:
+          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _floatValuesSV, numDocs);
+          break;
+        case LONG:
+          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _floatValuesSV, numDocs);
+          break;
+        case DOUBLE:
+          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _floatValuesSV, numDocs);
+          break;
+        case STRING:
+          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _floatValuesSV, numDocs);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      return _floatValuesSV;
+    }
   }
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    return _transformFunction.transformToDoubleValuesSV(projectionBlock);
+    // When casting to types other than DOUBLE, need to first read as the result type then convert to double values
+    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
+    if (resultStoredType == DataType.DOUBLE) {
+      return _transformFunction.transformToDoubleValuesSV(projectionBlock);
+    } else {
+      if (_doubleValuesSV == null) {
+        _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      }
+      int numDocs = projectionBlock.getNumDocs();
+      switch (resultStoredType) {
+        case INT:
+          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _doubleValuesSV, numDocs);
+          break;
+        case LONG:
+          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _doubleValuesSV, numDocs);
+          break;
+        case FLOAT:
+          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _doubleValuesSV, numDocs);
+          break;
+        case STRING:
+          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(stringValues, _doubleValuesSV, numDocs);
+          break;
+        default:
+          throw new IllegalStateException();
+      }
+      return _doubleValuesSV;
+    }
   }
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
-    DataType dataType = _transformFunction.getResultMetadata().getDataType();
-    if (dataType.getStoredType() != dataType) {
+    // When casting to types other than STRING, need to first read as the result type then convert to string values
+    DataType resultDataType = _resultMetadata.getDataType();
+    DataType resultStoredType = resultDataType.getStoredType();
+    int numDocs = projectionBlock.getNumDocs();
+    if (resultStoredType == DataType.STRING) {
+      // Specialize BOOlEAN and TIMESTAMP when casting to STRING
+      DataType inputDataType = _transformFunction.getResultMetadata().getDataType();
+      if (inputDataType.getStoredType() != inputDataType) {
+        if (_stringValuesSV == null) {
+          _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        }
+        if (inputDataType == DataType.BOOLEAN) {
+          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
+          for (int i = 0; i < numDocs; i++) {
+            _stringValuesSV[i] = Boolean.toString(intValues[i] == 1);
+          }
+        } else {
+          assert inputDataType == DataType.TIMESTAMP;
+          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
+          for (int i = 0; i < numDocs; i++) {
+            _stringValuesSV[i] = new Timestamp(longValues[i]).toString();
+          }
+        }
+        return _stringValuesSV;
+      } else {
+        return _transformFunction.transformToStringValuesSV(projectionBlock);
+      }
+    } else {
       if (_stringValuesSV == null) {
         _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
       }
-      int numDocs = projectionBlock.getNumDocs();
-      switch (dataType) {
+      switch (resultDataType) {
+        case INT:
+          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(intValues, _stringValuesSV, numDocs);
+          break;
+        case LONG:
+          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(longValues, _stringValuesSV, numDocs);
+          break;
+        case FLOAT:
+          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(floatValues, _stringValuesSV, numDocs);
+          break;
+        case DOUBLE:
+          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
+          ArrayCopyUtils.copy(doubleValues, _stringValuesSV, numDocs);
+          break;
         case BOOLEAN:
-          int[] intValuesSV = _transformFunction.transformToIntValuesSV(projectionBlock);
+          intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
           for (int i = 0; i < numDocs; i++) {
-            _stringValuesSV[i] = Boolean.toString(intValuesSV[i] == 1);
+            _stringValuesSV[i] = Boolean.toString(intValues[i] == 1);
           }
           break;
         case TIMESTAMP:
-          long[] longValuesSV = _transformFunction.transformToLongValuesSV(projectionBlock);
+          longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
           for (int i = 0; i < numDocs; i++) {
-            _stringValuesSV[i] = new Timestamp(longValuesSV[i]).toString();
+            _stringValuesSV[i] = new Timestamp(longValues[i]).toString();
           }
           break;
         default:
           throw new IllegalStateException();
       }
       return _stringValuesSV;
-    } else {
-      return _transformFunction.transformToStringValuesSV(projectionBlock);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -211,6 +211,36 @@ public abstract class BaseTransformFunctionTest {
     }
   }
 
+  protected void testTransformFunction(TransformFunction transformFunction, long[] expectedValues) {
+    int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+    long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+    float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+    double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(intValues[i], (int) expectedValues[i]);
+      Assert.assertEquals(longValues[i], expectedValues[i]);
+      Assert.assertEquals(floatValues[i], (float) expectedValues[i]);
+      Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
+      Assert.assertEquals(stringValues[i], Long.toString(expectedValues[i]));
+    }
+  }
+
+  protected void testTransformFunction(TransformFunction transformFunction, float[] expectedValues) {
+    int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+    long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+    float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+    double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(intValues[i], (int) expectedValues[i]);
+      Assert.assertEquals(longValues[i], (long) expectedValues[i]);
+      Assert.assertEquals(floatValues[i], expectedValues[i]);
+      Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
+      Assert.assertEquals(stringValues[i], Float.toString(expectedValues[i]));
+    }
+  }
+
   protected void testTransformFunction(TransformFunction transformFunction, double[] expectedValues) {
     int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
     long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -39,23 +39,45 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
 
+    expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("CAST(CAST(%s as INT) as FLOAT)", FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+    float[] expectedFloatValues = new float[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedFloatValues[i] = (int) _floatSVValues[i];
+    }
+    testTransformFunction(transformFunction, expectedFloatValues);
+
     expression = RequestContextUtils.getExpressionFromSQL(
-        String.format("CAST(ADD(CAST(%s AS INT), %s) AS STRING)", STRING_SV_COLUMN, DOUBLE_SV_COLUMN));
+        String.format("CAST(ADD(CAST(%s AS LONG), %s) AS STRING)", DOUBLE_SV_COLUMN, LONG_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Double.toString(Double.parseDouble(_stringSVValues[i]) + _doubleSVValues[i]);
+      expectedValues[i] = Double.toString((double) (long) _doubleSVValues[i] + (double) _longSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
     expression = RequestContextUtils.getExpressionFromSQL(
-        String.format("caSt(cAst(casT(%s as inT) + %s aS sTring) As DouBle)", STRING_SV_COLUMN, INT_SV_COLUMN));
+        String.format("caSt(cAst(casT(%s as inT) + %s aS sTring) As DouBle)", FLOAT_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CastTransformFunction);
     double[] expectedDoubleValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedDoubleValues[i] = Double.parseDouble(_stringSVValues[i]) + _intSVValues[i];
+      expectedDoubleValues[i] = (double) (int) _floatSVValues[i] + (double) _intSVValues[i];
     }
     testTransformFunction(transformFunction, expectedDoubleValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String
+        .format("CAST(CAST(%s AS INT) - CAST(%s AS FLOAT) / CAST(%s AS DOUBLE) AS LONG)", DOUBLE_SV_COLUMN,
+            LONG_SV_COLUMN, INT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+    long[] expectedLongValues = new long[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedLongValues[i] =
+          (long) ((double) (int) _doubleSVValues[i] - (double) (float) _longSVValues[i] / (double) _intSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedLongValues);
   }
 }


### PR DESCRIPTION
## Description
Currently the `CAST` transform function relies on the caller to call the correct API to perform the cast. When the `CAST` is chained with other transform functions such as `ADD`, the next transform function might ignore the output type, and ignore the `CAST`. E.g. `CAST(doubleCol AS INT) + 5` will return the same result as `doubleCol + 5`, which is unexpected.
This PR fixes the bug by checking the result type and always cast the values.
Also fix a bug for `TIMESTAMP` cast (missing `break;`)
