### PR TITLE
fixing v0_deprecated/pinot-hadoop and v0_deprecated/pinot-spark test

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
@@ -66,8 +66,16 @@
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>com.google.common.cache</pattern>
+                      <shadedPattern>shaded.com.google.common.cache</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
                       <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.http</pattern>
+                      <shadedPattern>shaded.org.apache.http</shadedPattern>
                     </relocation>
                   </relocations>
                   <transformers>
@@ -108,7 +116,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
       <version>${project.version}</version>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
@@ -70,8 +70,16 @@
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>com.google.common.cache</pattern>
+                      <shadedPattern>shaded.com.google.common.cache</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
                       <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.http</pattern>
+                      <shadedPattern>shaded.org.apache.http</shadedPattern>
                     </relocation>
                   </relocations>
                   <transformers>
@@ -134,7 +142,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
       <version>${project.version}</version>
-      <classifier>shaded</classifier>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Description

Fixing the tests of modules: `v0_deprecated/pinot-hadoop` and `v0_deprecated/pinot-spark`.
E.g. 
```
org.apache.pinot.hadoop.io.PinotOutputFormatTest with NoSuchMethodException
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
