### PR TITLE
Block filter clause not supported during query parsing

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -471,9 +471,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
 
     long startTime = System.currentTimeMillis();
-    // The query below will fail execution due to use of double quotes around value in IN clause.
-    JsonNode queryResponse = postSqlQuery("SELECT count(*) FROM mytable WHERE Dest IN (\"DFW\")");
-    String result = queryResponse.toPrettyString();
+    // The query below will fail execution due to JSON_MATCH on column without json index
+    JsonNode queryResponse = postSqlQuery("SELECT count(*) FROM mytable WHERE JSON_MATCH(Dest, '$=123')");
 
     assertTrue(System.currentTimeMillis() - startTime < queryTimeout);
     assertTrue(queryResponse.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));


### PR DESCRIPTION
During query parsing, block the following filter clause that are not supported:
- Non-literal in IN/NOT_IN/REGEXP_LIKE/TEXT_MATCH/JSON_MATCH predicate (`e.g. country IN (us), country IN ("us")`)
- Unsupported filter kind (`e.g. a like '%b'`)
- Return the invalid filter clause in the exception message for easier debugging