### PR TITLE
Improvements in compat-tester

### DIFF
--- a/compatibility-verifier/README.md
+++ b/compatibility-verifier/README.md
@@ -25,10 +25,21 @@
 
 ### Step 1: checkout source code and build targets for older commit and newer commit
 ```shell
-./compatibility-verifier/checkoutAndBuild.sh -o olderCommit -n newerCommit [-w workingDir]
+Usage: checkoutAndBuild.sh [-o olderCommit] [-n newerCommit] -w workingDir
+  -w, --working-dir                      Working directory where olderCommit and newCommit target files reside
+
+  -o, --old-commit-hash                  git hash (or tag) for old commit
+
+  -n, --new-commit-hash                  git hash (or tag) for new commit
+
+If -n is not specified, then current commit is assumed
+If -o is not specified, then previous commit is assumed (expected -n is also empty)
+Examples:
+    To compare this checkout with previous commit: 'checkoutAndBuild.sh -w /tmp/wd'
+    To compare this checkout with some older tag or hash: 'checkoutAndBuild.sh -o release-0.7.1 -w /tmp/wd'
+    To compare any two previous tags or hashes: 'checkoutAndBuild.sh -o release-0.7.1 -n 637cc3494 -w /tmp/wd
+
 ```
-***NOTE***: `[workingDir]` is optional, if user does not specify `[workingDir]`, the script will create a temporary working 
-dir and output the path, which can be used in step 2.
 
 ### Step 2: run compatibility regression test against the two targets build in step1
 ```shell

--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -18,18 +18,23 @@
 # under the License.
 #
 
-
-# get a temporary directory in case the workingDir is not provided by user
-TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-cmdName=`baseName $0`
-source `dirname $0`/utils.inc
+cmdName=`basename $0`
+cmdDir=`dirname $0`
+source ${cmdDir}/utils.inc
 
 # get usage of the script
 function usage() {
-  echo "Usage: $cmdName -o olderCommit -n newerCommit [-w workingDir]"
+  echo "This command sets up the two builds to test compatibility in the working directory"
+  echo "Usage: $cmdName [-o olderCommit] [-n newerCommit] -w workingDir"
   echo -e "  -w, --working-dir                      Working directory where olderCommit and newCommit target files reside\n"
-  echo -e "  -n, --new-commit-hash                  git hash for new commit\n"
-  echo -e "  -o, --old-commit-hash                  git hash for old commit\n"
+  echo -e "  -o, --old-commit-hash                  git hash (or tag) for old commit\n"
+  echo -e "  -n, --new-commit-hash                  git hash (or tag) for new commit\n"
+  echo -e "If -n is not specified, then current commit is assumed"
+  echo -e "If -o is not specified, then previous commit is assumed (expected -n is also empty)"
+  echo -e "Examples:"
+  echo -e "    To compare this checkout with previous commit: '${cmdName} -w /tmp/wd'"
+  echo -e "    To compare this checkout with some older tag or hash: '${cmdName} -o release-0.7.1 -w /tmp/wd'"
+  echo -e "    To compare any two previous tags or hashes: '${cmdName} -o release-0.7.1 -n 637cc3494 -w /tmp/wd"
   exit 1
 }
 
@@ -39,12 +44,15 @@ function checkoutAndBuild() {
   targetDir=$2
 
   pushd "$targetDir" || exit 1
-  git init
-  git remote add origin https://github.com/apache/incubator-pinot
-  git pull origin master
-  git checkout $commitHash
-  mvn install package -DskipTests -Pbin-dist
+  git init || exit 1
+  git remote add origin https://github.com/apache/incubator-pinot || exit 1
+  git pull origin master || exit 1
+  # Pull the tag list so that we can check out by tag name
+  git fetch --tags || exit 1
+  git checkout $commitHash || exit 1
+  mvn install package -DskipTests -Pbin-dist || exit 1
   popd || exit 1
+  exit 0
 }
 
 # get arguments
@@ -76,44 +84,67 @@ while [ "$1" != "" ]; do
   shift
 done
 
-if [ -z "$olderCommit" -o -z "$newerCommit" ]; then
+if [ -z "$olderCommit" -a ! -z "$newerCommit" ]; then
+   echo "If old commit hash is not given, then new commit has should not be given either"
+   usage
+   exit 1
+fi
+
+if [ -z "$olderCommit" ]; then
+  # Newer commit must also be null, so take the previous commit as the older one.
+  olderCommit=`git log  --pretty=format:'%h' -n 2|tail -1`
+fi
+
+if [ -z $workingDir ]; then
+  echo "Working directory must be specified"
   usage
   exit 1
 fi
 
-if [ -z $workingDir ]; then
-  workingDir=$TMP_DIR
-  echo "Using working directory $TMP_DIR"
-else 
-  if [ -d $workingDir ]; then
-    echo "Directory ${workingDir} already exists. Use a new directory."
-    usage
+if [ -d $workingDir ]; then
+  echo "Directory ${workingDir} already exists. Use a new directory."
+  usage
+  exit 1
+fi
+
+mkdir -p ${workingDir}
+if [ $? -ne 0 ]; then
+  echo "Could not create ${workingDir}"
+  exit 1
+fi
+workingDir=$(absPath "$workingDir")
+
+newTargetDir="$workingDir"/newTargetDir
+if [ -z "$newerCommit" ]; then
+  echo "Compiling current tree as newer version"
+  (cd $cmdDir/.. && mvn install package -DskipTests -Pbin-dist && mvn -pl pinot-tools package -DskipTests && mvn -pl pinot-integration-tests package -DskipTests)
+  if [ $? -ne 0 ]; then
+    echo Compile failed.
     exit 1
-  else
-    mkdir -p ${workingDir}
-    if [ $? -ne 0 ]; then
-      echo "Could not create ${workingDir}"
-      exit 1
-    fi
-    workingDir=$(absPath "$workingDir")
+  fi
+  ln -s $(absPath "${cmdDir}/..") "${newTargetDir}"
+else
+  if ! mkdir -p "$newTargetDir"; then
+    echo "Failed to create target directory ${newTargetDir}"
+    exit 1
+  fi
+  echo "Building the new version ..."
+  checkoutAndBuild "$newerCommit" "$newTargetDir"
+  if [ $? -ne 0 ];then
+    echo Could not build new version at "${newerCommit}"
+    exit 1
   fi
 fi
 
-# create subdirectories for given commits
 oldTargetDir="$workingDir"/oldTargetDir
-newTargetDir="$workingDir"/newTargetDir
-
 if ! mkdir -p "$oldTargetDir"; then
   echo "Failed to create target directory ${oldTargetDir}"
   exit 1
 fi
-if ! mkdir -p "$newTargetDir"; then
-  echo "Failed to create target directory ${newTargetDir}"
-  exit 1
-fi
-
-# Building targets
 echo "Building the old version ... "
 checkoutAndBuild "$olderCommit" "$oldTargetDir"
-echo "Building the new version ..."
-checkoutAndBuild "$newerCommit" "$newTargetDir"
+if [ $? -ne 0 ]; then
+  echo Could not build older version at "${olderCommit}"
+  exit 1
+fi
+exit 0

--- a/compatibility-verifier/compCheck.sh
+++ b/compatibility-verifier/compCheck.sh
@@ -295,10 +295,10 @@ if [ -f $testSuiteDir/pre-controller-upgrade.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/pre-controller-upgrade.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed before controller upgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed before controller upgrade
     exit 1
   fi
 fi
@@ -312,10 +312,10 @@ if [ -f $testSuiteDir/pre-broker-upgrade.yaml ]; then
   echo "Running tests after controller upgrade"
   $COMPAT_TESTER $testSuiteDir/pre-broker-upgrade.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed before broker upgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed before broker upgrade
     exit 1
   fi
 fi
@@ -328,10 +328,10 @@ if [ -f $testSuiteDir/pre-server-upgrade.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/pre-server-upgrade.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed before server upgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed before server upgrade
     exit 1
   fi
 fi
@@ -344,10 +344,10 @@ if [ -f $testSuiteDir/post-server-upgrade.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/post-server-upgrade.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed after server upgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed after server upgrade
     exit 1
   fi
 fi
@@ -362,10 +362,10 @@ if [ -f $testSuiteDir/post-server-rollback.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/post-server-rollback.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed after server downgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed after server downgrade
     exit 1
   fi
 fi
@@ -378,10 +378,10 @@ if [ -f $testSuiteDir/post-broker-rollback.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/post-broker-rollback.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed after broker downgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed after broker downgrade
     exit 1
   fi
 fi
@@ -395,10 +395,10 @@ if [ -f $testSuiteDir/post-controller-rollback.yaml ]; then
   genNum=$((genNum+1))
   $COMPAT_TESTER $testSuiteDir/post-controller-rollback.yaml $genNum
   if [ $? -ne 0 ]; then
-    echo Failed after controller downgrade
     if [ $keepClusterOnFailure == "false" ]; then
       stopServices
     fi
+    echo Failed after controller downgrade
     exit 1
   fi
 fi


### PR DESCRIPTION
Enable users to provide tag names as an alternative to actual git hash.

Made -w mandatory and -o and -n as optional arguments. If -n is
not specified, the current revision is taken to be the newer one.

If -o is also not specfied then the previous commit is taken to be
the older one.

Moved the error messages in compCheck so that they show up after the cluster
is shutdown.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
