### PR TITLE
Replace error code name to be more readable.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -122,8 +122,8 @@ public class QueryException {
     DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableDeserializationError");
     FUTURE_CALL_ERROR.setMessage("FutureCallError");
     BROKER_TIMEOUT_ERROR.setMessage("BrokerTimeoutError");
-    BROKER_RESOURCE_MISSING_ERROR.setMessage("BrokerResourceMissingError");
-    BROKER_INSTANCE_MISSING_ERROR.setMessage("BrokerInstanceMissingError");
+    BROKER_RESOURCE_MISSING_ERROR.setMessage("BrokerResourceNotFoundForTableError");
+    BROKER_INSTANCE_MISSING_ERROR.setMessage("BrokerInstanceNotFoundForTableError");
     INTERNAL_ERROR.setMessage("InternalError");
     MERGE_RESPONSE_ERROR.setMessage("MergeResponseError");
     FEDERATED_BROKER_UNAVAILABLE_ERROR.setMessage("FederatedBrokerUnavailableError");


### PR DESCRIPTION
One of the common mistakes that happen when using query console is to mis-type table name
in query. Today it leads to a cryptic error message `BrokerResourceMissing`.

Changing the error message to `BrokerResourceNotFoundForTable` to be a little more
intuitive for the user. Technically it is a backward incompatible change, however, the benefit might outweigh the cost here.

This addresses the issue https://github.com/apache/incubator-pinot/issues/6952.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [X ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [X] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
