### PR TITLE
Implement PassThroughTransformOperator to optimize select queries(#6972)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/PassThroughTransformBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/PassThroughTransformBlock.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.blocks;
+
+import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.operator.transform.function.TransformFunction;
+
+
+/**
+ * Transform Block servers as a pass-through to projection block.
+ */
+public class PassThroughTransformBlock extends TransformBlock {
+
+  public PassThroughTransformBlock(ProjectionBlock projectionBlock,
+      Map<ExpressionContext, TransformFunction> transformFunctionMap) {
+    super(projectionBlock, transformFunctionMap);
+ }
+
+  @Override
+  public BlockValSet getBlockValueSet(ExpressionContext expression) {
+    return _projectionBlock.getBlockValueSet(expression.getIdentifier());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
@@ -34,8 +34,8 @@ import org.apache.pinot.core.operator.transform.function.TransformFunction;
  * <p>In absence of transforms, it servers as a pass-through to projection block.
  */
 public class TransformBlock implements Block {
-  private final ProjectionBlock _projectionBlock;
-  private final Map<ExpressionContext, TransformFunction> _transformFunctionMap;
+  protected final ProjectionBlock _projectionBlock;
+  protected final Map<ExpressionContext, TransformFunction> _transformFunctionMap;
 
   public TransformBlock(ProjectionBlock projectionBlock,
       Map<ExpressionContext, TransformFunction> transformFunctionMap) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/PassThroughTransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/PassThroughTransformOperator.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform;
+
+import java.util.Collection;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.PassThroughTransformBlock;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+
+
+/**
+ * Class for evaluating pass through transform expressions.
+ */
+public class PassThroughTransformOperator extends TransformOperator {
+  private static final String OPERATOR_NAME = "PassThroughTransformOperator";
+  /**
+   * Constructor for the class
+   *
+   * @param projectionOperator Projection operator
+   * @param expressions Collection of expressions to evaluate
+   */
+  public PassThroughTransformOperator(ProjectionOperator projectionOperator, Collection<ExpressionContext> expressions) {
+    super(projectionOperator, expressions);
+  }
+
+  @Override
+  protected PassThroughTransformBlock getNextBlock() {
+    ProjectionBlock projectionBlock = _projectionOperator.nextBlock();
+    if (projectionBlock == null) {
+      return null;
+    } else {
+      return new PassThroughTransformBlock(projectionBlock, _transformFunctionMap);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
@@ -39,9 +39,9 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 public class TransformOperator extends BaseOperator<TransformBlock> {
   private static final String OPERATOR_NAME = "TransformOperator";
 
-  private final ProjectionOperator _projectionOperator;
-  private final Map<String, DataSource> _dataSourceMap;
-  private final Map<ExpressionContext, TransformFunction> _transformFunctionMap = new HashMap<>();
+  protected final ProjectionOperator _projectionOperator;
+  protected final Map<String, DataSource> _dataSourceMap;
+  protected final Map<ExpressionContext, TransformFunction> _transformFunctionMap = new HashMap<>();
 
   /**
    * Constructor for the class

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.operator.transform.PassThroughTransformOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -33,6 +34,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 public class TransformPlanNode implements PlanNode {
   private final Collection<ExpressionContext> _expressions;
   private final ProjectionPlanNode _projectionPlanNode;
+  private boolean _areAllExpressionsIdentifiers = true;
 
   public TransformPlanNode(IndexSegment indexSegment, QueryContext queryContext,
       Collection<ExpressionContext> expressions, int maxDocsPerCall) {
@@ -40,6 +42,7 @@ public class TransformPlanNode implements PlanNode {
     Set<String> projectionColumns = new HashSet<>();
     for (ExpressionContext expression : expressions) {
       expression.getColumns(projectionColumns);
+      if(expression.getType() != ExpressionContext.Type.IDENTIFIER) _areAllExpressionsIdentifiers = false;
     }
     // NOTE: Skip creating DocIdSetPlanNode when maxDocsPerCall is 0 (for selection query with LIMIT 0).
     DocIdSetPlanNode docIdSetPlanNode =
@@ -49,6 +52,10 @@ public class TransformPlanNode implements PlanNode {
 
   @Override
   public TransformOperator run() {
-    return new TransformOperator(_projectionPlanNode.run(), _expressions);
+    if(!_areAllExpressionsIdentifiers) {
+      return new TransformOperator(_projectionPlanNode.run(), _expressions);
+    } else {
+      return new PassThroughTransformOperator(_projectionPlanNode.run(), _expressions);
+    }
   }
 }


### PR DESCRIPTION
For general select queries

e.g SELECT * FROM Foo ..... LIMIT N

e.g SELECT col1, col2 ..... FROM Foo .... LIMIT N

the columns are identifier expressions and not some transform functions. So, we should have a PassThroughTransformOperator that avoids the if conditional check repeatedly in TransformBlock.

If the columns selected in the query are identifier expressions then no need to make the check again and again for every **block fetch of 10K records**. Since during query planning time, we have the information available in TransformPlanNode if selected expressions are identifiers or not, we can make an optimization to have a specialized TransformOperator and TransformBlock that simply does a pass through and avoids the repeated if check at **query runtime**.

This is something that would have been done in pinot if there was **run time query specific code generation**. Since we currently don't have it, we can handwrite the specialized operator.

The changes are already covered by tests https://github.com/apache/incubator-pinot/blob/master/pinot-core/src/test/java/org/apache/pinot/queries/BaseSingleValueQueriesTest.java and  https://github.com/apache/incubator-pinot/blob/master/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueQueriesTest.java

Issue #6972 