### PR TITLE
Enhance debug endpoint for table debugging.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentErrorInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentErrorInfo.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+
+/**
+ * This class is used to represent errors related to a segment.
+ */
+@SuppressWarnings("unused")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"timestamp", "errorMessage", "stackTrace"}) // For readability of JSON output
+public class SegmentErrorInfo {
+
+  private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss z";
+  private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(DATE_FORMAT, Locale.getDefault());
+
+  private final String _timestamp;
+  private final String _errorMessage;
+  private final String _stackTrace;
+
+  static {
+    SIMPLE_DATE_FORMAT.setTimeZone(TimeZone.getDefault());
+  }
+
+  /**
+   * This constructor is specifically for JSON ser/de.
+   *
+   * @param timestamp Time stamp of the error in Simple Date Format.
+   * @param errorMessage Error message
+   * @param stackTrace Exception stack trace
+   *
+   */
+  @JsonCreator
+  public SegmentErrorInfo(@JsonProperty("timestamp") String timestamp,
+      @JsonProperty("errorMessage") String errorMessage, @JsonProperty("stackTrace") String stackTrace) {
+    _timestamp = timestamp;
+    _errorMessage = errorMessage;
+    _stackTrace = stackTrace;
+  }
+
+  /**
+   * Constructor for the class
+   * @param timestampMs Timestamp of error/exception
+   * @param errorMessage Error message
+   * @param exception Exception
+   */
+  public SegmentErrorInfo(long timestampMs, String errorMessage, Exception exception) {
+    _timestamp = epochToSDF(timestampMs);
+    _errorMessage = errorMessage;
+    _stackTrace = (exception != null) ? ExceptionUtils.getStackTrace(exception) : null;
+  }
+
+  public String getStackTrace() {
+    return _stackTrace;
+  }
+
+  public String getErrorMessage() {
+    return _errorMessage;
+  }
+
+  public String getTimestamp() {
+    return _timestamp;
+  }
+
+  /**
+   * Utility function to convert epoch in millis to SDF of form "yyyy-MM-dd HH:mm:ss z".
+   *
+   * @param millisSinceEpoch Time in millis to convert
+   * @return SDF equivalent
+   */
+  private static String epochToSDF(long millisSinceEpoch) {
+    return SIMPLE_DATE_FORMAT.format(new Date(millisSinceEpoch));
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentServerDebugInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentServerDebugInfo.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * This class represents the server-side debug information for a segment.
+ * NOTE: Debug classes are not expected to maintain backward compatibility,
+ * and should not be exposed to the client side.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"segmentName", "segmentSize", "consumerInfo", "errorInfo"}) // For readability of JSON output
+public class SegmentServerDebugInfo {
+
+  private final String _segmentName;
+  private final String _segmentSize; // Segment Size in Human readable format
+
+  private final SegmentConsumerInfo _consumerInfo;
+  private final SegmentErrorInfo _errorInfo;
+
+  @JsonCreator
+  public SegmentServerDebugInfo(@JsonProperty("segmentName") String segmentName,
+      @JsonProperty("segmentSize") String segmentSize, @JsonProperty("consumerInfo") SegmentConsumerInfo consumerInfo,
+      @JsonProperty("errorInfo") SegmentErrorInfo errorInfo) {
+    _segmentName = segmentName;
+    _segmentSize = segmentSize;
+    _consumerInfo = consumerInfo;
+    _errorInfo = errorInfo;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public String getSegmentSize() {
+    return _segmentSize;
+  }
+
+  public SegmentConsumerInfo getConsumerInfo() {
+    return _consumerInfo;
+  }
+
+  public SegmentErrorInfo getErrorInfo() {
+    return _errorInfo;
+  }
+
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/debug/TableDebugInfo.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/debug/TableDebugInfo.java
@@ -23,9 +23,20 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 
 
+/**
+ * This class represents debug information associated with a table. For example:
+ * <ul>
+ *   <li>Table name, size, number of brokers, servers, segments, etc.</li>
+ *   <li>Debug information from server/brokers of the table.</li>
+ *   <li>Debug information related to segments of the table.</li>
+ * </ul>
+ */
 @JsonPropertyOrder({"tableName", "numSegments", "numServers", "numBrokers", "segmentDebugInfos", "serverDebugInfos", "brokerDebugInfos"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 @SuppressWarnings("unused")
@@ -102,54 +113,92 @@ public class TableDebugInfo {
     return _brokerDebugInfos;
   }
 
+  @JsonPropertyOrder({"segmentName", "serverState"})
   public static class SegmentDebugInfo {
     private final String _segmentName;
-    private final List<IsEvState> _states;
 
-    public SegmentDebugInfo(String name, List<IsEvState> states) {
-      _segmentName = name;
-      _states = states;
+    private final Map<String, SegmentState> _serverStateMap;
+
+    @JsonCreator
+    public SegmentDebugInfo(@JsonProperty("segmentName") String segmentName,
+        @JsonProperty("serverState") Map<String, SegmentState> segmentServerState) {
+      _segmentName = segmentName;
+      _serverStateMap = segmentServerState;
     }
 
     public String getSegmentName() {
       return _segmentName;
     }
 
-    public List<IsEvState> getSegmentStateInServer() {
-      return _states;
+    public Map<String, SegmentState> getServerState() {
+      return _serverStateMap;
     }
   }
 
-  public static class IsEvState {
-    private final String _serverName;
-    private final String _idealStateStatus;
-    private final String _externalViewStatus;
+  /**
+   * This class represents the state of segment on the server:
+   *
+   * <ul>
+   *   <li>Ideal State vs External view.</li>
+   *   <li>Segment related errors and consumer information.</li>
+   *   <li>Segment size.</li>
+   * </ul>
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"idealState", "externalView", "segmentSize", "consumerInfo", "errorInfo"})
+  public static class SegmentState {
+    private final String _idealState;
+    private final String _externalView;
+    private final String _segmentSize;
+    private final SegmentConsumerInfo _consumerInfo;
+    private final SegmentErrorInfo _errorInfo;
 
-    public IsEvState(String name, String idealStateStatus, String externalViewStatus) {
-      _serverName = name;
-      _idealStateStatus = idealStateStatus;
-      _externalViewStatus = externalViewStatus;
+    @JsonCreator
+    public SegmentState(@JsonProperty("idealState") String idealState,
+        @JsonProperty("externalView") String externalView, @JsonProperty("segmentSize") String segmentSize,
+        @JsonProperty("consumerInfo") SegmentConsumerInfo consumerInfo,
+        @JsonProperty("errorInfo") SegmentErrorInfo errorInfo) {
+      _idealState = idealState;
+      _externalView = externalView;
+      _segmentSize = segmentSize;
+      _consumerInfo = consumerInfo;
+      _errorInfo = errorInfo;
     }
 
-    public String getServerName() {
-      return _serverName;
+    public String getIdealState() {
+      return _idealState;
     }
 
-    public String getIdealStateStatus() {
-      return _idealStateStatus;
+    public String getExternalView() {
+      return _externalView;
     }
 
-    public String getExternalViewStatus() {
-      return _externalViewStatus;
+    public SegmentConsumerInfo getConsumerInfo() {
+      return _consumerInfo;
+    }
+
+    public SegmentErrorInfo getErrorInfo() {
+      return _errorInfo;
+    }
+
+    public String getSegmentSize() {
+      return _segmentSize;
     }
   }
 
+  /**
+   * Debug information related to Server.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"serverName", "numErrors", "numMessages"})
   public static class ServerDebugInfo {
+    private final String _serverName;
     private final int _numErrors;
     private final int _numMessages;
-    private final String _serverName;
 
-    public ServerDebugInfo(String serverName, int numErrors, int numMessages) {
+    @JsonCreator
+    public ServerDebugInfo(@JsonProperty("serverName") String serverName, @JsonProperty("numErrors") int numErrors,
+        @JsonProperty("numMessages") int numMessages) {
       _serverName = serverName;
       _numErrors = numErrors;
       _numMessages = numMessages;
@@ -168,24 +217,40 @@ public class TableDebugInfo {
     }
   }
 
+  /**
+   * Debug information related to broker.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"brokerName", "state"})
   public static class BrokerDebugInfo {
     private final String _brokerName;
-    private final IsEvState _state;
+    private final String _idealState;
+    private final String _externalView;
 
-    public BrokerDebugInfo(String brokerName, IsEvState state) {
+    @JsonCreator
+    public BrokerDebugInfo(@JsonProperty("brokerName") String brokerName, @JsonProperty("idealState") String idealState,
+        @JsonProperty("externalView") String externalView) {
       _brokerName = brokerName;
-      _state = state;
+      _idealState = idealState;
+      _externalView = externalView;
     }
 
     public String getBrokerName() {
       return _brokerName;
     }
 
-    public IsEvState getState() {
-      return _state;
+    public String getIdealState() {
+      return _idealState;
+    }
+
+    public String getExternalView() {
+      return _externalView;
     }
   }
 
+  /**
+   * Summary of table size - reported and estimated size.
+   */
   public static class TableSizeSummary {
     private final String _reportedSize;
     private final String _estimatedSize;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDebugResource.java
@@ -19,50 +19,70 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.BiMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixProperty;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
+import org.apache.pinot.common.restlet.resources.SegmentServerDebugInfo;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.debug.TableDebugInfo;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.util.CompletionServiceHelper;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.BROKER_RESOURCE_INSTANCE;
 
 
 /**
  * This class implements the debugging endpoints.
+ * NOTE: Debug classes are not expected to guarantee backward compatibility, and should
+ * not be exposed to the client side.
  */
 @Api(tags = Constants.CLUSTER_TAG)
 @Path("/")
 public class TableDebugResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableDebugResource.class);
+
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
 
@@ -81,43 +101,49 @@ public class TableDebugResource {
   @Path("/debug/tables/{tableName}")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get debug information for table.", notes = "Debug information for table.")
-  @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")})
-  public String getClusterInfo(
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 404, message = "Table not found"), @ApiResponse(code = 500, message = "Internal server error")})
+  public String getTableDebugInfo(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr)
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
+      @ApiParam(value = "Verbosity of debug information") @DefaultValue("0") @QueryParam("verbosity") int verbosity)
       throws JsonProcessingException {
     ObjectNode root = JsonUtils.newObjectNode();
     root.put("clusterName", _pinotHelixResourceManager.getHelixClusterName());
 
-    TableType tableType = Constants.validateTableType(tableTypeStr);
-    List<TableType> tableTypes = (tableType == null) ? Arrays.asList(TableType.OFFLINE, TableType.REALTIME)
-        : Collections.singletonList(tableType);
+    List<TableType> tableTypes = getValidTableTypes(tableName, tableTypeStr, _pinotHelixResourceManager);
+    if (tableTypes.isEmpty()) {
+      throw new ControllerApplicationException(LOGGER, "Table '" + tableName + "' not found",
+          Response.Status.NOT_FOUND);
+    }
 
     List<TableDebugInfo> tableDebugInfos = new ArrayList<>();
     for (TableType type : tableTypes) {
-      tableDebugInfos.add(debugTable(_pinotHelixResourceManager, tableName, type));
+      tableDebugInfos.add(debugTable(_pinotHelixResourceManager, tableName, type, verbosity));
     }
+
     return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(tableDebugInfos);
   }
 
   /**
-   * Helper method to colelct debug information about the table.
+   * Helper method to collect debug information about the table.
    *
    * @param pinotHelixResourceManager Helix Resource Manager for the cluster
    * @param tableName Name of the table
    * @param tableType Type of the table (offline|realtime)
-   * @return TableDebugInfo
+   * @param verbosity Verbosity level to include debug information. For level 0, only segments
+   *                  with errors are included. For level > 0, all segments are included.
+   * @return TableDebugInfo Debug info for table.
    */
   private TableDebugInfo debugTable(PinotHelixResourceManager pinotHelixResourceManager, String tableName,
-      TableType tableType) {
+      TableType tableType, int verbosity) {
     String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
 
     // Debug information for segments of the table.
     List<TableDebugInfo.SegmentDebugInfo> segmentDebugInfos =
-        debugSegments(pinotHelixResourceManager, tableNameWithType);
+        debugSegments(pinotHelixResourceManager, tableNameWithType, verbosity);
 
     // Debug information from brokers of the table.
-    List<TableDebugInfo.BrokerDebugInfo> brokerDebugInfos = debugBrokers(tableNameWithType);
+    List<TableDebugInfo.BrokerDebugInfo> brokerDebugInfos = debugBrokers(tableNameWithType, verbosity);
 
     // Debug information from servers of the table.
     List<TableDebugInfo.ServerDebugInfo> serverDebugInfos =
@@ -156,38 +182,90 @@ public class TableDebugResource {
    *
    * @param pinotHelixResourceManager Helix Resource Manager
    * @param tableNameWithType Name of table with type
-   * @return Debug information for segments
+   * @param verbosity Verbosity level to include debug information. For level 0, only segments
+   *                  with errors are included. For level > 0, all segments are included.   * @return Debug information for segments
    */
   private List<TableDebugInfo.SegmentDebugInfo> debugSegments(PinotHelixResourceManager pinotHelixResourceManager,
-      String tableNameWithType) {
+      String tableNameWithType, int verbosity) {
     ExternalView externalView = pinotHelixResourceManager.getTableExternalView(tableNameWithType);
     IdealState idealState = pinotHelixResourceManager.getTableIdealState(tableNameWithType);
 
-    List<TableDebugInfo.SegmentDebugInfo> segmentDebugInfos = new ArrayList<>();
+    List<TableDebugInfo.SegmentDebugInfo> result = new ArrayList<>();
     if (idealState == null) {
-      return segmentDebugInfos;
+      return result;
     }
 
+    int serverRequestTimeoutMs = _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000;
+    final Map<String, List<String>> serverToSegments =
+        _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
+
+    BiMap<String, String> serverToEndpoints;
+    try {
+      serverToEndpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
+    } catch (InvalidConfigException e) {
+      throw new WebApplicationException(
+          "Caught exception when getting segment debug info for table: " + tableNameWithType);
+    }
+
+    Map<String, Map<String, SegmentServerDebugInfo>> segmentsDebugInfoFromServers =
+        getSegmentsDebugInfoFromServers(tableNameWithType, serverToEndpoints, serverRequestTimeoutMs);
+
     for (Map.Entry<String, Map<String, String>> segmentMapEntry : idealState.getRecord().getMapFields().entrySet()) {
-      String segment = segmentMapEntry.getKey();
-      Map<String, String> instanceStateMap = segmentMapEntry.getValue();
+      String segmentName = segmentMapEntry.getKey();
+      Map<String, String> segmentIsMap = segmentMapEntry.getValue();
 
-      List<TableDebugInfo.IsEvState> isEvStates = new ArrayList<>();
-      for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
-        String serverName = entry.getKey();
-        String isState = entry.getValue();
+      Map<String, TableDebugInfo.SegmentState> segmentServerState = new HashMap<>();
+      for (Map.Entry<String, Map<String, SegmentServerDebugInfo>> segmentEntry : segmentsDebugInfoFromServers
+          .entrySet()) {
+        String instanceName = segmentEntry.getKey();
+        String isState = segmentIsMap.get(instanceName);
 
-        String evState = (externalView != null) ? externalView.getStateMap(segment).get(serverName) : "null";
-        if (!isState.equals(evState)) {
-          isEvStates.add(new TableDebugInfo.IsEvState(serverName, isState, evState));
+        Map<String, String> evStateMap = (externalView != null) ? externalView.getStateMap(segmentName) : null;
+        String evState = (evStateMap != null) ? evStateMap.get(instanceName) : null;
+
+        if (evState != null) {
+          Map<String, SegmentServerDebugInfo> segmentServerDebugInfoMap = segmentEntry.getValue();
+          SegmentServerDebugInfo segmentServerDebugInfo = segmentServerDebugInfoMap.get(segmentName);
+
+          if (verbosity > 0 || (segmentServerDebugInfo != null) && segmentHasErrors(segmentServerDebugInfo, evState)) {
+            segmentServerState.put(instanceName,
+                new TableDebugInfo.SegmentState(isState, evState, segmentServerDebugInfo.getSegmentSize(),
+                    segmentServerDebugInfo.getConsumerInfo(), segmentServerDebugInfo.getErrorInfo()));
+          }
+        } else {
+          segmentServerState.put(instanceName, new TableDebugInfo.SegmentState(isState, null, null, null, null));
         }
       }
 
-      if (isEvStates.size() > 0) {
-        segmentDebugInfos.add(new TableDebugInfo.SegmentDebugInfo(segment, isEvStates));
+      if (!segmentServerState.isEmpty()) {
+        result.add(new TableDebugInfo.SegmentDebugInfo(segmentName, segmentServerState));
       }
     }
-    return segmentDebugInfos;
+
+    return result;
+  }
+
+  /**
+   * Helper method to check if a segment has any errors/issues.
+   *
+   * @param segmentServerDebugInfo Segment debug info on server
+   * @param externalView external view of segment
+   * @return True if there's any error/issue for the segment, false otherwise.
+   */
+  private boolean segmentHasErrors(SegmentServerDebugInfo segmentServerDebugInfo, String externalView) {
+    // For now, we will skip cases where IS is ONLINE and EV is OFFLINE (or vice-versa), as it could happen during state transitions.
+    if (externalView.equals("ERROR")) {
+      return true;
+    }
+
+    SegmentConsumerInfo consumerInfo = segmentServerDebugInfo.getConsumerInfo();
+    if (consumerInfo != null && consumerInfo.getConsumerState()
+        .equals(CommonConstants.ConsumerState.NOT_CONSUMING.toString())) {
+      return true;
+    }
+
+    SegmentErrorInfo errorInfo = segmentServerDebugInfo.getErrorInfo();
+    return errorInfo != null && (errorInfo.getErrorMessage() != null || errorInfo.getStackTrace() != null);
   }
 
   /**
@@ -195,9 +273,10 @@ public class TableDebugResource {
    * for the broker resource.
    *
    * @param tableNameWithType Name of table with type suffix
+   * @param verbosity Verbosity level
    * @return Debug information for brokers of the table
    */
-  private List<TableDebugInfo.BrokerDebugInfo> debugBrokers(String tableNameWithType) {
+  private List<TableDebugInfo.BrokerDebugInfo> debugBrokers(String tableNameWithType, int verbosity) {
     List<TableDebugInfo.BrokerDebugInfo> brokerDebugInfos = new ArrayList<>();
     HelixDataAccessor helixDataAccessor = _pinotHelixResourceManager.getHelixZkManager().getHelixDataAccessor();
     IdealState idealState =
@@ -209,9 +288,8 @@ public class TableDebugResource {
       String brokerName = entry.getKey();
       String isState = entry.getValue();
       String evState = externalView.getStateMap(tableNameWithType).get(brokerName);
-      if (!isState.equals(evState)) {
-        brokerDebugInfos.add(
-            new TableDebugInfo.BrokerDebugInfo(brokerName, new TableDebugInfo.IsEvState(brokerName, isState, evState)));
+      if (verbosity > 0 || !isState.equals(evState)) {
+        brokerDebugInfos.add(new TableDebugInfo.BrokerDebugInfo(brokerName, isState, evState));
       }
     }
     return brokerDebugInfos;
@@ -252,5 +330,77 @@ public class TableDebugResource {
       serverDebugInfos.add(new TableDebugInfo.ServerDebugInfo(instanceName, numErrors, numMessages));
     }
     return serverDebugInfos;
+  }
+
+  /**
+   * This method makes a MultiGet call to all servers to get the segments debug info.
+   * @return Map of ServerName ->  (map of SegmentName -> SegmentServerDebugInfo).
+   */
+  private Map<String, Map<String, SegmentServerDebugInfo>> getSegmentsDebugInfoFromServers(String tableNameWithType,
+      BiMap<String, String> serverToEndpoints, int timeoutMs) {
+    LOGGER.info("Reading segments debug info from servers: {} for table: {}", serverToEndpoints.keySet(),
+        tableNameWithType);
+
+    List<String> serverUrls = new ArrayList<>(serverToEndpoints.size());
+    BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();
+    for (String endpoint : endpointsToServers.keySet()) {
+      String segmentDebugInfoURI = String.format("%s/debug/tables/%s", endpoint, tableNameWithType);
+      serverUrls.add(segmentDebugInfoURI);
+    }
+
+    CompletionServiceHelper completionServiceHelper =
+        new CompletionServiceHelper(_executor, _connectionManager, endpointsToServers);
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        completionServiceHelper.doMultiGetRequest(serverUrls, tableNameWithType, timeoutMs);
+
+    // Map from InstanceName -> <Segment -> DebugInfo>
+    Map<String, Map<String, SegmentServerDebugInfo>> serverToSegmentDebugInfoMap = new HashMap<>();
+    int failedParses = 0;
+    for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
+      try {
+        List<SegmentServerDebugInfo> segmentDebugInfos =
+            JsonUtils.stringToObject(streamResponse.getValue(), new TypeReference<List<SegmentServerDebugInfo>>() {
+            });
+        Map<String, SegmentServerDebugInfo> segmentsMap = segmentDebugInfos.stream()
+            .collect(Collectors.toMap(SegmentServerDebugInfo::getSegmentName, Function.identity()));
+        serverToSegmentDebugInfoMap.put(streamResponse.getKey(), segmentsMap);
+      } catch (IOException e) {
+        failedParses++;
+        LOGGER.error("Unable to parse server {} response due to an error: ", streamResponse.getKey(), e);
+      }
+    }
+    if (failedParses != 0) {
+      LOGGER.warn("Failed to parse {} / {} segment size info responses from servers.", failedParses, serverUrls.size());
+    }
+    return serverToSegmentDebugInfoMap;
+  }
+
+  /**
+   * Helper method to get valid types of table that exist in the cluster for the given table name.
+   *
+   * @param tableName Name of table
+   * @param tableTypeStr Type of table
+   * @param pinotHelixResourceManager Pinot Helix Resource manager
+   * @return List of valid table types that exist in the cluster
+   */
+  private List<TableType> getValidTableTypes(String tableName, String tableTypeStr,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    TableType tableType = Constants.validateTableType(tableTypeStr);
+    List<TableType> tableTypes = new ArrayList<>();
+
+    if (tableType == null) {
+      if (pinotHelixResourceManager.hasOfflineTable(tableName)) {
+        tableTypes.add(TableType.OFFLINE);
+      }
+      if (pinotHelixResourceManager.hasRealtimeTable(tableName)) {
+        tableTypes.add(TableType.REALTIME);
+      }
+    } else {
+      String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
+      if (pinotHelixResourceManager.hasTable(tableNameWithType)) {
+        tableTypes.add(tableType);
+      }
+    }
+    return tableTypes;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -19,10 +19,14 @@
 package org.apache.pinot.core.data.manager;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.LoadingCache;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
@@ -31,6 +35,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -38,6 +43,7 @@ import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,9 +65,14 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected HelixManager _helixManager;
   protected String _authToken;
 
+  // Fixed size LRU cache with TableName - SegmentName pair as key, and segment related
+  // errors as the value.
+  protected LoadingCache<Pair<String, String>, SegmentErrorInfo> _errorCache;
+
   @Override
   public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager) {
+      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
+      @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache) {
     LOGGER.info("Initializing table data manager for table: {}", tableDataManagerConfig.getTableName());
 
     _tableDataManagerConfig = tableDataManagerConfig;
@@ -77,6 +88,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (!_indexDir.exists()) {
       Preconditions.checkState(_indexDir.mkdirs());
     }
+    _errorCache = errorCache;
     _logger = LoggerFactory.getLogger(_tableNameWithType + "-" + getClass().getSimpleName());
 
     doInit();
@@ -227,5 +239,21 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public File getTableDataDir() {
     return _indexDir;
+  }
+
+  @Override
+  public void addSegmentError(String segmentName, SegmentErrorInfo segmentErrorInfo) {
+    _errorCache.put(new Pair<>(_tableNameWithType, segmentName), segmentErrorInfo);
+  }
+
+  @Override
+  public Map<String, SegmentErrorInfo> getSegmentErrors() {
+    if (_errorCache == null) {
+      return Collections.emptyMap();
+    } else {
+      // Filter out entries that match the table name.
+      return _errorCache.asMap().entrySet().stream().filter(map -> map.getKey().getFirst().equals(_tableNameWithType))
+          .collect(Collectors.toMap(map -> map.getKey().getSecond(), Map.Entry::getValue));
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -18,16 +18,19 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import com.google.common.cache.LoadingCache;
 import java.util.concurrent.Semaphore;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.Pair;
 
 
 /**
@@ -47,7 +50,8 @@ public class TableDataManagerProvider {
   }
 
   public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig, String instanceId,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager) {
+      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
+      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache) {
     TableDataManager tableDataManager;
     switch (TableType.valueOf(tableDataManagerConfig.getTableDataManagerType())) {
       case OFFLINE:
@@ -63,7 +67,7 @@ public class TableDataManagerProvider {
       default:
         throw new IllegalStateException();
     }
-    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager);
+    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, errorCache);
     return tableDataManager;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -45,6 +45,7 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
@@ -520,8 +521,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             }
           }
         } catch (Exception e) {
-          segmentLogger.error("Caught exception while transforming the record: {}", decodedRow, e);
+          String errorMessage = String.format("Caught exception while transforming the record: %s", decodedRow);
+          segmentLogger.error(errorMessage, e);
           _numRowsErrored++;
+          _realtimeTableDataManager
+              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
         }
       } else {
         realtimeRowsDroppedMeter = _serverMetrics
@@ -618,6 +622,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                   } else {
                     // Could not build segment for some reason. We can only download it.
                     _state = State.ERROR;
+                    _realtimeTableDataManager.addSegmentError(_segmentNameStr,
+                        new SegmentErrorInfo(System.currentTimeMillis(), "Could not build segment", null));
                   }
                   break;
               }
@@ -629,6 +635,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               if (_segmentBuildDescriptor == null) {
                 // We could not build the segment. Go into error state.
                 _state = State.ERROR;
+                _realtimeTableDataManager.addSegmentError(_segmentNameStr,
+                    new SegmentErrorInfo(System.currentTimeMillis(), "Could not build segment", null));
               } else {
                 success = commitSegment(response.getControllerVipUrl(),
                     response.isSplitCommit() && _indexLoadingConfig.isEnableSplitCommit());
@@ -650,9 +658,12 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           }
         }
       } catch (Exception e) {
-        segmentLogger.error("Exception while in work", e);
+        String errorMessage = "Exception while in work";
+        segmentLogger.error(errorMessage, e);
         postStopConsumedMsg(e.getClass().getName());
         _state = State.ERROR;
+        _realtimeTableDataManager
+            .addSegmentError(_segmentNameStr, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
         _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LLC_PARTITION_CONSUMING, 0);
         return;
       }
@@ -801,7 +812,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       try {
         FileUtils.moveDirectory(tempIndexDir, indexDir);
       } catch (IOException e) {
-        segmentLogger.error("Caught exception while moving index directory from: {} to: {}", tempIndexDir, indexDir, e);
+        String errorMessage =
+            String.format("Caught exception while moving index directory from: %s to: %s", tempIndexDir, indexDir);
+        segmentLogger.error(errorMessage, e);
+        _realtimeTableDataManager
+            .addSegmentError(_segmentNameStr, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
         return null;
       } finally {
         FileUtils.deleteQuietly(tempSegmentFolder);
@@ -818,8 +833,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         try {
           TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
         } catch (IOException e) {
-          segmentLogger
-              .error("Caught exception while taring index directory from: {} to: {}", indexDir, segmentTarFile, e);
+          String errorMessage =
+              String.format("Caught exception while taring index directory from: %s to: %s", indexDir, segmentTarFile);
+          segmentLogger.error(errorMessage, e);
+          _realtimeTableDataManager
+              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
           return null;
         }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -113,7 +113,7 @@ public class BaseTableDataManagerTest {
     tableDataManager
         .init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()),
-            mock(HelixManager.class));
+            mock(HelixManager.class), null);
     tableDataManager.start();
     Field segsMapField = BaseTableDataManager.class.getDeclaredField("_segmentDataManagerMap");
     segsMapField.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -108,7 +108,7 @@ public class DimensionTableDataManagerTest {
       when(config.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", mockPropertyStore(),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class));
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null);
     tableDataManager.start();
 
     return tableDataManager;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -775,7 +775,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", propertyStore, mock(ServerMetrics.class),
-            mock(HelixManager.class));
+            mock(HelixManager.class), null);
     tableDataManager.start();
     tableDataManager.shutDown();
     Assert.assertFalse(SegmentBuildTimeLeaseExtender.isExecutorShutdown());

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -129,7 +129,7 @@ public class QueryExecutorTest {
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),
-            mock(ServerMetrics.class), mock(HelixManager.class));
+            mock(ServerMetrics.class), mock(HelixManager.class), null);
     tableDataManager.start();
     for (ImmutableSegment indexSegment : _indexSegments) {
       tableDataManager.addSegment(indexSegment);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -145,7 +145,7 @@ public class SegmentWithNullValueVectorTest {
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", Mockito.mock(ZkHelixPropertyStore.class),
-            Mockito.mock(ServerMetrics.class), Mockito.mock(HelixManager.class));
+            Mockito.mock(ServerMetrics.class), Mockito.mock(HelixManager.class), null);
     tableDataManager.start();
     tableDataManager.addSegment(_segment);
     _instanceDataManager = Mockito.mock(InstanceDataManager.class);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -18,17 +18,21 @@
  */
 package org.apache.pinot.segment.local.data.manager;
 
+import com.google.common.cache.LoadingCache;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.Pair;
 
 
 /**
@@ -41,7 +45,8 @@ public interface TableDataManager {
    * Initializes the table data manager. Should be called only once and before calling any other method.
    */
   void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
-      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager);
+      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
+      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache);
 
   /**
    * Starts the table data manager. Should be called only once after table data manager gets initialized but before
@@ -126,4 +131,19 @@ public interface TableDataManager {
    * Returns the dir which contains the data segments.
    */
   File getTableDataDir();
+
+  /**
+   * Add error related to segment, if any. The implementation
+   * is expected to cache last 'N' errors for the table, related to
+   * segment transitions.
+   */
+  void addSegmentError(String segmentName, SegmentErrorInfo segmentErrorInfo);
+
+  /**
+   * Returns a list of segment errors that were encountered
+   * and cached.
+   *
+   * @return List of {@link SegmentErrorInfo}
+   */
+  Map<String, SegmentErrorInfo> getSegmentErrors();
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
+import org.apache.pinot.common.restlet.resources.SegmentServerDebugInfo;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/**
+ * Debug resource for Pinot Server.
+ */
+@Api(tags = "Debug")
+@Path("/debug/")
+public class DebugResource {
+
+  @Inject
+  private ServerInstance _serverInstance;
+
+  @GET
+  @Path("tables/{tableName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get segments debug info for this table", notes = "This is a debug endpoint, and won't maintain backward compatibility")
+  public List<SegmentServerDebugInfo> getSegmentsDebugInfo(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType) {
+
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    return getSegmentServerDebugInfo(tableNameWithType, tableType);
+  }
+
+  private List<SegmentServerDebugInfo> getSegmentServerDebugInfo(String tableNameWithType, TableType tableType) {
+    List<SegmentServerDebugInfo> segmentServerDebugInfos = new ArrayList<>();
+
+    TableDataManager tableDataManager =
+        ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
+
+    Map<String, SegmentErrorInfo> segmentErrorsMap = tableDataManager.getSegmentErrors();
+    Set<String> segmentsWithDataManagers = new HashSet<>();
+    List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+    try {
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+        String segmentName = segmentDataManager.getSegmentName();
+        segmentsWithDataManagers.add(segmentName);
+
+        // Get segment consumer info.
+        SegmentConsumerInfo segmentConsumerInfo = getSegmentConsumerInfo(segmentDataManager, tableType);
+
+        // Get segment size.
+        long segmentSize = getSegmentSize(segmentDataManager);
+
+        // Get segment error.
+        SegmentErrorInfo segmentErrorInfo = segmentErrorsMap.get(segmentName);
+
+        segmentServerDebugInfos.add(
+            new SegmentServerDebugInfo(segmentName, FileUtils.byteCountToDisplaySize(segmentSize), segmentConsumerInfo,
+                segmentErrorInfo));
+      }
+    } catch (Exception e) {
+      throw new WebApplicationException("Caught exception when getting consumer info for table: " + tableNameWithType);
+    } finally {
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
+
+    // There may be segment errors for segments without Data Managers (e.g. segment wasn't loaded).
+    for (Map.Entry<String, SegmentErrorInfo> entry : segmentErrorsMap.entrySet()) {
+      String segmentName = entry.getKey();
+
+      if (!segmentsWithDataManagers.contains(segmentName)) {
+        SegmentErrorInfo segmentErrorInfo = entry.getValue();
+        segmentServerDebugInfos.add(new SegmentServerDebugInfo(segmentName, null, null, segmentErrorInfo));
+      }
+    }
+    return segmentServerDebugInfos;
+  }
+
+  private long getSegmentSize(SegmentDataManager segmentDataManager) {
+    return (segmentDataManager instanceof ImmutableSegmentDataManager) ? ((ImmutableSegment) segmentDataManager
+        .getSegment()).getSegmentSizeBytes() : 0;
+  }
+
+  private SegmentConsumerInfo getSegmentConsumerInfo(SegmentDataManager segmentDataManager, TableType tableType) {
+    SegmentConsumerInfo segmentConsumerInfo = null;
+    if (tableType == TableType.REALTIME) {
+      RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
+      String segmentName = segmentDataManager.getSegmentName();
+      segmentConsumerInfo =
+          new SegmentConsumerInfo(segmentName, realtimeSegmentDataManager.getConsumerState().toString(),
+              realtimeSegmentDataManager.getLastConsumedTimestamp(),
+              realtimeSegmentDataManager.getPartitionToCurrentOffset());
+    }
+    return segmentConsumerInfo;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ServerResourceUtils.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ServerResourceUtils.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.server.starter.ServerInstance;
+
+
+/**
+ * Utility class for Server resources.
+ */
+public class ServerResourceUtils {
+
+  // Disable instantiation.
+  private ServerResourceUtils() {
+
+  }
+
+  public static TableDataManager checkGetTableDataManager(ServerInstance serverInstance, String tableName) {
+    InstanceDataManager dataManager = checkGetInstanceDataManager(serverInstance);
+    TableDataManager tableDataManager = dataManager.getTableDataManager(tableName);
+    if (tableDataManager == null) {
+      throw new WebApplicationException("Table " + tableName + " does not exist", Response.Status.NOT_FOUND);
+    }
+    return tableDataManager;
+  }
+
+  public static InstanceDataManager checkGetInstanceDataManager(ServerInstance serverInstance) {
+    if (serverInstance == null) {
+      throw new WebApplicationException("Server initialization error. Missing server instance");
+    }
+    InstanceDataManager instanceDataManager = serverInstance.getInstanceDataManager();
+    if (instanceDataManager == null) {
+      throw new WebApplicationException("Server initialization error. Missing data manager",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    return instanceDataManager;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +38,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploader;
@@ -53,6 +57,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +81,10 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private String _authToken;
   private SegmentUploader _segmentUploader;
 
+  // Fixed size LRU cache for storing last N errors on the instance.
+  // Key is TableNameWithType-SegmentName pair.
+  private LoadingCache<Pair<String, String>, SegmentErrorInfo> _errorCache;
+
   @Override
   public synchronized void init(PinotConfiguration config, HelixManager helixManager, ServerMetrics serverMetrics)
       throws ConfigurationException {
@@ -88,7 +97,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _serverMetrics = serverMetrics;
     _authToken = config.getProperty(CommonConstants.Server.CONFIG_OF_AUTH_TOKEN);
     _segmentUploader = new PinotFSSegmentUploader(_instanceDataManagerConfig.getSegmentStoreUri(),
-            PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
+        PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
 
     File instanceDataDir = new File(_instanceDataManagerConfig.getInstanceDataDir());
     if (!instanceDataDir.exists()) {
@@ -105,6 +114,16 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     // Initialize the table data manager provider
     TableDataManagerProvider.init(_instanceDataManagerConfig);
     LOGGER.info("Initialized Helix instance data manager");
+
+    // Initialize the error cache
+    _errorCache = CacheBuilder.newBuilder().maximumSize(_instanceDataManagerConfig.getErrorCacheSize())
+        .build(new CacheLoader<Pair<String, String>, SegmentErrorInfo>() {
+          @Override
+          public SegmentErrorInfo load(Pair<String, String> tableNameWithTypeSegmentNamePair) {
+            // This cache is populated only via the put api.
+            return null;
+          }
+        });
   }
 
   @Override
@@ -150,7 +169,8 @@ public class HelixInstanceDataManager implements InstanceDataManager {
         TableDataManagerConfig.getDefaultHelixTableDataManagerConfig(_instanceDataManagerConfig, tableNameWithType);
     tableDataManagerConfig.overrideConfigs(tableConfig, _authToken);
     TableDataManager tableDataManager = TableDataManagerProvider
-        .getTableDataManager(tableDataManagerConfig, _instanceId, _propertyStore, _serverMetrics, _helixManager);
+        .getTableDataManager(tableDataManagerConfig, _instanceId, _propertyStore, _serverMetrics, _helixManager,
+            _errorCache);
     tableDataManager.start();
     LOGGER.info("Created table data manager for table: {}", tableNameWithType);
     return tableDataManager;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -103,7 +103,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   //
   private static final String MAX_PARALLEL_REFRESH_THREADS = "max.parallel.refresh.threads";
 
+  // Size of cache that holds errors.
+  private static final String ERROR_CACHE_SIZE = "error.cache.size";
+
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID, INSTANCE_DATA_DIR, READ_MODE};
+  private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private PinotConfiguration _instanceDataManagerConfiguration = null;
 
   public HelixInstanceDataManagerConfig(PinotConfiguration serverConfig)
@@ -229,6 +233,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
       tierConfigs.put(READ_MODE, getReadMode());
     }
     return new PinotConfiguration(tierConfigs);
+  }
+
+  @Override
+  public long getErrorCacheSize() {
+    return _instanceDataManagerConfiguration.getProperty(ERROR_CACHE_SIZE, DEFAULT_ERROR_CACHE_SIZE);
   }
 
   @Override

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -184,7 +184,7 @@ public abstract class BaseResourceTest {
     TableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager
         .init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class),
-            mock(HelixManager.class));
+            mock(HelixManager.class), null);
     tableDataManager.start();
     _tableDataManagerMap.put(tableNameWithType, tableDataManager);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -58,4 +58,6 @@ public interface InstanceDataManagerConfig {
   String getTierBackend();
 
   PinotConfiguration getTierConfigs();
+
+  long getErrorCacheSize();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pair.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pair.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.utils;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 
 public class Pair<T1 extends Serializable, T2 extends Serializable> implements Serializable {
@@ -51,5 +52,22 @@ public class Pair<T1 extends Serializable, T2 extends Serializable> implements S
   @Override
   public String toString() {
     return "first=" + _first + ", second=" + _second;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Pair<?, ?> pair = (Pair<?, ?>) o;
+    return Objects.equals(_first, pair._first) && Objects.equals(_second, pair._second);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_first, _second);
   }
 }


### PR DESCRIPTION
Enhanced the existing endpoint for table deugging on controller as well as server
to include segment state transition and consumption related errors and information.

Note: This is a debug endpoint and should not be expected to maintain backward compatibility
from user's perspective. It would, however, ensure that debug calls from controller to
servers maintain compatibility.

- InstanceDataManager now caches exceptions caused during segment consumption or state transition.
  Added a config `pinot.server.instance.error.cache.size` for setting the number of errors to
  cache, defaults to 100. This means, by default we store the last 100 errors on an instance.

- Table debug endpoint on server now returns:
  - Segment name and size
  - Consumption info
  - Error info

- Table debug endpoint on the controller returns aggregated segment info's across all server
  in addition to existing broker and server info's.

- By default, only segments with issues are reported. To report all segments, an optional
  parameter `verbose=true` can be specified in the api call.

TODO:
- Compress stack traces in-memory. Right now, we only store 100 stack traces, so it should not be more than a few MBs in the worst case.

Sample output:

```
[ {
  "tableName" : "myTable_REALTIME",
  "numSegments" : 1,
  "numServers" : 1,
  "numBrokers" : 1,
  "segmentDebugInfos" : [ {
    "segmentName" : "myTable__0__0__20210525T2349Z",
    "serverState" : {
      "Server_192.168.1.90_7000" : {
        "segmentSize" : "0 bytes",
        "consumerInfo" : {
          "segmentName" : "myTable__0__0__20210525T2349Z",
          "consumerState" : "CONSUMING",
          "lastConsumedTimestamp" : 0,
          "partitionToOffsetMap" : {
            "0" : "1"
          }
        },
        "errorInfo" : {
          "timeStamp" : "2021-05-25 16:49:34 PDT",
          "error" : "Caught exception while transforming the record: {}",
          "exception" : "java.lang.RuntimeException: Caught exception while transforming data type for column: current_ts\n\tat org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.transform(DataTypeTransformer.java:120)\n\tat org.apache.pinot.segment.local.recordtransformer.CompositeTransformer.transform(CompositeTransformer.java:82)\n\tat org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.processStreamEvents(LLRealtimeSegmentDataManager.java:510)\n\tat org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.consumeLoop(LLRealtimeSegmentDataManager.java:417)\n\tat org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:560)\n\tat java.lang.Thread.run(Thread.java:748)\nCaused by: java.lang.NumberFormatException: For input string: \"2021-05-12T08:13:16.152000\"\n\tat java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)\n\tat java.lang.Long.parseLong(Long.java:589)\n\tat java.lang.Long.parseLong(Long.java:631)\n\tat org.apache.pinot.common.utils.PinotDataType$10.toLong(PinotDataType.java:502)\n\tat org.apache.pinot.common.utils.PinotDataType$6.convert(PinotDataType.java:333)\n\tat org.apache.pinot.common.utils.PinotDataType$6.convert(PinotDataType.java:290)\n\tat org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer.transform(DataTypeTransformer.java:114)\n\t... 5 more\n"
        },
        "isState" : "CONSUMING",
        "evState" : "CONSUMING"
      }
    }
  } ],
  "serverDebugInfos" : [ ],
  "brokerDebugInfos" : [ ],
  "tableSize" : {
    "reportedSize" : "0 bytes",
    "estimatedSize" : "0 bytes"
  }
} ]
```

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
