### PR TITLE
Fix bug in fetching subset of tier config props

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -226,7 +226,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public PinotConfiguration getTierConfigs() {
     String tierBackend = getTierBackend();
-    String tierConfigsPrefix = String.format("%s.%s.", TIER_CONFIGS_PREFIX, tierBackend);
+    String tierConfigsPrefix = String.format("%s.%s", TIER_CONFIGS_PREFIX, tierBackend);
     Map<String, Object> tierConfigs =
         new HashMap<>(_instanceDataManagerConfiguration.subset(tierConfigsPrefix).toMap());
     if (!tierConfigs.containsKey(READ_MODE)) {


### PR DESCRIPTION
figured that you don't need to provide the trailing "." in the prefix. It only fetches the right props if no "." is specified.