### PR TITLE
Remove constructor from base class ColumnIndexDirectory

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 // Abort writes: There is no way to abort discard changes
 //
 class SingleFileIndexDirectory extends ColumnIndexDirectory {
-  private static Logger LOGGER = LoggerFactory.getLogger(SingleFileIndexDirectory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SingleFileIndexDirectory.class);
 
   private static final String DEFAULT_INDEX_FILE_NAME = "columns.psf";
   private static final String INDEX_MAP_FILE = "index_map";
@@ -77,21 +77,45 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   // now till PinotDataBuffer can support large buffers again
   private static final int MAX_ALLOCATION_SIZE = 2000 * 1024 * 1024;
 
-  private File indexFile;
-  private Map<IndexKey, IndexEntry> columnEntries;
-  private List<PinotDataBuffer> allocBuffers;
+  private final File _segmentDirectory;
+  private SegmentMetadataImpl _segmentMetadata;
+  private final ReadMode _readMode;
+  private final File _indexFile;
+  private final Map<IndexKey, IndexEntry> _columnEntries;
+  private final List<PinotDataBuffer> _allocBuffers;
 
-  public SingleFileIndexDirectory(File segmentDirectory, SegmentMetadataImpl metadata, ReadMode readMode)
+  /**
+   * @param segmentDirectory File pointing to segment directory
+   * @param segmentMetadata segment metadata. Metadata must be fully initialized
+   * @param readMode mmap vs heap mode
+   */
+  public SingleFileIndexDirectory(File segmentDirectory, SegmentMetadataImpl segmentMetadata, ReadMode readMode)
       throws IOException, ConfigurationException {
-    super(segmentDirectory, metadata, readMode);
+    Preconditions.checkNotNull(segmentDirectory);
+    Preconditions.checkNotNull(readMode);
+    Preconditions.checkNotNull(segmentMetadata);
 
-    indexFile = new File(segmentDirectory, DEFAULT_INDEX_FILE_NAME);
-    if (!indexFile.exists()) {
-      indexFile.createNewFile();
+    Preconditions.checkArgument(segmentDirectory.exists(),
+        "SegmentDirectory: " + segmentDirectory.toString() + " does not exist");
+    Preconditions.checkArgument(segmentDirectory.isDirectory(),
+        "SegmentDirectory: " + segmentDirectory.toString() + " is not a directory");
+
+    _segmentDirectory = segmentDirectory;
+    _segmentMetadata = segmentMetadata;
+    _readMode = readMode;
+
+    _indexFile = new File(segmentDirectory, DEFAULT_INDEX_FILE_NAME);
+    if (!_indexFile.exists()) {
+      _indexFile.createNewFile();
     }
-    columnEntries = new HashMap<>(metadata.getAllColumns().size());
-    allocBuffers = new ArrayList<>();
+    _columnEntries = new HashMap<>(_segmentMetadata.getAllColumns().size());
+    _allocBuffers = new ArrayList<>();
     load();
+  }
+
+  @Override
+  public void setSegmentMetadata(SegmentMetadataImpl segmentMetadata) {
+    _segmentMetadata = segmentMetadata;
   }
 
   @Override
@@ -112,12 +136,12 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       return hasTextIndex(column);
     }
     IndexKey key = new IndexKey(column, type);
-    return columnEntries.containsKey(key);
+    return _columnEntries.containsKey(key);
   }
 
   private boolean hasTextIndex(String column) {
     String suffix = V1Constants.Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION;
-    File[] textIndexFiles = segmentDirectory.listFiles(new FilenameFilter() {
+    File[] textIndexFiles = _segmentDirectory.listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String name) {
         return name.equals(column + suffix);
@@ -125,7 +149,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     });
     if (textIndexFiles.length > 0) {
       Preconditions.checkState(textIndexFiles.length == 1,
-          "Illegal number of text index directories for columns " + column + " segment directory " + segmentDirectory
+          "Illegal number of text index directories for columns " + column + " segment directory " + _segmentDirectory
               .getAbsolutePath());
       return true;
     }
@@ -134,10 +158,10 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   private PinotDataBuffer checkAndGetIndexBuffer(String column, ColumnIndexType type) {
     IndexKey key = new IndexKey(column, type);
-    IndexEntry entry = columnEntries.get(key);
+    IndexEntry entry = _columnEntries.get(key);
     if (entry == null || entry.buffer == null) {
       throw new RuntimeException(
-          "Could not find index for column: " + column + ", type: " + type + ", segment: " + segmentDirectory
+          "Could not find index for column: " + column + ", type: " + type + ", segment: " + _segmentDirectory
               .toString());
     }
     return entry.buffer;
@@ -152,19 +176,19 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
     String allocContext = allocationContext(key) + context;
     IndexEntry entry = new IndexEntry(key);
-    entry.startOffset = indexFile.length();
+    entry.startOffset = _indexFile.length();
     entry.size = size + MAGIC_MARKER_SIZE_BYTES;
 
     // Backward-compatible: index file is always big-endian
     PinotDataBuffer appendBuffer =
-        PinotDataBuffer.mapFile(indexFile, false, entry.startOffset, entry.size, ByteOrder.BIG_ENDIAN, allocContext);
+        PinotDataBuffer.mapFile(_indexFile, false, entry.startOffset, entry.size, ByteOrder.BIG_ENDIAN, allocContext);
 
     LOGGER.debug("Allotted buffer for key: {}, startOffset: {}, size: {}", key, entry.startOffset, entry.size);
     appendBuffer.putLong(0, MAGIC_MARKER);
-    allocBuffers.add(appendBuffer);
+    _allocBuffers.add(appendBuffer);
 
     entry.buffer = appendBuffer.view(MAGIC_MARKER_SIZE_BYTES, entry.size);
-    columnEntries.put(key, entry);
+    _columnEntries.put(key, entry);
 
     persistIndexMap(entry);
 
@@ -172,19 +196,19 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   private void checkKeyNotPresent(IndexKey key) {
-    if (columnEntries.containsKey(key)) {
+    if (_columnEntries.containsKey(key)) {
       throw new RuntimeException(
           "Attempt to re-create an existing index for key: " + key.toString() + ", for segmentDirectory: "
-              + segmentDirectory.getAbsolutePath());
+              + _segmentDirectory.getAbsolutePath());
     }
   }
 
   private void validateMagicMarker(PinotDataBuffer buffer, long startOffset) {
     long actualMarkerValue = buffer.getLong(startOffset);
     if (actualMarkerValue != MAGIC_MARKER) {
-      LOGGER.error("Missing magic marker in index file: {} at position: {}", indexFile, startOffset);
+      LOGGER.error("Missing magic marker in index file: {} at position: {}", _indexFile, startOffset);
       throw new RuntimeException(
-          "Inconsistent data read. Index data file " + indexFile.toString() + " is possibly corrupted");
+          "Inconsistent data read. Index data file " + _indexFile.toString() + " is possibly corrupted");
     }
   }
 
@@ -196,7 +220,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   private void loadMap()
       throws ConfigurationException {
-    File mapFile = new File(segmentDirectory, INDEX_MAP_FILE);
+    File mapFile = new File(_segmentDirectory, INDEX_MAP_FILE);
 
     PropertiesConfiguration mapConfig = CommonsConfigurationUtils.fromFile(mapFile);
 
@@ -206,19 +230,19 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       // or, "column.name.dictionary.endOffset" where column.name is the key
       int lastSeparatorPos = key.lastIndexOf(MAP_KEY_SEPARATOR);
       Preconditions
-          .checkState(lastSeparatorPos != -1, "Key separator not found: " + key + ", segment: " + segmentDirectory);
+          .checkState(lastSeparatorPos != -1, "Key separator not found: " + key + ", segment: " + _segmentDirectory);
       String propertyName = key.substring(lastSeparatorPos + 1);
 
       int indexSeparatorPos = key.lastIndexOf(MAP_KEY_SEPARATOR, lastSeparatorPos - 1);
       Preconditions
-          .checkState(indexSeparatorPos != -1, "Index separator not found: " + key + " , segment: " + segmentDirectory);
+          .checkState(indexSeparatorPos != -1, "Index separator not found: " + key + " , segment: " + _segmentDirectory);
       String indexName = key.substring(indexSeparatorPos + 1, lastSeparatorPos);
       String columnName = key.substring(0, indexSeparatorPos);
       IndexKey indexKey = new IndexKey(columnName, ColumnIndexType.getValue(indexName));
-      IndexEntry entry = columnEntries.get(indexKey);
+      IndexEntry entry = _columnEntries.get(indexKey);
       if (entry == null) {
         entry = new IndexEntry(indexKey);
-        columnEntries.put(indexKey, entry);
+        _columnEntries.put(indexKey, entry);
       }
 
       if (propertyName.equals(MAP_KEY_NAME_START_OFFSET)) {
@@ -227,16 +251,16 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
         entry.size = mapConfig.getLong(key);
       } else {
         throw new ConfigurationException(
-            "Invalid map file key: " + key + ", segmentDirectory: " + segmentDirectory.toString());
+            "Invalid map file key: " + key + ", segmentDirectory: " + _segmentDirectory.toString());
       }
     }
 
     // validation
-    for (Map.Entry<IndexKey, IndexEntry> colIndexEntry : columnEntries.entrySet()) {
+    for (Map.Entry<IndexKey, IndexEntry> colIndexEntry : _columnEntries.entrySet()) {
       IndexEntry entry = colIndexEntry.getValue();
       if (entry.size < 0 || entry.startOffset < 0) {
         throw new ConfigurationException(
-            "Invalid map entry for key: " + colIndexEntry.getKey().toString() + ", segment: " + segmentDirectory
+            "Invalid map entry for key: " + colIndexEntry.getKey().toString() + ", segment: " + _segmentDirectory
                 .toString());
       }
     }
@@ -246,7 +270,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       throws IOException {
     SortedMap<Long, IndexEntry> indexStartMap = new TreeMap<>();
 
-    for (Map.Entry<IndexKey, IndexEntry> columnEntry : columnEntries.entrySet()) {
+    for (Map.Entry<IndexKey, IndexEntry> columnEntry : _columnEntries.entrySet()) {
       long startOffset = columnEntry.getValue().startOffset;
       indexStartMap.put(startOffset, columnEntry.getValue());
     }
@@ -279,17 +303,17 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     long fromFilePos = offsetAccum.get(0);
     long size = endOffset - fromFilePos;
 
-    String context = allocationContext(indexFile,
+    String context = allocationContext(_indexFile,
         "single_file_index.rw." + "." + String.valueOf(fromFilePos) + "." + String.valueOf(size));
 
     // Backward-compatible: index file is always big-endian
     PinotDataBuffer buffer;
-    if (readMode == ReadMode.heap) {
-      buffer = PinotDataBuffer.loadFile(indexFile, fromFilePos, size, ByteOrder.BIG_ENDIAN, context);
+    if (_readMode == ReadMode.heap) {
+      buffer = PinotDataBuffer.loadFile(_indexFile, fromFilePos, size, ByteOrder.BIG_ENDIAN, context);
     } else {
-      buffer = PinotDataBuffer.mapFile(indexFile, true, fromFilePos, size, ByteOrder.BIG_ENDIAN, context);
+      buffer = PinotDataBuffer.mapFile(_indexFile, true, fromFilePos, size, ByteOrder.BIG_ENDIAN, context);
     }
-    allocBuffers.add(buffer);
+    _allocBuffers.add(buffer);
 
     long prevSlicePoint = 0;
     for (Long fileOffset : offsetAccum) {
@@ -303,7 +327,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   private void persistIndexMap(IndexEntry entry)
       throws IOException {
-    File mapFile = new File(segmentDirectory, INDEX_MAP_FILE);
+    File mapFile = new File(_segmentDirectory, INDEX_MAP_FILE);
     try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(mapFile, true)))) {
       String startKey = getKey(entry.key.name, entry.key.type.getIndexName(), true);
 
@@ -329,11 +353,11 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   @Override
   public void close()
       throws IOException {
-    for (PinotDataBuffer buf : allocBuffers) {
+    for (PinotDataBuffer buf : _allocBuffers) {
       buf.close();
     }
-    columnEntries.clear();
-    allocBuffers.clear();
+    _columnEntries.clear();
+    _allocBuffers.clear();
   }
 
   @Override
@@ -350,6 +374,6 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public String toString() {
-    return segmentDirectory.toString() + "/" + indexFile.toString();
+    return _segmentDirectory.toString() + "/" + _indexFile.toString();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
@@ -18,51 +18,20 @@
  */
 package org.apache.pinot.segment.spi.store;
 
-import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.utils.ReadMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * Abstract class to map the columnar indices to their location on disk.
+ * Abstract class to map the columnar indices to their buffers
  *
  */
 public abstract class ColumnIndexDirectory implements Closeable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnIndexDirectory.class);
 
-  protected File segmentDirectory;
-  protected SegmentMetadataImpl metadata;
-  protected ReadMode readMode;
-
-  /**
-   * @param segmentDirectory File pointing to segment directory
-   * @param metadata segment metadata. Metadata must be fully initialized
-   * @param readMode mmap vs heap map mode
-   */
-  protected ColumnIndexDirectory(File segmentDirectory, SegmentMetadataImpl metadata, ReadMode readMode) {
-    Preconditions.checkNotNull(segmentDirectory);
-    Preconditions.checkNotNull(readMode);
-    Preconditions.checkNotNull(metadata);
-
-    Preconditions.checkArgument(segmentDirectory.exists(),
-        "SegmentDirectory: " + segmentDirectory.toString() + " does not exist");
-    Preconditions.checkArgument(segmentDirectory.isDirectory(),
-        "SegmentDirectory: " + segmentDirectory.toString() + " is not a directory");
-
-    this.segmentDirectory = segmentDirectory;
-    this.metadata = metadata;
-    this.readMode = readMode;
-  }
-
-  public void setMetadata(SegmentMetadataImpl metadata) {
-    this.metadata = metadata;
-  }
+  public abstract void setSegmentMetadata(SegmentMetadataImpl segmentMetadata);
 
   /**
    * Allocation context for tracking memory


### PR DESCRIPTION
The parameters of the constructor in the base class will not make sense for an implementation which doesn't have segmentDirectory on the local disk