### PR TITLE
Fixing HadoopPinotFS listFiles method to contain scheme

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -146,7 +146,7 @@ public class HadoopPinotFS extends PinotFS {
       // _hadoopFS.listFiles(path, false) will not return directories as files, thus use listStatus(path) here.
       List<FileStatus> files = listStatus(path, recursive);
       for (FileStatus file : files) {
-        filePathStrings.add(file.getPath().toUri().getRawPath());
+        filePathStrings.add(file.getPath().toString());
       }
     } else {
       throw new IllegalArgumentException("segmentUri is not valid");


### PR DESCRIPTION
## Description
Fixing HadoopPinotFS listFiles method to contain scheme.
We observed that some cases: `path.toUri().getRawPath()` doesn't give the scheme, but `path.toString()` will do always.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
