### PR TITLE
Include null check for setting minion tag.

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -20,6 +20,7 @@ package org.apache.pinot.minion;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.io.FileUtils;
@@ -284,8 +285,8 @@ public class MinionStarter implements ServiceStartable {
     HelixAdmin helixAdmin = _helixManager.getClusterManagmentTool();
     String clusterName = _helixManager.getClusterName();
     InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, _instanceId);
-    List<String> instanceTags = instanceConfig.getTags();
-    if (instanceTags == null || instanceTags.isEmpty()) {
+    List<String> instanceTags = instanceConfig == null ? new ArrayList<>(0) : instanceConfig.getTags();
+    if (instanceTags.isEmpty()) {
       LOGGER.info("Adding default Helix tag: {} to Pinot minion", CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
       helixAdmin.addInstanceTag(clusterName, _instanceId, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -284,7 +284,8 @@ public class MinionStarter implements ServiceStartable {
     HelixAdmin helixAdmin = _helixManager.getClusterManagmentTool();
     String clusterName = _helixManager.getClusterName();
     InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, _instanceId);
-    if (instanceConfig.getTags().isEmpty()) {
+    List<String> instanceTags = instanceConfig.getTags();
+    if (instanceTags == null || instanceTags.isEmpty()) {
       LOGGER.info("Adding default Helix tag: {} to Pinot minion", CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
       helixAdmin.addInstanceTag(clusterName, _instanceId, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
     }


### PR DESCRIPTION
## Description
Null check to ensure that a default tag will be added for Pinot Minion instance even when `instanceTags` are null. Broker and Server already carry out similar null check.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
