### PR TITLE
Move KafkaJsonDecoder code to pinot-json

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 /**
  * An implementation of StreamMessageDecoder to read JSON records from a stream.
  */
-public class StreamJSONMessageDecoder implements StreamMessageDecoder<byte[]> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StreamJSONMessageDecoder.class);
+public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JSONMessageDecoder.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String JSON_RECORD_EXTRACTOR_CLASS =
       "org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor";

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/StreamJSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/StreamJSONMessageDecoder.java
@@ -1,0 +1,61 @@
+package org.apache.pinot.plugin.inputformat.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordExtractor;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of StreamMessageDecoder to read JSON records from a stream.
+ */
+public class StreamJSONMessageDecoder implements StreamMessageDecoder<byte[]> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamJSONMessageDecoder.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String JSON_RECORD_EXTRACTOR_CLASS =
+      "org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor";
+
+  private RecordExtractor<Map<String, Object>> _jsonRecordExtractor;
+
+  @Override
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+      throws Exception {
+    String recordExtractorClass = null;
+    if (props != null) {
+      recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
+    }
+    if (recordExtractorClass == null) {
+      recordExtractorClass = JSON_RECORD_EXTRACTOR_CLASS;
+    }
+    _jsonRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
+    _jsonRecordExtractor.init(fieldsToRead, null);
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, GenericRow destination) {
+    try {
+      JsonNode message = JsonUtils.bytesToJsonNode(payload);
+      Map<String, Object> from = OBJECT_MAPPER.convertValue(message, new TypeReference<Map<String, Object>>() {
+      });
+      _jsonRecordExtractor.extract(from, destination);
+      return destination;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
+      return null;
+    }
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/StreamJSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/StreamJSONMessageDecoder.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.plugin.inputformat.json;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -42,7 +42,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-json</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
@@ -18,62 +18,13 @@
  */
 package org.apache.pinot.plugin.stream.kafka;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.RecordExtractor;
-import org.apache.pinot.spi.plugin.PluginManager;
-import org.apache.pinot.spi.stream.StreamMessageDecoder;
-import org.apache.pinot.spi.utils.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder;
 
 
 /**
- * An implementation of StreamMessageDecoder to read JSON records from a stream.
+ * This class has been kept for backward compatability. Use @see `org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder` for future use cases.
  */
-public class KafkaJSONMessageDecoder implements StreamMessageDecoder<byte[]> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaJSONMessageDecoder.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final String JSON_RECORD_EXTRACTOR_CLASS =
-      "org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor";
+public class KafkaJSONMessageDecoder extends StreamJSONMessageDecoder {
 
-  private RecordExtractor<Map<String, Object>> _jsonRecordExtractor;
-
-  @Override
-  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
-      throws Exception {
-    String recordExtractorClass = null;
-    if (props != null) {
-      recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
-    }
-    if (recordExtractorClass == null) {
-      recordExtractorClass = JSON_RECORD_EXTRACTOR_CLASS;
-    }
-    _jsonRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
-    _jsonRecordExtractor.init(fieldsToRead, null);
-  }
-
-  @Override
-  public GenericRow decode(byte[] payload, GenericRow destination) {
-    try {
-      JsonNode message = JsonUtils.bytesToJsonNode(payload);
-      Map<String, Object> from = OBJECT_MAPPER.convertValue(message, new TypeReference<Map<String, Object>>() {
-      });
-      _jsonRecordExtractor.extract(from, destination);
-      return destination;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
-      return null;
-    }
-  }
-
-  @Override
-  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
-  }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
@@ -18,13 +18,14 @@
  */
 package org.apache.pinot.plugin.stream.kafka;
 
-
 import org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder;
 
 
 /**
  * This class has been kept for backward compatability. Use @see `org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder` for future use cases.
+ * This class will be removed in a later release.
  */
+@Deprecated
 public class KafkaJSONMessageDecoder extends StreamJSONMessageDecoder {
 
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaJSONMessageDecoder.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.plugin.stream.kafka;
 
-import org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder;
+import org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder;
 
 
 /**
@@ -26,6 +26,6 @@ import org.apache.pinot.plugin.inputformat.json.StreamJSONMessageDecoder;
  * This class will be removed in a later release.
  */
 @Deprecated
-public class KafkaJSONMessageDecoder extends StreamJSONMessageDecoder {
+public class KafkaJSONMessageDecoder extends JSONMessageDecoder {
 
 }


### PR DESCRIPTION
Currently, JSONDecoder for realtime data is present in KafkaJSONMessageDecoder class. However, with new realtime integrations of Kinesis and Pulsar in the pipeline, it doesn't make sense to import kafka-base and use this class for decoding.

The PR moves the decoder to pinot-json package where it should rightfully reside. The KafkaJSONMessageDecoder has been kept as an empty implementation of the new decoder so that it doesn't cause any issues for devs updating the Kafka plugin.


## Release Notes

Move JSON decoder from `pinot-kafka` to `pinot-json` package.  Use class `org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder` instead of `org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder`
