### PR TITLE
Produce GenericRow file in segment processing mapper

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapper.java
@@ -20,28 +20,32 @@ package org.apache.pinot.core.segment.processing.framework;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.avro.Schema;
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.segment.processing.filter.RecordFilter;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterFactory;
+import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerFactory;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformer;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerFactory;
-import org.apache.pinot.core.util.SegmentProcessorAvroUtils;
-import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
+import org.apache.pinot.core.segment.processing.utils.SegmentProcessingUtils;
+import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
+import org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer;
+import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.segment.spi.partition.Partitioner;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,34 +59,47 @@ import org.slf4j.LoggerFactory;
  * - partitioning
  */
 public class SegmentMapper {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentMapper.class);
-  private final File _inputSegment;
+
+  private final List<RecordReader> _recordReaders;
   private final File _mapperOutputDir;
 
-  private final String _mapperId;
-  private final Schema _avroSchema;
-  private final RecordTransformer _recordTransformer;
-  private final RecordFilter _recordFilter;
-  private final int _numPartitioners;
-  private final List<Partitioner> _partitioners = new ArrayList<>();
-  private final Map<String, DataFileWriter<GenericData.Record>> _partitionToDataFileWriterMap = new HashMap<>();
+  private final List<FieldSpec> _fieldSpecs;
+  private final boolean _includeNullFields;
 
-  public SegmentMapper(String mapperId, File inputSegment, SegmentMapperConfig mapperConfig, File mapperOutputDir) {
-    _inputSegment = inputSegment;
+  // TODO: Merge the following transformers into one. Currently we need an extra DataTypeTransformer in the end in case
+  //       _recordTransformer changes the data type.
+  private final CompositeTransformer _defaultRecordTransformer;
+  private final RecordFilter _recordFilter;
+  private final RecordTransformer _recordTransformer;
+  private final DataTypeTransformer _dataTypeTransformer;
+
+  private final List<Partitioner> _partitioners = new ArrayList<>();
+  private final Map<String, GenericRowFileManager> _partitionToFileManagerMap = new HashMap<>();
+
+  public SegmentMapper(List<RecordReader> recordReaders, SegmentMapperConfig mapperConfig, File mapperOutputDir) {
+    _recordReaders = recordReaders;
     _mapperOutputDir = mapperOutputDir;
 
-    _mapperId = mapperId;
-    _avroSchema = SegmentProcessorAvroUtils.convertPinotSchemaToAvroSchema(mapperConfig.getPinotSchema());
+    TableConfig tableConfig = mapperConfig.getTableConfig();
+    Schema schema = mapperConfig.getSchema();
+    List<String> sortOrder = tableConfig.getIndexingConfig().getSortedColumn();
+    if (CollectionUtils.isNotEmpty(sortOrder)) {
+      _fieldSpecs = SegmentProcessingUtils.getFieldSpecs(schema, sortOrder);
+    } else {
+      _fieldSpecs = SegmentProcessingUtils.getFieldSpecs(schema);
+    }
+    _includeNullFields = tableConfig.getIndexingConfig().isNullHandlingEnabled();
+    _defaultRecordTransformer = CompositeTransformer.getDefaultTransformer(tableConfig, schema);
     _recordFilter = RecordFilterFactory.getRecordFilter(mapperConfig.getRecordFilterConfig());
     _recordTransformer = RecordTransformerFactory.getRecordTransformer(mapperConfig.getRecordTransformerConfig());
+    _dataTypeTransformer = new DataTypeTransformer(schema);
     for (PartitionerConfig partitionerConfig : mapperConfig.getPartitionerConfigs()) {
       _partitioners.add(PartitionerFactory.getPartitioner(partitionerConfig));
     }
-    _numPartitioners = _partitioners.size();
     LOGGER.info(
-        "Initialized mapper with id: {}, input segment: {}, output dir: {}, recordTransformer: {}, recordFilter: {}, partitioners: {}",
-        _mapperId, _inputSegment, _mapperOutputDir, _recordTransformer.getClass(), _recordFilter.getClass(),
+        "Initialized mapper with {} record readers, output dir: {}, recordTransformer: {}, recordFilter: {}, partitioners: {}",
+        _recordReaders.size(), _mapperOutputDir, _recordTransformer.getClass(), _recordFilter.getClass(),
         _partitioners.stream().map(p -> p.getClass().toString()).collect(Collectors.joining(",")));
   }
 
@@ -90,63 +107,65 @@ public class SegmentMapper {
    * Reads the input segment and generates partitioned avro data files into the mapper output directory
    * Records for each partition are put into a directory of its own withing the mapper output directory, identified by the partition name
    */
-  public void map()
+  public Map<String, GenericRowFileManager> map()
       throws Exception {
+    GenericRow reuse = new GenericRow();
+    for (RecordReader recordReader : _recordReaders) {
+      while (recordReader.hasNext()) {
+        reuse = recordReader.next(reuse);
 
-    PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(_inputSegment);
-    GenericRow reusableRow = new GenericRow();
-    GenericData.Record reusableRecord = new GenericData.Record(_avroSchema);
-    String[] partitions = new String[_numPartitioners];
+        // TODO: Add ComplexTypeTransformer here. Currently it is not idempotent so cannot add it
 
-    while (segmentRecordReader.hasNext()) {
-      reusableRow = segmentRecordReader.next(reusableRow);
-
-      // Record filtering
-      if (_recordFilter.filter(reusableRow)) {
-        continue;
-      }
-
-      // Record transformation
-      reusableRow = _recordTransformer.transformRecord(reusableRow);
-
-      // Partitioning
-      int p = 0;
-      for (Partitioner partitioner : _partitioners) {
-        partitions[p++] = partitioner.getPartition(reusableRow);
-      }
-      String partition = StringUtil.join("_", partitions);
-
-      // Create writer for the partition, if not exists
-      DataFileWriter<GenericData.Record> recordWriter = _partitionToDataFileWriterMap.get(partition);
-      if (recordWriter == null) {
-        File partDir = new File(_mapperOutputDir, partition);
-        if (!partDir.exists()) {
-          Files.createDirectory(Paths.get(partDir.getAbsolutePath()));
+        if (reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY) != null) {
+          //noinspection unchecked
+          for (GenericRow row : (Collection<GenericRow>) reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
+            GenericRow transformedRow = _defaultRecordTransformer.transform(row);
+            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow) && !_recordFilter
+                .filter(transformedRow)) {
+              writeRecord(transformedRow);
+            }
+          }
+        } else {
+          GenericRow transformedRow = _defaultRecordTransformer.transform(reuse);
+          if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow) && !_recordFilter
+              .filter(transformedRow)) {
+            writeRecord(transformedRow);
+          }
         }
-        recordWriter = new DataFileWriter<>(new GenericDatumWriter<>(_avroSchema));
-        recordWriter.create(_avroSchema, new File(partDir, createMapperOutputFileName(_mapperId)));
-        _partitionToDataFileWriterMap.put(partition, recordWriter);
+
+        reuse.clear();
       }
-
-      // Write record to avro file for its partition
-      SegmentProcessorAvroUtils.convertGenericRowToAvroRecord(reusableRow, reusableRecord);
-      recordWriter.append(reusableRecord);
-
-      reusableRow.clear();
     }
+
+    for (GenericRowFileManager fileManager : _partitionToFileManagerMap.values()) {
+      fileManager.closeFileWriter();
+    }
+
+    return _partitionToFileManagerMap;
   }
 
-  /**
-   * Cleanup the mapper state
-   */
-  public void cleanup()
+  private void writeRecord(GenericRow row)
       throws IOException {
-    for (DataFileWriter<GenericData.Record> recordDataFileWriter : _partitionToDataFileWriterMap.values()) {
-      recordDataFileWriter.close();
-    }
-  }
+    // Record transformation
+    row = _dataTypeTransformer.transform(_recordTransformer.transformRecord(row));
 
-  public static String createMapperOutputFileName(String mapperId) {
-    return "mapper_" + mapperId + ".avro";
+    // Partitioning
+    int numPartitioners = _partitioners.size();
+    String[] partitions = new String[numPartitioners];
+    for (int i = 0; i < numPartitioners; i++) {
+      partitions[i] = _partitioners.get(i).getPartition(row);
+    }
+    String partition = StringUtil.join("_", partitions);
+
+    // Create writer for the partition if not exists
+    GenericRowFileManager fileManager = _partitionToFileManagerMap.get(partition);
+    if (fileManager == null) {
+      File partitionOutputDir = new File(_mapperOutputDir, partition);
+      FileUtils.forceMkdir(partitionOutputDir);
+      fileManager = new GenericRowFileManager(partitionOutputDir, _fieldSpecs, _includeNullFields);
+      _partitionToFileManagerMap.put(partition, fileManager);
+    }
+
+    fileManager.getFileWriter().write(row);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -29,25 +30,30 @@ import org.apache.pinot.spi.data.Schema;
  * Config for the mapper phase of SegmentProcessorFramework
  */
 public class SegmentMapperConfig {
-
-  private final Schema _pinotSchema;
+  private final TableConfig _tableConfig;
+  private final Schema _schema;
   private final RecordTransformerConfig _recordTransformerConfig;
   private final RecordFilterConfig _recordFilterConfig;
   private final List<PartitionerConfig> _partitionerConfigs;
 
-  public SegmentMapperConfig(Schema pinotSchema, RecordTransformerConfig recordTransformerConfig,
+  public SegmentMapperConfig(TableConfig tableConfig, Schema schema, RecordTransformerConfig recordTransformerConfig,
       RecordFilterConfig recordFilterConfig, List<PartitionerConfig> partitionerConfigs) {
-    _pinotSchema = pinotSchema;
+    _tableConfig = tableConfig;
+    _schema = schema;
     _recordTransformerConfig = recordTransformerConfig;
     _recordFilterConfig = recordFilterConfig;
     _partitionerConfigs = partitionerConfigs;
   }
 
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
   /**
    * The Pinot schema
    */
-  public Schema getPinotSchema() {
-    return _pinotSchema;
+  public Schema getSchema() {
+    return _schema;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileManager.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.genericrow;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * Manager for generic row files.
+ */
+public class GenericRowFileManager {
+  public static final String OFFSET_FILE_NAME = "record.offset";
+  public static final String DATA_FILE_NAME = "record.data";
+
+  private final File _offsetFile;
+  private final File _dataFile;
+  private final List<FieldSpec> _fieldSpecs;
+  private final boolean _includeNullFields;
+
+  private GenericRowFileWriter _fileWriter;
+  private GenericRowFileReader _fileReader;
+
+  public GenericRowFileManager(File outputDir, List<FieldSpec> fieldSpecs, boolean includeNullFields) {
+    _offsetFile = new File(outputDir, OFFSET_FILE_NAME);
+    _dataFile = new File(outputDir, DATA_FILE_NAME);
+    _fieldSpecs = fieldSpecs;
+    _includeNullFields = includeNullFields;
+  }
+
+  /**
+   * Returns the file writer. Creates one if not exists.
+   */
+  public GenericRowFileWriter getFileWriter()
+      throws IOException {
+    if (_fileWriter == null) {
+      Preconditions.checkState(!_offsetFile.exists(), "Record offset file: %s already exists", _offsetFile);
+      Preconditions.checkState(!_dataFile.exists(), "Record data file: %s already exists", _dataFile);
+      _fileWriter = new GenericRowFileWriter(_offsetFile, _dataFile, _fieldSpecs, _includeNullFields);
+    }
+    return _fileWriter;
+  }
+
+  /**
+   * Closes the file writer.
+   */
+  public void closeFileWriter()
+      throws IOException {
+    if (_fileWriter != null) {
+      _fileWriter.close();
+      _fileWriter = null;
+    }
+  }
+
+  /**
+   * Returns the file reader. Creates one if not exists.
+   */
+  public GenericRowFileReader getFileReader()
+      throws IOException {
+    if (_fileReader == null) {
+      Preconditions.checkState(_offsetFile.exists(), "Record offset file: %s does not exist", _offsetFile);
+      Preconditions.checkState(_dataFile.exists(), "Record data file: %s does not exist", _dataFile);
+      _fileReader = new GenericRowFileReader(_offsetFile, _dataFile, _fieldSpecs, _includeNullFields);
+    }
+    return _fileReader;
+  }
+
+  /**
+   * Closes the file reader.
+   */
+  public void closeFileReader()
+      throws IOException {
+    if (_fileReader != null) {
+      _fileReader.close();
+      _fileReader = null;
+    }
+  }
+
+  /**
+   * Cleans up the files.
+   */
+  public void cleanUp()
+      throws IOException {
+    closeFileWriter();
+    closeFileReader();
+    FileUtils.deleteQuietly(_offsetFile);
+    FileUtils.deleteQuietly(_dataFile);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileReader.java
@@ -60,8 +60,7 @@ public class GenericRowFileReader implements Closeable {
    */
   public GenericRow read(int rowId, GenericRow reuse) {
     long offset = _offsetBuffer.getLong((long) rowId << 3); // rowId * Long.BYTES
-    _deserializer.deserialize(offset, reuse);
-    return reuse;
+    return _deserializer.deserialize(offset, reuse);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessingUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessingUtils.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.utils;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class SegmentProcessingUtils {
+  private SegmentProcessingUtils() {
+  }
+
+  /**
+   * Returns the field specs with the names sorted in alphabetical order.
+   */
+  public static List<FieldSpec> getFieldSpecs(Schema schema) {
+    List<FieldSpec> fieldSpecs = new ArrayList<>();
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn()) {
+        fieldSpecs.add(fieldSpec);
+      }
+    }
+    fieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
+    return fieldSpecs;
+  }
+
+  /**
+   * Returns the field specs with sorted column in the front, followed by other columns sorted in alphabetical order.
+   */
+  public static List<FieldSpec> getFieldSpecs(Schema schema, List<String> sortOrder) {
+    List<FieldSpec> fieldSpecs = new ArrayList<>();
+    for (String sortColumn : sortOrder) {
+      FieldSpec fieldSpec = schema.getFieldSpecFor(sortColumn);
+      Preconditions.checkArgument(fieldSpec != null, "Failed to find sort column: %s", sortColumn);
+      Preconditions.checkArgument(fieldSpec.isSingleValueField(), "Cannot sort on MV column: %s", sortColumn);
+      fieldSpecs.add(fieldSpec);
+    }
+
+    List<FieldSpec> nonSortFieldSpecs = new ArrayList<>();
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn() && !sortOrder.contains(fieldSpec.getName())) {
+        nonSortFieldSpecs.add(fieldSpec);
+      }
+    }
+    nonSortFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
+
+    fieldSpecs.addAll(nonSortFieldSpecs);
+    return fieldSpecs;
+  }
+
+  /**
+   * Returns the value comparator based on the sort order.
+   */
+  public static SortOrderComparator getSortOrderComparator(List<FieldSpec> fieldSpecs, int numSortColumns) {
+    DataType[] sortColumnStoredTypes = new DataType[numSortColumns];
+    for (int i = 0; i < numSortColumns; i++) {
+      sortColumnStoredTypes[i] = fieldSpecs.get(i).getDataType().getStoredType();
+    }
+    return new SortOrderComparator(numSortColumns, sortColumnStoredTypes);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessingUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessingUtils.java
@@ -27,12 +27,12 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 
 
-public class SegmentProcessingUtils {
+public final class SegmentProcessingUtils {
   private SegmentProcessingUtils() {
   }
 
   /**
-   * Returns the field specs with the names sorted in alphabetical order.
+   * Returns the field specs (physical only) with the names sorted in alphabetical order.
    */
   public static List<FieldSpec> getFieldSpecs(Schema schema) {
     List<FieldSpec> fieldSpecs = new ArrayList<>();
@@ -46,7 +46,8 @@ public class SegmentProcessingUtils {
   }
 
   /**
-   * Returns the field specs with sorted column in the front, followed by other columns sorted in alphabetical order.
+   * Returns the field specs (physical only) with sorted column in the front, followed by other columns sorted in
+   * alphabetical order.
    */
   public static List<FieldSpec> getFieldSpecs(Schema schema, List<String> sortOrder) {
     List<FieldSpec> fieldSpecs = new ArrayList<>();
@@ -54,6 +55,7 @@ public class SegmentProcessingUtils {
       FieldSpec fieldSpec = schema.getFieldSpecFor(sortColumn);
       Preconditions.checkArgument(fieldSpec != null, "Failed to find sort column: %s", sortColumn);
       Preconditions.checkArgument(fieldSpec.isSingleValueField(), "Cannot sort on MV column: %s", sortColumn);
+      Preconditions.checkArgument(!fieldSpec.isVirtualColumn(), "Cannot sort on virtual column: %s", sortColumn);
       fieldSpecs.add(fieldSpec);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SortOrderComparator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SortOrderComparator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.segment.processing.collector;
+package org.apache.pinot.core.segment.processing.utils;
 
 import java.util.Comparator;
 import org.apache.pinot.spi.data.FieldSpec.DataType;

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.segment.processing.framework;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,12 +31,14 @@ import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterConfig;
 import org.apache.pinot.core.segment.processing.filter.RecordFilterFactory;
+import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager;
+import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileReader;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerFactory;
 import org.apache.pinot.core.segment.processing.transformer.RecordTransformerConfig;
-import org.apache.pinot.plugin.inputformat.avro.AvroRecordReader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -50,6 +54,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -57,39 +62,42 @@ import static org.testng.Assert.assertTrue;
  * Tests for {@link SegmentMapper}
  */
 public class SegmentMapperTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "SegmentMapperTest");
 
-  private File _baseDir;
-  private File _inputSegment;
-  private Schema _pinotSchema;
-  private final List<Object[]> _rawData = Lists
-      .newArrayList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{"pqr", 2000, 1597773600000L},
+  private final TableConfig _tableConfig =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTimeColumnName("timeValue")
+          .setNullHandlingEnabled(true).build();
+  private final Schema _schema = new Schema.SchemaBuilder().setSchemaName("myTable")
+      .addSingleValueDimension("campaign", FieldSpec.DataType.STRING, "xyz").addMetric("clicks", FieldSpec.DataType.INT)
+      .addDateTime("timeValue", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+  private final List<Object[]> _rawData = Arrays
+      .asList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{"pqr", 2000, 1597773600000L},
           new Object[]{"abc", 1000, 1597777200000L}, new Object[]{"abc", 4000, 1597795200000L},
           new Object[]{"abc", 3000, 1597802400000L}, new Object[]{"pqr", 1000, 1597838400000L},
-          new Object[]{"xyz", 4000, 1597856400000L}, new Object[]{"pqr", 1000, 1597878000000L},
-          new Object[]{"abc", 7000, 1597881600000L}, new Object[]{"xyz", 6000, 1597892400000L});
+          new Object[]{null, 4000, 1597856400000L}, new Object[]{"pqr", 1000, 1597878000000L},
+          new Object[]{"abc", 7000, 1597881600000L}, new Object[]{null, 6000, 1597892400000L});
+
+  private File _indexDir;
 
   @BeforeClass
-  public void before()
+  public void setUp()
       throws Exception {
-    _baseDir = new File(FileUtils.getTempDirectory(), "segment_mapper_test_" + System.currentTimeMillis());
-    FileUtils.deleteQuietly(_baseDir);
-    assertTrue(_baseDir.mkdirs());
+    FileUtils.deleteQuietly(TEMP_DIR);
+    assertTrue(TEMP_DIR.mkdirs());
 
     // Segment directory
-    File inputSegmentDir = new File(_baseDir, "input_segment");
+    File inputSegmentDir = new File(TEMP_DIR, "input_segment");
     assertTrue(inputSegmentDir.mkdirs());
-
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTimeColumnName("timeValue").build();
-    _pinotSchema = new Schema.SchemaBuilder().setSchemaName("mySchema")
-        .addSingleValueDimension("campaign", FieldSpec.DataType.STRING).addMetric("clicks", FieldSpec.DataType.INT)
-        .addDateTime("timeValue", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
 
     // Create test data
     List<GenericRow> inputRows = new ArrayList<>();
     for (Object[] rawRow : _rawData) {
       GenericRow row = new GenericRow();
-      row.putValue("campaign", rawRow[0]);
+      if (rawRow[0] != null) {
+        row.putValue("campaign", rawRow[0]);
+      } else {
+        row.putDefaultNullValue("campaign", "xyz");
+      }
       row.putValue("clicks", rawRow[1]);
       row.putValue("timeValue", rawRow[2]);
       inputRows.add(row);
@@ -97,57 +105,67 @@ public class SegmentMapperTest {
 
     // Create test segment
     RecordReader recordReader = new GenericRowRecordReader(inputRows);
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, _pinotSchema);
-    segmentGeneratorConfig.setTableName(tableConfig.getTableName());
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, _schema);
     segmentGeneratorConfig.setOutDir(inputSegmentDir.getAbsolutePath());
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig, recordReader);
     driver.build();
 
-    assertEquals(inputSegmentDir.listFiles().length, 1);
-    _inputSegment = inputSegmentDir.listFiles()[0];
+    File[] segmentFiles = inputSegmentDir.listFiles();
+    assertTrue(segmentFiles != null && segmentFiles.length == 1);
+    _indexDir = segmentFiles[0];
   }
 
   @Test(dataProvider = "segmentMapperConfigProvider")
-  public void segmentMapperTest(String mapperId, SegmentMapperConfig segmentMapperConfig,
-      Map<String, List<Object[]>> partitionToRecords)
+  public void segmentMapperTest(SegmentMapperConfig segmentMapperConfig, Map<String, List<Object[]>> partitionToRecords)
       throws Exception {
-
-    File mapperOutputDir = new File(_baseDir, "mapper_output");
+    File mapperOutputDir = new File(TEMP_DIR, "mapper_output");
     FileUtils.deleteQuietly(mapperOutputDir);
     assertTrue(mapperOutputDir.mkdirs());
-    SegmentMapper segmentMapper = new SegmentMapper(mapperId, _inputSegment, segmentMapperConfig, mapperOutputDir);
-    segmentMapper.map();
-    segmentMapper.cleanup();
 
-    File[] partitionDirs = mapperOutputDir.listFiles();
-    // as many directories in output as num partitions created + passed filter
-    assertEquals(partitionDirs.length, partitionToRecords.size());
-    for (File partitionDir : partitionDirs) {
-      String partition = partitionDir.getName();
-      // directory named after every partition
-      assertTrue(partitionToRecords.containsKey(partition));
-      // each partition directory has as many files as mapper
-      File[] avroFiles = partitionDir.listFiles();
-      assertEquals(avroFiles.length, 1);
-      assertEquals(avroFiles[0].getName(), SegmentMapper.createMapperOutputFileName(mapperId));
+    PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader();
+    segmentRecordReader.init(_indexDir, null, null, true);
+    SegmentMapper segmentMapper =
+        new SegmentMapper(Collections.singletonList(segmentRecordReader), segmentMapperConfig, mapperOutputDir);
+    Map<String, GenericRowFileManager> partitionToFileManagerMap = segmentMapper.map();
+    segmentRecordReader.close();
 
-      RecordReader avroRecordReader = new AvroRecordReader();
-      avroRecordReader.init(avroFiles[0], _pinotSchema.getColumnNames(), null);
-      int numRecords = 0;
+    assertEquals(partitionToFileManagerMap.size(), partitionToRecords.size());
+    for (Map.Entry<String, GenericRowFileManager> entry : partitionToFileManagerMap.entrySet()) {
+      // Directory named after every partition
+      String partition = entry.getKey();
+      File partitionDir = new File(mapperOutputDir, partition);
+      assertTrue(partitionDir.isDirectory());
+
+      // Each partition directory should contain 2 files (offset & data)
+      String[] fileNames = partitionDir.list();
+      assertNotNull(fileNames);
+      assertEquals(fileNames.length, 2);
+      Arrays.sort(fileNames);
+      assertEquals(fileNames[0], GenericRowFileManager.DATA_FILE_NAME);
+      assertEquals(fileNames[1], GenericRowFileManager.OFFSET_FILE_NAME);
+
+      GenericRowFileManager fileManager = entry.getValue();
+      GenericRowFileReader fileReader = fileManager.getFileReader();
+      int numRows = fileReader.getNumRows();
       List<Object[]> expectedRecords = partitionToRecords.get(partition);
-      GenericRow next = new GenericRow();
-      while (avroRecordReader.hasNext()) {
-        avroRecordReader.next(next);
-        assertEquals(next.getValue("campaign"), expectedRecords.get(numRecords)[0]);
-        assertEquals(next.getValue("clicks"), expectedRecords.get(numRecords)[1]);
-        assertEquals(next.getValue("timeValue"), expectedRecords.get(numRecords)[2]);
-        numRecords++;
+      assertEquals(numRows, expectedRecords.size());
+      GenericRow reuse = new GenericRow();
+      for (int i = 0; i < numRows; i++) {
+        reuse = fileReader.read(i, reuse);
+        Object[] expectedValues = expectedRecords.get(i);
+        assertEquals(reuse.getValue("campaign"), expectedValues[0]);
+        assertEquals(reuse.getValue("clicks"), expectedValues[1]);
+        assertEquals(reuse.getValue("timeValue"), expectedValues[2]);
+        // Default null value
+        if (expectedValues[0].equals("xyz")) {
+          assertEquals(reuse.getNullValueFields(), Collections.singleton("campaign"));
+        } else {
+          assertEquals(reuse.getNullValueFields(), Collections.emptySet());
+        }
       }
-      assertEquals(numRecords, expectedRecords.size());
+      fileManager.cleanUp();
     }
-
-    FileUtils.deleteQuietly(mapperOutputDir);
   }
 
   /**
@@ -155,139 +173,152 @@ public class SegmentMapperTest {
    */
   @DataProvider(name = "segmentMapperConfigProvider")
   public Object[][] segmentMapperConfigProvider() {
-    String mapperId = "aMapperId";
-    List<Object[]> outputData = new ArrayList<>();
-    _rawData.forEach(r -> outputData.add(new Object[]{r[0], r[1], r[2]}));
+    List<Object[]> outputData = Arrays
+        .asList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{"pqr", 2000, 1597773600000L},
+            new Object[]{"abc", 1000, 1597777200000L}, new Object[]{"abc", 4000, 1597795200000L},
+            new Object[]{"abc", 3000, 1597802400000L}, new Object[]{"pqr", 1000, 1597838400000L},
+            new Object[]{"xyz", 4000, 1597856400000L}, new Object[]{"pqr", 1000, 1597878000000L},
+            new Object[]{"abc", 7000, 1597881600000L}, new Object[]{"xyz", 6000, 1597892400000L});
 
     List<Object[]> inputs = new ArrayList<>();
 
     // default configs
-    SegmentMapperConfig config1 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
+    SegmentMapperConfig config1 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords1 = new HashMap<>();
     expectedRecords1.put("0", outputData);
-    inputs.add(new Object[]{mapperId, config1, expectedRecords1});
+    inputs.add(new Object[]{config1, expectedRecords1});
 
     // round robin partitioner
-    SegmentMapperConfig config12 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.ROUND_ROBIN)
-            .setNumPartitions(3).build()));
+    SegmentMapperConfig config12 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.ROUND_ROBIN)
+                .setNumPartitions(3).build()));
     Map<String, List<Object[]>> expectedRecords12 = new HashMap<>();
     IntStream.range(0, 3).forEach(i -> expectedRecords12.put(String.valueOf(i), new ArrayList<>()));
     for (int i = 0; i < outputData.size(); i++) {
       expectedRecords12.get(String.valueOf(i % 3)).add(outputData.get(i));
     }
-    inputs.add(new Object[]{mapperId, config12, expectedRecords12});
+    inputs.add(new Object[]{config12, expectedRecords12});
 
     // partition by timeValue
-    SegmentMapperConfig config2 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("timeValue").build()));
+    SegmentMapperConfig config2 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
+                .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords2 =
         outputData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[2]), Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config2, expectedRecords2});
+    inputs.add(new Object[]{config2, expectedRecords2});
 
     // partition by campaign
-    SegmentMapperConfig config3 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("campaign").build()));
+    SegmentMapperConfig config3 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
+                .setColumnName("campaign").build()));
     Map<String, List<Object[]>> expectedRecords3 =
         outputData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[0]), Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config3, expectedRecords3});
+    inputs.add(new Object[]{config3, expectedRecords3});
 
     // transform function partition
-    SegmentMapperConfig config4 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
-            .setTransformFunction("toEpochDays(timeValue)").build()));
+    SegmentMapperConfig config4 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
+                .setTransformFunction("toEpochDays(timeValue)").build()));
     Map<String, List<Object[]>> expectedRecords4 = outputData.stream()
         .collect(Collectors.groupingBy(r -> String.valueOf(((long) r[2]) / 86400000), Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config4, expectedRecords4});
+    inputs.add(new Object[]{config4, expectedRecords4});
 
     // partition by column and then table column partition config
-    SegmentMapperConfig config41 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("campaign").build(),
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TABLE_PARTITION_CONFIG)
-            .setColumnName("clicks").setColumnPartitionConfig(new ColumnPartitionConfig("Modulo", 3)).build()));
+    SegmentMapperConfig config41 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().build(), Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
+                .setColumnName("campaign").build(), new PartitionerConfig.Builder()
+                .setPartitionerType(PartitionerFactory.PartitionerType.TABLE_PARTITION_CONFIG).setColumnName("clicks")
+                .setColumnPartitionConfig(new ColumnPartitionConfig("Modulo", 3)).build()));
     Map<String, List<Object[]>> expectedRecords41 = new HashMap<>();
     for (Object[] record : outputData) {
       String partition = record[0] + "_" + (int) record[1] % 3;
       List<Object[]> objects = expectedRecords41.computeIfAbsent(partition, k -> new ArrayList<>());
       objects.add(record);
     }
-    inputs.add(new Object[]{mapperId, config41, expectedRecords41});
+    inputs.add(new Object[]{config41, expectedRecords41});
 
     // filter function which filters out nothing
-    SegmentMapperConfig config5 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({campaign == \"foo\"}, campaign)").build(),
-        Lists.newArrayList(new PartitionerConfig.Builder().build()));
+    SegmentMapperConfig config5 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
+                .setFilterFunction("Groovy({campaign == \"foo\"}, campaign)").build(),
+            Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords5 = new HashMap<>();
     expectedRecords5.put("0", outputData);
-    inputs.add(new Object[]{mapperId, config5, expectedRecords5});
+    inputs.add(new Object[]{config5, expectedRecords5});
 
     // filter function which filters out everything
-    SegmentMapperConfig config6 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue > 0}, timeValue)").build(),
-        Lists.newArrayList(new PartitionerConfig.Builder().build()));
+    SegmentMapperConfig config6 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
+                .setFilterFunction("Groovy({timeValue > 0}, timeValue)").build(),
+            Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords6 = new HashMap<>();
-    inputs.add(new Object[]{mapperId, config6, expectedRecords6});
+    inputs.add(new Object[]{config6, expectedRecords6});
 
     // filter function which filters out certain times
-    SegmentMapperConfig config7 = new SegmentMapperConfig(_pinotSchema, new RecordTransformerConfig.Builder().build(),
-        new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue < 1597795200000L || timeValue >= 1597881600000L}, timeValue)")
-            .build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
+    SegmentMapperConfig config7 =
+        new SegmentMapperConfig(_tableConfig, _schema, new RecordTransformerConfig.Builder().build(),
+            new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
+                .setFilterFunction("Groovy({timeValue < 1597795200000L || timeValue >= 1597881600000L}, timeValue)")
+                .build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     Map<String, List<Object[]>> expectedRecords7 =
         outputData.stream().filter(r -> ((long) r[2]) >= 1597795200000L && ((long) r[2]) < 1597881600000L)
             .collect(Collectors.groupingBy(r -> "0", Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config7, expectedRecords7});
+    inputs.add(new Object[]{config7, expectedRecords7});
 
     // record transformation - round timeValue to nearest day
     Map<String, String> transformFunctionMap = new HashMap<>();
     transformFunctionMap.put("timeValue", "round(timeValue, 86400000)");
-    SegmentMapperConfig config9 = new SegmentMapperConfig(_pinotSchema,
+    SegmentMapperConfig config9 = new SegmentMapperConfig(_tableConfig, _schema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
         new RecordFilterConfig.Builder().build(), Lists.newArrayList(new PartitionerConfig.Builder().build()));
     List<Object[]> transformedData = new ArrayList<>();
     outputData.forEach(r -> transformedData.add(new Object[]{r[0], r[1], (((long) r[2]) / 86400000) * 86400000}));
     Map<String, List<Object[]>> expectedRecords9 = new HashMap<>();
     expectedRecords9.put("0", transformedData);
-    inputs.add(new Object[]{mapperId, config9, expectedRecords9});
+    inputs.add(new Object[]{config9, expectedRecords9});
 
     // record transformation - round timeValue to nearest day, partition on timeValue
-    SegmentMapperConfig config10 = new SegmentMapperConfig(_pinotSchema,
+    SegmentMapperConfig config10 = new SegmentMapperConfig(_tableConfig, _schema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
         new RecordFilterConfig.Builder().build(), Lists.newArrayList(
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
             .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords10 =
         transformedData.stream().collect(Collectors.groupingBy(r -> String.valueOf(r[2]), Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config10, expectedRecords10});
+    inputs.add(new Object[]{config10, expectedRecords10});
 
     // record transformation - round timeValue to nearest day, partition on timeValue, filter out timeValues
-    SegmentMapperConfig config11 = new SegmentMapperConfig(_pinotSchema,
+    SegmentMapperConfig config11 = new SegmentMapperConfig(_tableConfig, _schema,
         new RecordTransformerConfig.Builder().setTransformFunctionsMap(transformFunctionMap).build(),
         new RecordFilterConfig.Builder().setRecordFilterType(RecordFilterFactory.RecordFilterType.FILTER_FUNCTION)
-            .setFilterFunction("Groovy({timeValue < 1597795200000L|| timeValue >= 1597881600000}, timeValue)").build(), Lists.newArrayList(
-        new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
-            .setColumnName("timeValue").build()));
+            .setFilterFunction("Groovy({timeValue < 1597795200000L|| timeValue >= 1597881600000}, timeValue)").build(),
+        Lists.newArrayList(
+            new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.COLUMN_VALUE)
+                .setColumnName("timeValue").build()));
     Map<String, List<Object[]>> expectedRecords11 =
         transformedData.stream().filter(r -> ((long) r[2]) == 1597795200000L)
             .collect(Collectors.groupingBy(r -> "1597795200000", Collectors.toList()));
-    inputs.add(new Object[]{mapperId, config11, expectedRecords11});
+    inputs.add(new Object[]{config11, expectedRecords11});
 
     return inputs.toArray(new Object[0][]);
   }
 
   @AfterClass
-  public void after() {
-    FileUtils.deleteQuietly(_baseDir);
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
   }
 }


### PR DESCRIPTION
Produce GenericRow file instead of Avro file in segment processing mapper:
- To preserve the null value info from the source file
- Apply default record transformation to solve the NPE described in #6902
- GenericRow file can be random accessed, which can be used directly as the record reader

Add `GenericRowFileManager` to wrap the file reader/writer and related arguments to simplify the handling.
Also modify the `SegmentMapperTest` to ensure the null value info can be preserved