### PR TITLE
Add Bloom Filter based pruning support for IN predicate(#7005)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -240,7 +240,7 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
 
   /**
    * For IN predicate, segment will not be pruned if the size of values is greater than threshold
-   * Prune the segment based on: Column min/max value
+   * Prune the segment based on: Column min/max value and Bloom Filter
    * @return true if the segment can be pruned
    * otherwise false if size of values > threshold or any of the value is greater than min value or smaller than max value of segment
    */
@@ -262,6 +262,16 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
         return false;
       }
     }
+
+    BloomFilterReader bloomFilter = dataSource.getBloomFilter();
+    if (bloomFilter != null) {
+      for (String value : values) {
+        if (bloomFilter.mightContain(value)) {
+          return false;
+        }
+      }
+    }
+
     return true;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -26,6 +26,7 @@ import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUt
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -131,6 +132,38 @@ public class ColumnValueSegmentPrunerTest {
     assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 2"));
     assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column < 10"));
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 10"));
+  }
+
+  @Test
+  public void testBloomFilterInPredicatePruning() {
+    Map<String, Object> properties = new HashMap<>();
+    // override default value
+    properties.put(ColumnValueSegmentPruner.IN_PREDICATE_THRESHOLD, 5);
+    PinotConfiguration configuration = new PinotConfiguration(properties);
+    PRUNER.init(configuration);
+
+    IndexSegment indexSegment = mock(IndexSegment.class);
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource("column")).thenReturn(dataSource);
+    // Add support for bloom filter
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    BloomFilterReader bloomFilterReader = mock(BloomFilterReader.class);
+
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+    when(dataSource.getBloomFilter()).thenReturn(bloomFilterReader);
+    when(bloomFilterReader.mightContain("1")).thenReturn(true);
+    when(bloomFilterReader.mightContain("2")).thenReturn(true);
+    when(bloomFilterReader.mightContain("3")).thenReturn(true);
+    when(dataSourceMetadata.getMinValue()).thenReturn(5);
+    when(dataSourceMetadata.getMaxValue()).thenReturn(10);
+
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21, 30)"));
+    assertFalse(
+        runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)"));
   }
 
   private boolean runPruner(IndexSegment indexSegment, String query) {


### PR DESCRIPTION
Server side segment pruning is currently supported for =, RANGE,IN filter operators using min-max value stats (segment metadata). Similarly, bloom filter is also used for = filter.

For IN filter operator, we should add support for bloom filter based pruning if the number of values in the IN clause are below a certain threshold.

Adding this support for large number of values in IN clause won't be helpful as the pruning may not happen (since values are likely to be spread across several segments) and the time to prune itself may negate the benefits.

This ticket uses similar approach as that of Issue #6756 

Issue #7005 
