### PR TITLE
Fix NPE in NumericalFilterOptimizer due to IS NULL and IS NOT NULL operator.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
@@ -245,29 +245,17 @@ public class NumericalFilterOptimizerTest {
     // Test DOUBLE column greater than Long.MIN_VALUE.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn > " + Long.MIN_VALUE),
         "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:-9.223372036854776E18>)]))");
-
-
   }
 
   @Test
-  public void temp() {
+  public void testNull() {
+    // Test column IS NOT NULL.
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE intColumn IS NOT NULL"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:IS_NOT_NULL, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:intColumn))]))");
 
-    // Test LONG column with DOUBLE value that falls within LONG bounds.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn < -2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:longColumn)), Expression(type:LITERAL, literal:<Literal longValue:-2100000000>)]))");
-
-    // Test LONG column with DOUBLE value that falls within LONG bounds.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn > -2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN_OR_EQUAL, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:longColumn)), Expression(type:LITERAL, literal:<Literal longValue:-2100000000>)]))");
-
-    // Test LONG column with DOUBLE value that falls within LONG bounds.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn < 2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN_OR_EQUAL, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:longColumn)), Expression(type:LITERAL, literal:<Literal longValue:2100000000>)]))");
-
-    // Test LONG column with DOUBLE value that falls within LONG bounds.
-    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn > 2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:longColumn)), Expression(type:LITERAL, literal:<Literal longValue:2100000000>)]))");
-
+    // Test column IS NULL.
+    Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE intColumn IS NULL"),
+        "Expression(type:FUNCTION, functionCall:Function(operator:IS_NULL, operands:[Expression(type:IDENTIFIER, identifier:Identifier(name:intColumn))]))");
   }
 
   @Test


### PR DESCRIPTION
## Description
In the current code, Line 92 of `NumericalFilterOptimizer` throws NPE while processing `IS NULL` and `IS NOT NULL` operators because these operators have only one operand. This PR adds a fix for avoiding NPE and a test case to verify the fix.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
