### PR TITLE
Fix deep store directory structure

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -292,11 +292,11 @@ public class PinotSegmentUploadDownloadRestletResource {
                 tableNameWithType);
         zkDownloadUri = downloadUri;
       } else {
-        zkDownloadUri = getZkDownloadURIForSegmentUpload(tableName, segmentName);
+        zkDownloadUri = getZkDownloadURIForSegmentUpload(rawTableName, segmentName);
       }
 
       // Zk operations
-      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableName, tableNameWithType,
+      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, rawTableName, tableNameWithType,
           segmentMetadata, segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -296,8 +296,8 @@ public class PinotSegmentUploadDownloadRestletResource {
       }
 
       // Zk operations
-      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, rawTableName, tableNameWithType,
-          segmentMetadata, segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
+      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableNameWithType, segmentMetadata,
+          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);
     } catch (WebApplicationException e) {
@@ -386,12 +386,12 @@ public class PinotSegmentUploadDownloadRestletResource {
   }
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File uploadedSegmentFile,
-      String rawTableName, String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName,
-      String zkDownloadURI, boolean moveSegmentToFinalLocation, String crypter)
+      String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
+      boolean moveSegmentToFinalLocation, String crypter)
       throws Exception {
-    URI finalSegmentLocationURI = URIUtils
-        .getUri(ControllerFilePathProvider.getInstance().getDataDirURI().toString(), rawTableName,
-            URIUtils.encode(segmentName));
+    String basePath = ControllerFilePathProvider.getInstance().getDataDirURI().toString();
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    URI finalSegmentLocationURI = URIUtils.getUri(basePath, rawTableName, URIUtils.encode(segmentName));
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator.completeSegmentOperations(tableNameWithType, segmentMetadata, finalSegmentLocationURI, uploadedSegmentFile,
         enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -292,12 +292,12 @@ public class PinotSegmentUploadDownloadRestletResource {
                 tableNameWithType);
         zkDownloadUri = downloadUri;
       } else {
-        zkDownloadUri = getZkDownloadURIForSegmentUpload(tableNameWithType, segmentName);
+        zkDownloadUri = getZkDownloadURIForSegmentUpload(tableName, segmentName);
       }
 
       // Zk operations
-      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableNameWithType, segmentMetadata,
-          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
+      completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableName, tableNameWithType,
+          segmentMetadata, segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);
     } catch (WebApplicationException e) {
@@ -386,11 +386,11 @@ public class PinotSegmentUploadDownloadRestletResource {
   }
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File uploadedSegmentFile,
-      String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation, String crypter)
+      String rawTableName, String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName,
+      String zkDownloadURI, boolean moveSegmentToFinalLocation, String crypter)
       throws Exception {
     URI finalSegmentLocationURI = URIUtils
-        .getUri(ControllerFilePathProvider.getInstance().getDataDirURI().toString(), tableNameWithType,
+        .getUri(ControllerFilePathProvider.getInstance().getDataDirURI().toString(), rawTableName,
             URIUtils.encode(segmentName));
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator.completeSegmentOperations(tableNameWithType, segmentMetadata, finalSegmentLocationURI, uploadedSegmentFile,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -255,8 +255,8 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tableConfigs", "validate");
   }
 
-  public String forSegmentDownload(String tableNameWithType, String segmentName) {
-    return URIUtils.constructDownloadUrl(_baseUrl, tableNameWithType, segmentName);
+  public String forSegmentDownload(String tableName, String segmentName) {
+    return URIUtils.constructDownloadUrl(_baseUrl, tableName, segmentName);
   }
 
   public String forSegmentDelete(String tableName, String segmentName) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthRealtimeIntegrationTest.java
@@ -184,7 +184,7 @@ public class BasicAuthRealtimeIntegrationTest extends BaseClusterIntegrationTest
     for (int i = 0; i < offlineSegments.size(); i++) {
       String segment = offlineSegments.get(i).asText();
       Assert.assertTrue(sendGetRequest(_controllerRequestURLBuilder
-          .forSegmentDownload(TableNameBuilder.OFFLINE.tableNameWithType(getTableName()), segment), AUTH_HEADER)
+          .forSegmentDownload(getTableName(), segment), AUTH_HEADER)
           .length() > 200000); // download segment
     }
   }


### PR DESCRIPTION
## Description
This PR is the fix for the issue described in #6966. Basically it reverts the changes recently made to deep store directory structure.
## Testing Done
Deployed locally and verified that segments are created in tableName/segmentName directory structure instead of the current problematic directory structure tableName_OFFLINE/segmentName. Also segmentDownloadUrl in segment ZKMetadata points to the desired directory. 
Before:
`"segment.offline.download.url": "http://172.18.164.3:9000/segments/baseballStats_OFFLINE/baseballStats_OFFLINE_0"`
After:
    `"segment.offline.download.url": "http://172.18.164.3:9000/segments/baseballStats/baseballStats_OFFLINE_0"`

The tests were done with an offline table and also a hybrid table to validated both realtime and offline segments. The query execution is also fine for both offline and realtime scenarios.