### PR TITLE
Add the complex-type support to decoder/reader

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -23,12 +23,16 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.function.scalar.JsonFunctions;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -143,6 +147,21 @@ public class ComplexTypeTransformer implements RecordTransformer {
     } else {
       return DEFAULT_COLLECTION_TO_JSON_MODE;
     }
+  }
+
+  public static Set<String> getFieldsToReadWithComplexType(Set<String> fieldsToRead, IngestionConfig ingestionConfig) {
+    if (ingestionConfig == null || ingestionConfig.getComplexTypeConfig() == null) {
+      // do nothing
+      return fieldsToRead;
+    }
+    ComplexTypeConfig complexTypeConfig = ingestionConfig.getComplexTypeConfig();
+    Set<String> result = new HashSet<>();
+    String delimiter = complexTypeConfig.getDelimiter() == null ? DEFAULT_DELIMITER : complexTypeConfig.getDelimiter();
+    for (String field : fieldsToRead) {
+      // need to quote because split takes regex as arg
+      result.add(field.split(Pattern.quote(delimiter))[0]);
+    }
+    return result;
   }
 
   @Nullable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -23,16 +23,12 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.function.scalar.JsonFunctions;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -147,21 +143,6 @@ public class ComplexTypeTransformer implements RecordTransformer {
     } else {
       return DEFAULT_COLLECTION_TO_JSON_MODE;
     }
-  }
-
-  public static Set<String> getFieldsToReadWithComplexType(Set<String> fieldsToRead, IngestionConfig ingestionConfig) {
-    if (ingestionConfig == null || ingestionConfig.getComplexTypeConfig() == null) {
-      // do nothing
-      return fieldsToRead;
-    }
-    ComplexTypeConfig complexTypeConfig = ingestionConfig.getComplexTypeConfig();
-    Set<String> result = new HashSet<>();
-    String delimiter = complexTypeConfig.getDelimiter() == null ? DEFAULT_DELIMITER : complexTypeConfig.getDelimiter();
-    for (String field : fieldsToRead) {
-      // need to quote because split takes regex as arg
-      result.add(field.split(Pattern.quote(delimiter))[0]);
-    }
-    return result;
   }
 
   @Nullable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -32,6 +32,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
+import org.apache.pinot.segment.local.recordtransformer.ComplexTypeTransformer;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
@@ -298,6 +299,8 @@ public final class IngestionUtils {
     Set<String> fieldsForRecordExtractor = new HashSet<>();
     extractFieldsFromIngestionConfig(ingestionConfig, fieldsForRecordExtractor);
     extractFieldsFromSchema(schema, fieldsForRecordExtractor);
+    fieldsForRecordExtractor =
+        ComplexTypeTransformer.getFieldsToReadWithComplexType(fieldsForRecordExtractor, ingestionConfig);
     return fieldsForRecordExtractor;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_schema.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_schema.json
@@ -9,21 +9,41 @@
       "dataType": "STRING"
     },
     {
-      "name": "payload.commits.sha",
-      "dataType": "STRING"
-    },
-    {
-      "name": "payload.commits.author.name",
-      "dataType": "STRING"
-    },
-    {
-      "name": "payload.commits.author.email",
-      "dataType": "STRING"
-    },
-    {
-      "name": "payload_json",
-      "dataType": "STRING",
-      "maxLength": 2147483647
+      "name" : "payload.push_id",
+      "dataType" : "LONG"
+    }, {
+      "name" : "payload.size",
+      "dataType" : "INT"
+    }, {
+      "name" : "payload.distinct_size",
+      "dataType" : "INT"
+    }, {
+      "name" : "payload.ref",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.head",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.before",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.commits.sha",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.commits.author.name",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.commits.author.email",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.commits.message",
+      "dataType" : "STRING"
+    }, {
+      "name" : "payload.commits.distinct",
+      "dataType" : "BOOLEAN"
+    }, {
+      "name" : "payload.commits.url",
+      "dataType" : "STRING"
     }
   ],
   "dateTimeFieldSpecs": [

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_table_config.json
@@ -16,10 +16,6 @@
       {
         "columnName": "created_at_timestamp",
         "transformFunction": "fromDateTime(created_at, 'yyyy-MM-dd''T''HH:mm:ss''Z''')"
-      },
-      {
-        "columnName": "payload_json",
-        "transformFunction": "jsonFormat(\"payload\")"
       }
     ],
     "complexTypeConfig": {

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_realtime_table_config.json
@@ -26,23 +26,13 @@
       ]
     },
     "transformConfigs": [
-      {
-        "columnName": "group_json",
-        "transformFunction": "jsonFormat(\"group\")"
-      }
     ],
     "complexTypeConfig": {
       "unnestFields": ["group.group_topics"]
     }
   },
   "tableIndexConfig": {
-    "loadMode": "MMAP",
-    "noDictionaryColumns": [
-      "group_json"
-    ],
-    "jsonIndexColumns": [
-      "group_json"
-    ]
+    "loadMode": "MMAP"
   },
   "metadata": {
     "customConfigs": {}

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_schema.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_schema.json
@@ -2,21 +2,35 @@
   "schemaName": "meetupRsvp",
   "dimensionFieldSpecs": [
     {
-      "name": "group_json",
-      "dataType": "STRING",
-      "maxLength": 2147483647
-    },
-    {
-      "name": "group.group_topics.urlkey",
-      "dataType": "STRING"
-    },
-    {
-      "name": "group.group_topics.topic_name",
-      "dataType": "STRING"
-    },
-    {
-      "name": "group.group_id",
-      "dataType": "LONG"
+      "name" : "group.group_topics.urlkey",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_topics.topic_name",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_city",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_country",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_id",
+      "dataType" : "INT"
+    }, {
+      "name" : "group.group_name",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_lon",
+      "dataType" : "DOUBLE"
+    }, {
+      "name" : "group.group_urlname",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_state",
+      "dataType" : "STRING"
+    }, {
+      "name" : "group.group_lat",
+      "dataType" : "DOUBLE"
     },
     {
       "name": "rsvp_id",


### PR DESCRIPTION
Part of https://github.com/apache/incubator-pinot/issues/6904

## Description
Add the complex-type support in the decoder/reader for realtime/offline ingestion. So the fields to read will parse path with complex-type and read the fields accordingly.

Also, update the quickstart examples to include all fields under the complex-type structure after flattening/unnesting.


