### PR TITLE
Modified the checkout scripts to parse arguments

### DIFF
--- a/compatibility-verifier/README.md
+++ b/compatibility-verifier/README.md
@@ -25,7 +25,7 @@
 
 ### Step 1: checkout source code and build targets for older commit and newer commit
 ```shell
-./compatibility-verifier/checkoutAndBuild.sh [olderCommit] [newerCommit] [workingDir]
+./compatibility-verifier/checkoutAndBuild.sh -o olderCommit -n newerCommit [-w workingDir]
 ```
 ***NOTE***: `[workingDir]` is optional, if user does not specify `[workingDir]`, the script will create a temporary working 
 dir and output the path, which can be used in step 2.

--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -22,24 +22,15 @@
 # get a temporary directory in case the workingDir is not provided by user
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 cmdName=`baseName $0`
+source `dirname $0`/utils.inc
 
 # get usage of the script
 function usage() {
   echo "Usage: $cmdName -o olderCommit -n newerCommit [-w workingDir]"
+  echo -e "  -w, --working-dir                      Working directory where olderCommit and newCommit target files reside\n"
+  echo -e "  -n, --new-commit-hash                  git hash for new commit\n"
+  echo -e "  -o, --old-commit-hash                  git hash for old commit\n"
   exit 1
-}
-
-#compute absolute path from a relative path
-function absPath() {
-  local relPath=$1
-  if [[ ! "$relPath" == /* ]]; then
-    #relative path
-    absolutePath=$(
-      cd "$relPath"
-      pwd
-    )
-  fi
-  echo "$absolutePath"
 }
 
 # This function builds Pinot given a specific commit hash and target directory

--- a/compatibility-verifier/compCheck.sh
+++ b/compatibility-verifier/compCheck.sh
@@ -43,6 +43,7 @@ RM="/bin/rm"
 logCount=1
 #Declare the number of mandatory args
 cmdName=`baseName $0`
+source `dirname $0`/utils.inc
 
 # get usage of the script
 function usage() {
@@ -216,19 +217,6 @@ function setupCompatTester() {
   ))
   CLASSPATH_PREFIX=$(ls ${pinotIntegTestsAbsDir}/pinot-integration-tests-*-tests.jar)
   export CLASSPATH_PREFIX
-}
-
-#compute absolute path for testSuiteDir if given relative
-function absPath() {
-  local testSuiteDirPath=$1
-  if [[ ! "$testSuiteDirPath" == /* ]]; then
-    #relative path
-    testSuiteDirPath=$(
-      cd "$testSuiteDirPath"
-      pwd
-    )
-  fi
-  echo "$testSuiteDirPath"
 }
 
 #

--- a/compatibility-verifier/utils.inc
+++ b/compatibility-verifier/utils.inc
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # Compute absolute dir path from a relative path. Requires that the path exist
 function absPath() {
   local relPath=$1

--- a/compatibility-verifier/utils.inc
+++ b/compatibility-verifier/utils.inc
@@ -1,0 +1,12 @@
+#compute absolute path from a relative path
+function absPath() {
+  local relPath=$1
+  if [[ ! "$relPath" == /* ]]; then
+    #relative path
+    absolutePath=$(
+      cd "$relPath"
+      pwd
+    )
+  fi
+  echo "$absolutePath"
+}

--- a/compatibility-verifier/utils.inc
+++ b/compatibility-verifier/utils.inc
@@ -1,8 +1,7 @@
-#compute absolute path from a relative path
+# Compute absolute dir path from a relative path. Requires that the path exist
 function absPath() {
   local relPath=$1
   if [[ ! "$relPath" == /* ]]; then
-    #relative path
     relPath=$(
       cd "$relPath"
       pwd

--- a/compatibility-verifier/utils.inc
+++ b/compatibility-verifier/utils.inc
@@ -3,10 +3,10 @@ function absPath() {
   local relPath=$1
   if [[ ! "$relPath" == /* ]]; then
     #relative path
-    absolutePath=$(
+    relPath=$(
       cd "$relPath"
       pwd
     )
   fi
-  echo "$absolutePath"
+  echo "$relPath"
 }


### PR DESCRIPTION
Unified the two arg parsers to have the same type of arguments.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
