### PR TITLE
Changes in QueryInvertedSortedIndexRecommender to handle non-dimension columns for sorted and inverted index(#7018)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -118,7 +118,7 @@ public class InputManager {
   Set<String> _dimNames = null;
   Set<String> _metricNames = null;
   Set<String> _dateTimeNames = null;
-  Set<String> _dimNamesInvertedSortedIndexApplicable = null;
+  Set<String> _columnNamesInvertedSortedIndexApplicable = null;
   Map<String, Integer> _colNameToIntMap = null;
   String[] _intToColNameMap = null;
   Map<String, Triple<Double, BrokerRequest, QueryContext>> _parsedQueries = new HashMap<>();
@@ -236,39 +236,28 @@ public class InputManager {
     _intToColNameMap = new String[_dimNames.size() + _metricNames.size() + _dateTimeNames.size()];
     _colNameToIntMap = new HashMap<>();
 
-    _dimNamesInvertedSortedIndexApplicable = new HashSet<>(_dimNames);
-    _dimNamesInvertedSortedIndexApplicable.remove(sortedColumn);
-    _dimNamesInvertedSortedIndexApplicable.removeAll(invertedIndexColumns);
-    _dimNamesInvertedSortedIndexApplicable.removeAll(noDictionaryColumns);
+    // Inverted index and sorted index will be recommended on all types of columns : dimensions, metrics and date time
+    _columnNamesInvertedSortedIndexApplicable = new HashSet<>(_dimNames);
+    _columnNamesInvertedSortedIndexApplicable.addAll(_metricNames);
+    _columnNamesInvertedSortedIndexApplicable.addAll(_dateTimeNames);
 
-    HashSet<String> dimNamesInveredSortedIndexNotApplicable = new HashSet<>(_dimNames);
-    dimNamesInveredSortedIndexNotApplicable.removeAll(_dimNamesInvertedSortedIndexApplicable);
-
-    LOGGER.debug("_dimNamesInveredSortedIndexApplicable {}", _dimNamesInvertedSortedIndexApplicable);
     AtomicInteger counter = new AtomicInteger(0);
-    _dimNamesInvertedSortedIndexApplicable.forEach(name -> {
+    _columnNamesInvertedSortedIndexApplicable.forEach(name -> {
       _intToColNameMap[counter.get()] = name;
       _colNameToIntMap.put(name, counter.getAndIncrement());
     });
 
-    dimNamesInveredSortedIndexNotApplicable.forEach(name -> {
-      _intToColNameMap[counter.get()] = name;
-      _colNameToIntMap.put(name, counter.getAndIncrement());
-    });
+    _columnNamesInvertedSortedIndexApplicable.remove(sortedColumn);
+    _columnNamesInvertedSortedIndexApplicable.removeAll(invertedIndexColumns);
+    _columnNamesInvertedSortedIndexApplicable.removeAll(noDictionaryColumns);
+
+    LOGGER.debug("_columnNamesInvertedSortedIndexApplicable {}", _columnNamesInvertedSortedIndexApplicable);
 
     LOGGER.debug("_dimNames{}", _dimNames);
     LOGGER.debug("_metricNames{}", _metricNames);
     LOGGER.debug("_dateTimeNames{}", _dateTimeNames);
-    _metricNames.forEach(name -> {
-      _intToColNameMap[counter.get()] = name;
-      _colNameToIntMap.put(name, counter.getAndIncrement());
-    });
-    _dateTimeNames.forEach(name -> {
-      _intToColNameMap[counter.get()] = name;
-      _colNameToIntMap.put(name, counter.getAndIncrement());
-    });
 
-    LOGGER.info("*Num dims we can apply index on: {}", getNumDimsInvertedSortedApplicable());
+    LOGGER.info("*Num dims we can apply index on: {}", getNumColumnsInvertedSortedApplicable());
     LOGGER.info("*Col name to int map {} _intToColNameMap {}", _colNameToIntMap, _intToColNameMap);
   }
 
@@ -427,8 +416,8 @@ public class InputManager {
    * Get the number of dimensions we can apply Inverted Sorted indices on.
    * @return total number of dimensions minus number of dimensions with overwritten indices
    */
-  public int getNumDimsInvertedSortedApplicable() {
-    return _dimNamesInvertedSortedIndexApplicable.size();
+  public int getNumColumnsInvertedSortedApplicable() {
+    return _columnNamesInvertedSortedIndexApplicable.size();
   }
 
   public NoDictionaryOnHeapDictionaryJointRuleParams getNoDictionaryOnHeapDictionaryJointRuleParams() {
@@ -539,7 +528,7 @@ public class InputManager {
   }
 
   public boolean isIndexableDim(String colName) {
-    return _dimNamesInvertedSortedIndexApplicable.contains(colName);
+    return _columnNamesInvertedSortedIndexApplicable.contains(colName);
   }
 
   public boolean isSingleValueColumn(String colName) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
@@ -63,7 +63,7 @@ public class QueryInvertedSortedIndexRecommender {
   private boolean _useOverwrittenIndices;
   private IndexConfig _indexOverwritten;
   private InvertedSortedIndexJointRuleParams _params;
-  private int _numDimsIndexApplicable;
+  private int _numColumnsIndexApplicable;
   private String _queryType;
 
   /**
@@ -531,11 +531,6 @@ public class QueryInvertedSortedIndexRecommender {
           .setRecommendationPriorityEnum(RecommendationPriorityEnum.NON_CANDIDATE_SCAN) // won't recommend index
           .setnESI(nESI).setPercentSelected(_params.PERCENT_SELECT_FOR_FUNCTION).setnESIWithIdx(nESI).build();
     }
-    // Not a valid dimension name
-    else if (!_inputManager.isDim(colName)) {
-      LOGGER.error("Error: Column {} should not appear in filter", colName);
-      return null;
-    }
     // e.g. a > 10 / b between 1 and 10
     else if (type == Predicate.Type.RANGE) {
       LOGGER.trace("Entering RANGE clause: {}", leafPredicate);
@@ -744,7 +739,7 @@ public class QueryInvertedSortedIndexRecommender {
       queryInvertedSortedIndexRecommender._params = this._invertedSortedIndexJointRuleParams;
       queryInvertedSortedIndexRecommender._useOverwrittenIndices = this._useOverwrittenIndices;
       queryInvertedSortedIndexRecommender._inputManager = this._inputManager;
-      queryInvertedSortedIndexRecommender._numDimsIndexApplicable = _inputManager.getNumDimsInvertedSortedApplicable();
+      queryInvertedSortedIndexRecommender._numColumnsIndexApplicable = _inputManager.getNumColumnsInvertedSortedApplicable();
       queryInvertedSortedIndexRecommender._indexOverwritten = _inputManager.getOverWrittenConfigs().getIndexConfig();
       queryInvertedSortedIndexRecommender._queryType = _inputManager.getQueryType();
 
@@ -753,6 +748,6 @@ public class QueryInvertedSortedIndexRecommender {
   }
 
   private FixedLenBitset MUTABLE_EMPTY_SET() {
-    return new FixedLenBitset(_numDimsIndexApplicable);
+    return new FixedLenBitset(_numColumnsIndexApplicable);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
@@ -126,6 +126,18 @@ public class TestConfigEngine {
   }
 
   @Test
+  void testSortedInvertedIndexJointRuleWithMetricAndDateTimeColumn()
+      throws InvalidInputException, IOException {
+    loadInput("recommenderInput/SortedInvertedIndexInputWithMetricAndDateTimeColumn.json");
+    ConfigManager output = new ConfigManager();
+    AbstractRule abstractRule =
+        RulesToExecute.RuleFactory.getRule(RulesToExecute.Rule.InvertedSortedIndexJointRule, _input, output);
+    abstractRule.run();
+    assertEquals(output.getIndexConfig().getInvertedIndexColumns().toString(), "[c, t, x]");
+    assertEquals(output.getIndexConfig().getSortedColumn(), "p");
+  }
+
+  @Test
   void testEngineEmptyQueries()
       throws InvalidInputException, IOException {
     String input = readInputToStr("recommenderInput/EmptyQueriesInput.json");
@@ -144,9 +156,9 @@ public class TestConfigEngine {
             .build();
 
     Set<String> results = new HashSet<String>() {{
-      add("[[PredicateParseResult{dims{[1]}, AND, BITMAP, nESI=1.568, selected=0.068, nESIWithIdx=0.618}, PredicateParseResult{dims{[0]}, AND, BITMAP, nESI=1.568, selected=0.068, nESIWithIdx=0.767}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=1.568, selected=0.068, nESIWithIdx=1.568}]]");
-      add("[[PredicateParseResult{dims{[5]}, AND, BITMAP, nESI=0.150, selected=0.015, nESIWithIdx=0.058}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=0.150, selected=0.015, nESIWithIdx=0.150}], [PredicateParseResult{dims{[3, 7]}, AND, BITMAP, nESI=12.000, selected=0.500, nESIWithIdx=4.000}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=12.000, selected=0.500, nESIWithIdx=12.000}]]");
-      add("[[PredicateParseResult{dims{[0, 2]}, AND, BITMAP, nESI=7.250, selected=0.047, nESIWithIdx=1.122}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=7.250, selected=0.047, nESIWithIdx=7.250}]]");
+      add("[[PredicateParseResult{dims{[3]}, AND, BITMAP, nESI=1.645, selected=0.034, nESIWithIdx=0.695}, PredicateParseResult{dims{[2]}, AND, BITMAP, nESI=1.645, selected=0.034, nESIWithIdx=0.835}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=1.645, selected=0.034, nESIWithIdx=1.645}]]");
+      add("[[PredicateParseResult{dims{[7]}, AND, BITMAP, nESI=0.150, selected=0.015, nESIWithIdx=0.058}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=0.150, selected=0.015, nESIWithIdx=0.150}], [PredicateParseResult{dims{[5, 9]}, AND, BITMAP, nESI=12.000, selected=0.500, nESIWithIdx=4.000}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=12.000, selected=0.500, nESIWithIdx=12.000}]]");
+      add("[[PredicateParseResult{dims{[2, 4]}, AND, BITMAP, nESI=7.625, selected=0.023, nESIWithIdx=1.309}, PredicateParseResult{dims{[]}, AND, NESTED, nESI=7.625, selected=0.023, nESIWithIdx=7.625}]]");
     }};
 
     String q1 = "select i from tableName where b in (2,4) and ((a in (1,2,3) and e = 4) or c = 7) and d in ('#VALUES', 23) and t > 500";

--- a/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInputWithMetricAndDateTimeColumn.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInputWithMetricAndDateTimeColumn.json
@@ -1,0 +1,64 @@
+{
+  "schema":{
+    "schemaName": "tableSchema",
+    "dimensionFieldSpecs": [
+      {
+        "name": "b",
+        "dataType": "DOUBLE",
+        "cardinality":6,
+        "singleValueField": false,
+        "numValuesPerEntry":1.5
+      },
+      {
+        "name": "c",
+        "dataType": "FLOAT",
+        "cardinality":7,
+        "numValuesPerEntry":1
+      },
+      {
+        "name": "d",
+        "dataType": "STRING",
+        "cardinality":41,
+        "singleValueField": false,
+        "numValuesPerEntry":2,
+        "averageLength" : 27
+      }
+    ],
+    "metricFieldSpecs": [
+      {
+        "name": "p",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      }
+    ],
+    "dateTimeFieldSpecs": [
+      {
+        "name": "x",
+        "dataType": "INT",
+        "format": "1:DAYS:EPOCH",
+        "granularity": "1:DAYS",
+        "cardinality": 3
+      }
+    ],
+    "timeFieldSpec": {
+      "incomingGranularitySpec": {
+        "dataType": "INT",
+        "name": "t",
+        "timeType": "DAYS",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      }
+    }
+  },
+  "queriesWithWeights":{
+    "select i from tableName where p in (2,4) and (c = 7) and t in ('#VALUES', 500)": 1,
+    "select j from tableName where (x=3)": 2,
+    "select f from tableName where (p=1) and t<3": 4,
+    "select f from tableName where (x=0 and b=1) or c=7 or (t = 7)": 2,
+    "select f from tableName where t between 1 and 1000": 2
+  },
+  "invertedSortedIndexJointRuleParams": {
+    "THRESHOLD_RATIO_MIN_GAIN_DIFF_BETWEEN_ITERATION" : 0.06
+  }
+}


### PR DESCRIPTION
Typically the dimension columns are used in filter and group by. However, technically nothing prevents user from doing a filter on a non-dimension column. So, we need to update the query inverted index and sorted index recommender (QueryInvertedSortedIndexRecommender) and remove this limitation. This will allow rule engine to recommend inverted or sorted index on non-dimension columns as well
This issue is followup for issue #6937