### PR TITLE
Resolve bug in HelixServerStarter for populating environment property…

### DIFF
--- a/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
+++ b/pinot-plugins/pinot-environment/pinot-azure/src/main/java/org/apache/pinot/plugin/provider/AzureEnvironmentProvider.java
@@ -40,8 +40,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -49,12 +47,10 @@ import org.slf4j.LoggerFactory;
  */
 public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(AzureEnvironmentProvider.class);
-
   protected static final String MAX_RETRY = "maxRetry";
   protected static final String IMDS_ENDPOINT = "imdsEndpoint";
-  protected static final String CONNECTION_TIMEOUT = "connectionTimeout";
-  protected static final String REQUEST_TIMEOUT = "requestTimeout";
+  protected static final String CONNECTION_TIMEOUT_MILLIS = "connectionTimeoutMillis";
+  protected static final String REQUEST_TIMEOUT_MILLIS = "requestTimeoutMillis";
   private static final String COMPUTE = "compute";
   private static final String METADATA = "Metadata";
   private static final String PLATFORM_FAULT_DOMAIN = "platformFaultDomain";
@@ -73,12 +69,12 @@ public class AzureEnvironmentProvider implements PinotEnvironmentProvider {
 
     _maxRetry = Integer.parseInt(pinotConfiguration.getProperty(MAX_RETRY));
     _imdsEndpoint = pinotConfiguration.getProperty(IMDS_ENDPOINT);
-    int connectionTimeout = Integer.parseInt(pinotConfiguration.getProperty(CONNECTION_TIMEOUT));
-    int requestTimeout = Integer.parseInt(pinotConfiguration.getProperty(REQUEST_TIMEOUT));
+    int connectionTimeoutMillis = Integer.parseInt(pinotConfiguration.getProperty(CONNECTION_TIMEOUT_MILLIS));
+    int requestTimeoutMillis = Integer.parseInt(pinotConfiguration.getProperty(REQUEST_TIMEOUT_MILLIS));
 
     final RequestConfig requestConfig = RequestConfig.custom()
-        .setConnectTimeout(connectionTimeout)
-        .setConnectionRequestTimeout(requestTimeout)
+        .setConnectTimeout(connectionTimeoutMillis)
+        .setConnectionRequestTimeout(requestTimeoutMillis)
         .build();
 
     final HttpRequestRetryHandler httpRequestRetryHandler = (iOException, executionCount, httpContext) ->

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -303,7 +303,7 @@ public class HelixServerStarter implements ServiceStartable {
       Map<String, String> existingEnvironmentConfigsMap = instanceConfig.getRecord().getMapField(
           CommonConstants.ENVIRONMENT_IDENTIFIER);
 
-      if (existingEnvironmentConfigsMap != null && !existingEnvironmentConfigsMap.equals(environmentProperties)) {
+      if (existingEnvironmentConfigsMap == null || !existingEnvironmentConfigsMap.equals(environmentProperties)) {
         instanceConfig.getRecord().setMapField(CommonConstants.ENVIRONMENT_IDENTIFIER, environmentProperties);
         LOGGER.info("Adding environment properties: {} for instance: {}", environmentProperties, _instanceId);
         needToUpdateInstanceConfig = true;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -31,8 +31,8 @@ public class PinotEnvironmentProviderFactoryTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("class.test", PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider.class.getName());
     properties.put("test.maxRetry", "3");
-    properties.put("test.connectionTimeout", "100");
-    properties.put("test.requestTimeout", "100");
+    properties.put("test.connectionTimeoutMillis", "100");
+    properties.put("test.requestTimeoutMillis", "100");
     PinotEnvironmentProviderFactory.init(new PinotConfiguration(properties));
 
     PinotEnvironmentProvider testPinotEnvironment = PinotEnvironmentProviderFactory.getEnvironmentProvider("test");
@@ -42,9 +42,9 @@ public class PinotEnvironmentProviderFactoryTest {
     Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
         testPinotEnvironment).getConfiguration().getProperty("maxRetry"), "3");
     Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getConfiguration().getProperty("connectionTimeout"), "100");
+        testPinotEnvironment).getConfiguration().getProperty("connectionTimeoutMillis"), "100");
     Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getConfiguration().getProperty("requestTimeout"), "100");
+        testPinotEnvironment).getConfiguration().getProperty("requestTimeoutMillis"), "100");
   }
 
   public static class TestEnvironmentProvider implements PinotEnvironmentProvider {


### PR DESCRIPTION
… map field and rename timeout variables to follow timeunit convention

## Description
There was a bug in the HelixServerStarter code which would prevent us to update zookeeper node's mapFields with correct environment properties. Secondly, changed the AzureEnvironmentProvider variable names to include time units as suffix for better readability and debuggability. 

Previous Wrong Syntax:
```
Map<String, String> existingEnvironmentConfigsMap = instanceConfig.getRecord().getMapField(
          CommonConstants.ENVIRONMENT_IDENTIFIER);
if (existingEnvironmentConfigsMap != null && !existingEnvironmentConfigsMap.equals(environmentProperties)) {
  do Something......
}
```
The above check would prevent us to add values to mapFields for environment key if it not already present.

Corrected Syntax:
```
Map<String, String> existingEnvironmentConfigsMap = instanceConfig.getRecord().getMapField(
          CommonConstants.ENVIRONMENT_IDENTIFIER);
if (existingEnvironmentConfigsMap == null || !existingEnvironmentConfigsMap.equals(environmentProperties)) { 
  do Something......
}

```
The corrected check will resolve the bug shown in the faulty syntax and will update mapFields for environment key when it is not present in the map as well as when the value set has a mismatch.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options

* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation

![Screen Shot 2021-06-03 at 3 24 06 PM](https://user-images.githubusercontent.com/8770850/120719873-e3ff9280-c47f-11eb-90a6-562e88f875cf.png)
