### PR TITLE
Rename some complex type configs

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -274,11 +274,11 @@ public class TableConfigSerDeTest {
       streamConfigMaps.add(streamConfigMap);
       List<Map<String, String>> batchConfigMaps = new ArrayList<>();
       batchConfigMaps.add(batchConfigMap);
-      List<String> unnestFields = Arrays.asList("c1, c2");
+      List<String> fieldsToUnnest = Arrays.asList("c1, c2");
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
-              new ComplexTypeConfig(unnestFields, ".", ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE));
+              new ComplexTypeConfig(fieldsToUnnest, ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
@@ -90,7 +90,7 @@ public class AvroUtilsTest {
             .put("hoursSinceEpoch", FieldType.TIME).put("m1", FieldType.METRIC).build();
     Schema inferredPinotSchema = AvroUtils
         .getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, fieldSpecMap, TimeUnit.HOURS,
-            new ArrayList<>(), ".", ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            new ArrayList<>(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     Schema expectedSchema =
         new Schema.SchemaBuilder().addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addSingleValueDimension("tuple.streetaddress", DataType.STRING)
@@ -102,7 +102,7 @@ public class AvroUtilsTest {
     // unnest collection entries
     inferredPinotSchema = AvroUtils
         .getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, fieldSpecMap, TimeUnit.HOURS,
-            Lists.newArrayList("entries"), ".", ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            Lists.newArrayList("entries"), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     expectedSchema =
         new Schema.SchemaBuilder().addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addSingleValueDimension("tuple.streetaddress", DataType.STRING)
@@ -114,7 +114,7 @@ public class AvroUtilsTest {
     // change delimiter
     inferredPinotSchema = AvroUtils
         .getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, fieldSpecMap, TimeUnit.HOURS,
-            Lists.newArrayList(), "_", ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            Lists.newArrayList(), "_", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     expectedSchema =
         new Schema.SchemaBuilder().addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addSingleValueDimension("tuple_streetaddress", DataType.STRING)
@@ -126,7 +126,7 @@ public class AvroUtilsTest {
     // change the handling of collection-to-json option, d2 will become string
     inferredPinotSchema = AvroUtils
         .getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, fieldSpecMap, TimeUnit.HOURS,
-            Lists.newArrayList("entries"), ".", ComplexTypeConfig.CollectionToJsonMode.ALL);
+            Lists.newArrayList("entries"), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.ALL);
     expectedSchema =
         new Schema.SchemaBuilder().addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addSingleValueDimension("tuple.streetaddress", DataType.STRING)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -296,7 +296,7 @@ public class ComplexTypeTransformerTest {
     // {
     //   "array":"[1,2]"
     // }
-    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionToJsonMode.ALL);
+    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.ALL);
     genericRow = new GenericRow();
     array = new Object[]{1, 2};
     genericRow.putValue("array", array);
@@ -341,7 +341,7 @@ public class ComplexTypeTransformerTest {
     array1[0] = ImmutableMap.of("b", "v1");
     map.put("array1", array1);
     genericRow.putValue("t", map);
-    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionToJsonMode.NONE);
+    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NONE);
     transformer.transform(genericRow);
     Assert.assertTrue(ComplexTypeTransformer.isArray(genericRow.getValue("t.array1")));
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -31,31 +31,31 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  */
 public class ComplexTypeConfig extends BaseJsonConfig {
 
-  public enum CollectionToJsonMode {
+  public enum CollectionNotUnnestedToJson {
     NONE, NON_PRIMITIVE, ALL
   }
 
   @JsonPropertyDescription("The fields to unnest")
-  private final List<String> _unnestFields;
+  private final List<String> _fieldsToUnnest;
 
   @JsonPropertyDescription("The delimiter used to separate components in a path")
   private final String _delimiter;
 
   @JsonPropertyDescription("The mode of converting collection to JSON string")
-  private final CollectionToJsonMode _collectionToJsonMode;
+  private final CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
 
   @JsonCreator
-  public ComplexTypeConfig(@JsonProperty("unnestFields") @Nullable List<String> unnestFields,
+  public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
-      @JsonProperty("collectionToJsonMode") @Nullable CollectionToJsonMode collectionToJsonMode) {
-    _unnestFields = unnestFields;
+      @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson) {
+    _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
-    _collectionToJsonMode = collectionToJsonMode;
+    _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
   }
 
   @Nullable
-  public List<String> getUnnestFields() {
-    return _unnestFields;
+  public List<String> getFieldsToUnnest() {
+    return _fieldsToUnnest;
   }
 
   @Nullable
@@ -64,7 +64,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   }
 
   @Nullable
-  public CollectionToJsonMode getCollectionToJsonMode() {
-    return _collectionToJsonMode;
+  public CollectionNotUnnestedToJson getCollectionNotUnnestedToJson() {
+    return _collectionNotUnnestedToJson;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -410,34 +410,34 @@ public class JsonUtils {
 
   public static Schema getPinotSchemaFromJsonFile(File jsonFile,
       @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit,
-      @Nullable List<String> unnestFields, String delimiter,
-      ComplexTypeConfig.CollectionToJsonMode collectionToJsonMode)
+      @Nullable List<String> fieldsToUnnest, String delimiter,
+      ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson)
       throws IOException {
     JsonNode jsonNode = fileToFirstJsonNode(jsonFile);
-    if (unnestFields == null) {
-      unnestFields = new ArrayList<>();
+    if (fieldsToUnnest == null) {
+      fieldsToUnnest = new ArrayList<>();
     }
     Preconditions.checkState(jsonNode.isObject(), "the JSON data shall be an object");
-    return getPinotSchemaFromJsonNode(jsonNode, fieldTypeMap, timeUnit, unnestFields, delimiter, collectionToJsonMode);
+    return getPinotSchemaFromJsonNode(jsonNode, fieldTypeMap, timeUnit, fieldsToUnnest, delimiter, collectionNotUnnestedToJson);
   }
 
   public static Schema getPinotSchemaFromJsonNode(JsonNode jsonNode,
-      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, List<String> unnestFields,
-      String delimiter, ComplexTypeConfig.CollectionToJsonMode collectionToJsonMode) {
+      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, List<String> fieldsToUnnest,
+      String delimiter, ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson) {
     Schema pinotSchema = new Schema();
     Iterator<Map.Entry<String, JsonNode>> fieldIterator = jsonNode.fields();
     while (fieldIterator.hasNext()) {
       Map.Entry<String, JsonNode> fieldEntry = fieldIterator.next();
       JsonNode childNode = fieldEntry.getValue();
-      inferPinotSchemaFromJsonNode(childNode, pinotSchema, fieldEntry.getKey(), fieldTypeMap, timeUnit, unnestFields,
-          delimiter, collectionToJsonMode);
+      inferPinotSchemaFromJsonNode(childNode, pinotSchema, fieldEntry.getKey(), fieldTypeMap, timeUnit, fieldsToUnnest,
+          delimiter, collectionNotUnnestedToJson);
     }
     return pinotSchema;
   }
 
   private static void inferPinotSchemaFromJsonNode(JsonNode jsonNode, Schema pinotSchema, String path,
-      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, List<String> unnestFields,
-      String delimiter, ComplexTypeConfig.CollectionToJsonMode collectionToJsonMode) {
+      @Nullable Map<String, FieldSpec.FieldType> fieldTypeMap, @Nullable TimeUnit timeUnit, List<String> fieldsToUnnest,
+      String delimiter, ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson) {
     if (jsonNode.isNull()) {
       // do nothing
       return;
@@ -452,12 +452,12 @@ public class JsonUtils {
       }
       JsonNode childNode = jsonNode.get(0);
 
-      if (unnestFields.contains(path)) {
-        inferPinotSchemaFromJsonNode(childNode, pinotSchema, path, fieldTypeMap, timeUnit, unnestFields, delimiter,
-            collectionToJsonMode);
-      } else if (shallConvertToJson(collectionToJsonMode, childNode)) {
+      if (fieldsToUnnest.contains(path)) {
+        inferPinotSchemaFromJsonNode(childNode, pinotSchema, path, fieldTypeMap, timeUnit, fieldsToUnnest, delimiter,
+            collectionNotUnnestedToJson);
+      } else if (shallConvertToJson(collectionNotUnnestedToJson, childNode)) {
         addFieldToPinotSchema(pinotSchema, DataType.STRING, path, true, fieldTypeMap, timeUnit);
-      } else if (collectionToJsonMode == ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE && childNode
+      } else if (collectionNotUnnestedToJson == ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE && childNode
           .isValueNode()) {
         addFieldToPinotSchema(pinotSchema, valueOf(childNode), path, false, fieldTypeMap, timeUnit);
       }
@@ -468,16 +468,16 @@ public class JsonUtils {
         Map.Entry<String, JsonNode> fieldEntry = fieldIterator.next();
         JsonNode childNode = fieldEntry.getValue();
         inferPinotSchemaFromJsonNode(childNode, pinotSchema, String.join(delimiter, path, fieldEntry.getKey()),
-            fieldTypeMap, timeUnit, unnestFields, delimiter, collectionToJsonMode);
+            fieldTypeMap, timeUnit, fieldsToUnnest, delimiter, collectionNotUnnestedToJson);
       }
     } else {
       throw new IllegalArgumentException(String.format("Unsupported json node type", jsonNode.getClass()));
     }
   }
 
-  private static boolean shallConvertToJson(ComplexTypeConfig.CollectionToJsonMode collectionToJsonMode,
+  private static boolean shallConvertToJson(ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson,
       JsonNode childNode) {
-    switch (collectionToJsonMode) {
+    switch (collectionNotUnnestedToJson) {
       case ALL:
         return true;
       case NONE:
@@ -485,7 +485,7 @@ public class JsonUtils {
       case NON_PRIMITIVE:
         return !childNode.isValueNode();
       default:
-        throw new IllegalArgumentException(String.format("Unsupported collectionToJsonMode %s", collectionToJsonMode));
+        throw new IllegalArgumentException(String.format("Unsupported collectionNotUnnestedToJson %s", collectionNotUnnestedToJson));
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
@@ -276,7 +276,7 @@ public class JsonUtilsTest {
             .put("hoursSinceEpoch", FieldSpec.FieldType.DATE_TIME).put("m1", FieldSpec.FieldType.METRIC).build();
     Schema inferredPinotSchema = JsonUtils
         .getPinotSchemaFromJsonFile(file, fieldSpecMap, TimeUnit.HOURS, new ArrayList<>(), ".",
-            ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     Schema expectedSchema = new Schema.SchemaBuilder().addSingleValueDimension("d1", FieldSpec.DataType.STRING)
         .addMetric("m1", FieldSpec.DataType.INT)
         .addSingleValueDimension("tuple.address.streetaddress", FieldSpec.DataType.STRING)
@@ -289,7 +289,7 @@ public class JsonUtilsTest {
     // unnest collection entries
     inferredPinotSchema = JsonUtils
         .getPinotSchemaFromJsonFile(file, fieldSpecMap, TimeUnit.HOURS, Lists.newArrayList("entries"), ".",
-            ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     expectedSchema = new Schema.SchemaBuilder().addSingleValueDimension("d1", FieldSpec.DataType.STRING)
         .addMetric("m1", FieldSpec.DataType.INT)
         .addSingleValueDimension("tuple.address.streetaddress", FieldSpec.DataType.STRING)
@@ -303,7 +303,7 @@ public class JsonUtilsTest {
     // change delimiter
     inferredPinotSchema = JsonUtils
         .getPinotSchemaFromJsonFile(file, fieldSpecMap, TimeUnit.HOURS, Lists.newArrayList(""), "_",
-            ComplexTypeConfig.CollectionToJsonMode.NON_PRIMITIVE);
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE);
     expectedSchema = new Schema.SchemaBuilder().addSingleValueDimension("d1", FieldSpec.DataType.STRING)
         .addMetric("m1", FieldSpec.DataType.INT)
         .addSingleValueDimension("tuple_address_streetaddress", FieldSpec.DataType.STRING)
@@ -316,7 +316,7 @@ public class JsonUtilsTest {
     // change the handling of collection-to-json option, d2 will become string
     inferredPinotSchema = JsonUtils
         .getPinotSchemaFromJsonFile(file, fieldSpecMap, TimeUnit.HOURS, Lists.newArrayList("entries"), ".",
-            ComplexTypeConfig.CollectionToJsonMode.ALL);
+            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL);
     expectedSchema = new Schema.SchemaBuilder().addSingleValueDimension("d1", FieldSpec.DataType.STRING)
         .addMetric("m1", FieldSpec.DataType.INT)
         .addSingleValueDimension("tuple.address.streetaddress", FieldSpec.DataType.STRING)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -68,8 +68,8 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   @Option(name = "-timeUnit", metaVar = "<string>", usage = "Unit of the time column (default DAYS).")
   TimeUnit _timeUnit = TimeUnit.DAYS;
 
-  @Option(name = "-unnestFields", metaVar = "<string>", usage = "Comma separated fields to unnest")
-  String _unnestFields;
+  @Option(name = "-fieldsToUnnest", metaVar = "<string>", usage = "Comma separated fields to unnest")
+  String _fieldsToUnnest;
 
   @Option(name = "-delimiter", metaVar = "<string>", usage = "The delimiter separating components in nested structure, default to dot")
   String _delimiter;
@@ -77,8 +77,8 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   @Option(name = "-complexType", metaVar = "<boolean>", usage = "allow complex-type handling, default to false")
   boolean _complexType;
 
-  @Option(name = "-collectionToJsonMode", metaVar = "<string>", usage = "The mode of converting collection to JSON string, can be NONE/NON_PRIMITIVE/ALL")
-  String _collectionToJsonMode;
+  @Option(name = "-collectionNotUnnestedToJson", metaVar = "<string>", usage = "The mode of converting collection to JSON string, can be NONE/NON_PRIMITIVE/ALL")
+  String _collectionNotUnnestedToJson;
 
   @SuppressWarnings("FieldCanBeLocal")
   @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
@@ -97,7 +97,7 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
     if (_avroSchemaFile != null) {
       schema = AvroUtils
           .getPinotSchemaFromAvroSchemaFile(new File(_avroSchemaFile), buildFieldTypesMap(), _timeUnit, _complexType,
-              buildUnnestFields(), getDelimiter(), getCollectionToJsonMode());
+              buildfieldsToUnnest(), getDelimiter(), getcollectionNotUnnestedToJson());
     } else if (_avroDataFile != null) {
       schema = AvroUtils.getPinotSchemaFromAvroDataFile(new File(_avroDataFile), buildFieldTypesMap(), _timeUnit);
     } else {
@@ -137,8 +137,8 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
     return "AvroSchemaToPinotSchema -avroSchemaFile " + _avroSchemaFile + " -avroDataFile " + _avroDataFile
         + " -outputDir " + _outputDir + " -pinotSchemaName " + _pinotSchemaName + " -dimensions " + _dimensions
         + " -metrics " + _metrics + " -timeColumnName " + _timeColumnName + " -timeUnit " + _timeUnit
-        + " _unnestFields " + _unnestFields + " _delimiter " + _delimiter + " _complexType " + _complexType
-        + " _collectionToJsonMode " + _collectionToJsonMode;
+        + " _fieldsToUnnest " + _fieldsToUnnest + " _delimiter " + _delimiter + " _complexType " + _complexType
+        + " _collectionNotUnnestedToJson " + _collectionNotUnnestedToJson;
   }
 
   /**
@@ -165,21 +165,21 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
     return fieldTypes;
   }
 
-  private List<String> buildUnnestFields() {
-    List<String> unnestFields = new ArrayList<>();
-    if (_unnestFields != null) {
-      for (String field : _unnestFields.split(",")) {
-        unnestFields.add(field);
+  private List<String> buildfieldsToUnnest() {
+    List<String> fieldsToUnnest = new ArrayList<>();
+    if (_fieldsToUnnest != null) {
+      for (String field : _fieldsToUnnest.split(",")) {
+        fieldsToUnnest.add(field);
       }
     }
-    return unnestFields;
+    return fieldsToUnnest;
   }
 
-  private ComplexTypeConfig.CollectionToJsonMode getCollectionToJsonMode() {
-    if (_collectionToJsonMode == null) {
+  private ComplexTypeConfig.CollectionNotUnnestedToJson getcollectionNotUnnestedToJson() {
+    if (_collectionNotUnnestedToJson == null) {
       return ComplexTypeTransformer.DEFAULT_COLLECTION_TO_JSON_MODE;
     }
-    return ComplexTypeConfig.CollectionToJsonMode.valueOf(_collectionToJsonMode);
+    return ComplexTypeConfig.CollectionNotUnnestedToJson.valueOf(_collectionNotUnnestedToJson);
   }
 
   private String getDelimiter() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/JsonToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/JsonToPinotSchema.java
@@ -65,14 +65,14 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
   @Option(name = "-timeUnit", metaVar = "<string>", usage = "Unit of the time column (default DAYS).")
   TimeUnit _timeUnit = TimeUnit.DAYS;
 
-  @Option(name = "-unnestFields", metaVar = "<string>", usage = "Comma separated fields to unnest")
-  String _unnestFields;
+  @Option(name = "-fieldsToUnnest", metaVar = "<string>", usage = "Comma separated fields to unnest")
+  String _fieldsToUnnest;
 
   @Option(name = "-delimiter", metaVar = "<string>", usage = "The delimiter separating components in nested structure, default to dot")
   String _delimiter;
 
-  @Option(name = "-collectionToJsonMode", metaVar = "<string>", usage = "The mode of converting collection to JSON string, can be NONE/NON_PRIMITIVE/ALL")
-  String _collectionToJsonMode;
+  @Option(name = "-collectionNotUnnestedToJson", metaVar = "<string>", usage = "The mode of converting collection to JSON string, can be NONE/NON_PRIMITIVE/ALL")
+  String _collectionNotUnnestedToJson;
 
   @SuppressWarnings("FieldCanBeLocal")
   @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
@@ -89,8 +89,8 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
 
     Schema schema;
     schema = JsonUtils
-        .getPinotSchemaFromJsonFile(new File(_jsonFile), buildFieldTypesMap(), _timeUnit, buildUnnestFields(),
-            getDelimiter(), getCollectionToJsonMode());
+        .getPinotSchemaFromJsonFile(new File(_jsonFile), buildFieldTypesMap(), _timeUnit, buildfieldsToUnnest(),
+            getDelimiter(), getcollectionNotUnnestedToJson());
     schema.setSchemaName(_pinotSchemaName);
 
     File outputDir = new File(_outputDir);
@@ -122,8 +122,8 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
   public String toString() {
     return "JsonToPinotSchema -jsonFile " + _jsonFile + " -outputDir " + _outputDir + " -pinotSchemaName "
         + _pinotSchemaName + " -dimensions " + _dimensions + " -metrics " + _metrics + " -timeColumnName "
-        + _dateTimeColumnName + " -timeUnit " + _timeUnit + " _unnestFields " + _unnestFields + " _delimiter "
-        + _delimiter + " _collectionToJsonMode " + _collectionToJsonMode;
+        + _dateTimeColumnName + " -timeUnit " + _timeUnit + " _fieldsToUnnest " + _fieldsToUnnest + " _delimiter "
+        + _delimiter + " _collectionNotUnnestedToJson " + _collectionNotUnnestedToJson;
   }
 
   /**
@@ -150,21 +150,21 @@ public class JsonToPinotSchema extends AbstractBaseAdminCommand implements Comma
     return fieldTypes;
   }
 
-  private List<String> buildUnnestFields() {
-    List<String> unnestFields = new ArrayList<>();
-    if (_unnestFields != null) {
-      for (String field : _unnestFields.split(",")) {
-        unnestFields.add(field.trim());
+  private List<String> buildfieldsToUnnest() {
+    List<String> fieldsToUnnest = new ArrayList<>();
+    if (_fieldsToUnnest != null) {
+      for (String field : _fieldsToUnnest.split(",")) {
+        fieldsToUnnest.add(field.trim());
       }
     }
-    return unnestFields;
+    return fieldsToUnnest;
   }
 
-  private ComplexTypeConfig.CollectionToJsonMode getCollectionToJsonMode() {
-    if (_collectionToJsonMode == null) {
+  private ComplexTypeConfig.CollectionNotUnnestedToJson getcollectionNotUnnestedToJson() {
+    if (_collectionNotUnnestedToJson == null) {
       return ComplexTypeTransformer.DEFAULT_COLLECTION_TO_JSON_MODE;
     }
-    return ComplexTypeConfig.CollectionToJsonMode.valueOf(_collectionToJsonMode);
+    return ComplexTypeConfig.CollectionNotUnnestedToJson.valueOf(_collectionNotUnnestedToJson);
   }
 
   private String getDelimiter() {

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_complexTypeHandling_table_config.json
@@ -19,7 +19,7 @@
       }
     ],
     "complexTypeConfig": {
-      "unnestFields": ["payload.commits"]
+      "fieldsToUnnest": ["payload.commits"]
     }
   },
   "metadata": {

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/complexTypeHandling_meetupRsvp_realtime_table_config.json
@@ -28,7 +28,7 @@
     "transformConfigs": [
     ],
     "complexTypeConfig": {
-      "unnestFields": ["group.group_topics"]
+      "fieldsToUnnest": ["group.group_topics"]
     }
   },
   "tableIndexConfig": {


### PR DESCRIPTION
Part of https://github.com/apache/incubator-pinot/issues/6904

## Description

Rename `ComplexTypeConfig. unnestFields ` to `ComplexTypeConfig. fieldsToUnnest `
and `ComplexTypeConfig. collectionToJsonMode ` to `ComplexTypeConfig.collectionNotUnnestedToJson `


