### PR TITLE
mark PinotFS.move as not final

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -90,7 +90,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if move is successful
    * @throws IOException on IO failure
    */
-  public final boolean move(URI srcUri, URI dstUri, boolean overwrite)
+  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
       throws IOException {
     if (!exists(srcUri)) {
       LOGGER.warn("Source {} does not exist", srcUri);


### PR DESCRIPTION
Recently `PinotFS.move` was marked as final in this [PR](https://github.com/apache/incubator-pinot/pull/6841). However, it's possible for the subclass to have different implementations for other considerations such as optimization. Change it back as not final to keep the flexibility.