### PR TITLE
Use stored types instead of derived types in Forward Indices.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -292,7 +292,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       case BYTES:
         return new VarByteChunkSVForwardIndexReader(forwardIndexBuffer, storedType);
       default:
-        throw new IllegalStateException("Illegal data type for raw forward index: " + storedType);
+        throw new IllegalStateException("Illegal data type for raw forward index: " + dataType);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -180,7 +180,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       }
     } else {
       // Raw index
-      _forwardIndex = loadRawForwardIndex(fwdIndexBuffer, metadata.getDataType().getStoredType());
+      _forwardIndex = loadRawForwardIndex(fwdIndexBuffer, metadata.getDataType());
       _dictionary = null;
       _rangeIndex = null;
       _invertedIndex = null;
@@ -281,17 +281,18 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   }
 
   private static ForwardIndexReader<?> loadRawForwardIndex(PinotDataBuffer forwardIndexBuffer, DataType dataType) {
-    switch (dataType.getStoredType()) {
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
       case INT:
       case LONG:
       case FLOAT:
       case DOUBLE:
-        return new FixedByteChunkSVForwardIndexReader(forwardIndexBuffer, dataType);
+        return new FixedByteChunkSVForwardIndexReader(forwardIndexBuffer, storedType);
       case STRING:
       case BYTES:
-        return new VarByteChunkSVForwardIndexReader(forwardIndexBuffer, dataType);
+        return new VarByteChunkSVForwardIndexReader(forwardIndexBuffer, storedType);
       default:
-        throw new IllegalStateException("Illegal data type for raw forward index: " + dataType);
+        throw new IllegalStateException("Illegal data type for raw forward index: " + storedType);
     }
   }
 


### PR DESCRIPTION
## Description
Use stored types instead of derived types in Forward Indices. This fix got left out of #6951, so creating a new PR for the fix.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
