### PR TITLE
Support LZ4 compression codec for raw index  (#6804)

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -144,6 +144,10 @@
       <artifactId>zstd-jni</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryIntegerCompression.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryIntegerCompression.java
@@ -21,11 +21,8 @@ import com.github.luben.zstd.Zstd;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
+import net.jpountz.lz4.LZ4Factory;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.pinot.segment.local.io.compression.SnappyCompressor;
-import org.apache.pinot.segment.local.io.compression.SnappyDecompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardCompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardDecompressor;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -41,6 +38,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.xerial.snappy.Snappy;
 
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -48,7 +46,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @State(Scope.Benchmark)
-// Test to get memory statistics for snappy and zstandard integer compression techniques
+// Test to get memory statistics for snappy, zstandard and lz4 integer compression techniques
 public class BenchmarkNoDictionaryIntegerCompression {
 
   @Param({"500000", "1000000", "2000000", "3000000", "4000000", "5000000"})
@@ -58,16 +56,18 @@ public class BenchmarkNoDictionaryIntegerCompression {
   public static class BenchmarkNoDictionaryIntegerCompressionState {
 
     private static ByteBuffer _uncompressedInt;
-    private static ByteBuffer _snappyIntegerIntegerInput;
+    private static ByteBuffer _snappyCompressedIntegerInput;
     private static ByteBuffer _zstandardCompressedIntegerInput;
     private static ByteBuffer _snappyCompressedIntegerOutput;
     private static ByteBuffer _zstdCompressedIntegerOutput;
     private static ByteBuffer _snappyIntegerDecompressed;
     private static ByteBuffer _zstdIntegerDecompressed;
-    private static SnappyCompressor snappyCompressor;
-    private static SnappyDecompressor snappyDecompressor;
-    private static ZstandardCompressor zstandardCompressor;
-    private static ZstandardDecompressor zstandardDecompressor;
+
+    private static ByteBuffer _lz4CompressedIntegerOutput;
+    private static ByteBuffer _lz4CompressedIntegerInput;
+    private static ByteBuffer _lz4IntegerDecompressed;
+
+    private static LZ4Factory factory;
 
     @Setup(Level.Invocation)
     public void setUp()
@@ -77,10 +77,13 @@ public class BenchmarkNoDictionaryIntegerCompression {
       generateRandomIntegerBuffer();
       allocateBufferMemory();
 
-      snappyCompressor.compress(_uncompressedInt,_snappyIntegerIntegerInput);
+      Snappy.compress(_uncompressedInt, _snappyCompressedIntegerInput);
       Zstd.compress(_zstandardCompressedIntegerInput, _uncompressedInt);
+      // ZSTD compressor with change the position of _uncompressedInt, a flip() operation over input to reset position for lz4 is required
+      _uncompressedInt.flip();
+      factory.fastCompressor().compress(_uncompressedInt, _lz4CompressedIntegerInput);
 
-      _zstdIntegerDecompressed.flip();_zstandardCompressedIntegerInput.flip();_uncompressedInt.flip();_snappyIntegerDecompressed.flip();
+      _zstdIntegerDecompressed.rewind();_zstandardCompressedIntegerInput.flip();_uncompressedInt.flip();_snappyIntegerDecompressed.rewind();_lz4CompressedIntegerInput.flip();
     }
 
     private void generateRandomIntegerBuffer() {
@@ -90,26 +93,24 @@ public class BenchmarkNoDictionaryIntegerCompression {
         _uncompressedInt.putInt(RandomUtils.nextInt());
       }
       _uncompressedInt.flip();
-
-      _snappyCompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
-      _zstdCompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
     }
 
     private void initializeCompressors() {
-      //Initialize compressors and decompressors for snappy
-      snappyCompressor = new SnappyCompressor();
-      snappyDecompressor = new SnappyDecompressor();
-
-      //Initialize compressors and decompressors for zstandard
-      zstandardCompressor = new ZstandardCompressor();
-      zstandardDecompressor = new ZstandardDecompressor();
+      //Initialize compressors and decompressors for lz4
+      factory = LZ4Factory.fastestInstance();
     }
 
     private void allocateBufferMemory() {
       _snappyIntegerDecompressed = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
       _zstdIntegerDecompressed = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
-      _snappyIntegerIntegerInput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _snappyCompressedIntegerInput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
       _zstandardCompressedIntegerInput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _lz4IntegerDecompressed = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _lz4CompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _lz4CompressedIntegerInput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _lz4CompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _snappyCompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
+      _zstdCompressedIntegerOutput = ByteBuffer.allocateDirect(_uncompressedInt.capacity()*2);
     }
 
     @TearDown(Level.Invocation)
@@ -119,9 +120,12 @@ public class BenchmarkNoDictionaryIntegerCompression {
       _snappyIntegerDecompressed.clear();
       _zstdCompressedIntegerOutput.clear();
       _zstdIntegerDecompressed.clear();
+      _lz4CompressedIntegerOutput.clear();
+      _lz4IntegerDecompressed.clear();
 
       _uncompressedInt.rewind();
       _zstandardCompressedIntegerInput.rewind();
+      _lz4CompressedIntegerInput.rewind();
     }
   }
 
@@ -130,7 +134,7 @@ public class BenchmarkNoDictionaryIntegerCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyIntegerCompression(BenchmarkNoDictionaryIntegerCompressionState state)
       throws IOException {
-    int size = state.snappyCompressor.compress(state._uncompressedInt, state._snappyCompressedIntegerOutput);
+    int size = Snappy.compress(state._uncompressedInt, state._snappyCompressedIntegerOutput);
     return size;
   }
 
@@ -139,7 +143,7 @@ public class BenchmarkNoDictionaryIntegerCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyIntegerDecompression(BenchmarkNoDictionaryIntegerCompressionState state)
       throws IOException {
-    int size = state.snappyDecompressor.decompress(state._snappyIntegerIntegerInput, state._snappyIntegerDecompressed);
+    int size = Snappy.uncompress(state._snappyCompressedIntegerInput, state._snappyIntegerDecompressed);
     return size;
   }
 
@@ -148,7 +152,7 @@ public class BenchmarkNoDictionaryIntegerCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkZstandardIntegerCompression(BenchmarkNoDictionaryIntegerCompressionState state)
       throws IOException {
-    int size = state.zstandardCompressor.compress(state._zstdCompressedIntegerOutput, state._uncompressedInt);
+    int size = Zstd.compress(state._zstdCompressedIntegerOutput, state._uncompressedInt);
     return size;
   }
 
@@ -157,8 +161,44 @@ public class BenchmarkNoDictionaryIntegerCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkZstandardIntegerDecompression(BenchmarkNoDictionaryIntegerCompressionState state)
       throws IOException {
-    int size = state.zstandardDecompressor.decompress(state._zstdIntegerDecompressed, state._zstandardCompressedIntegerInput);
+    int size = Zstd.decompress(state._zstdIntegerDecompressed, state._zstandardCompressedIntegerInput);
     return size;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4IntegerCompression(BenchmarkNoDictionaryIntegerCompressionState state)
+      throws IOException {
+    state.factory.fastCompressor().compress(state._uncompressedInt, state._lz4CompressedIntegerOutput);
+    return state._lz4CompressedIntegerOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4IntegerDecompression(BenchmarkNoDictionaryIntegerCompressionState state)
+      throws IOException {
+    state.factory.safeDecompressor().decompress(state._lz4CompressedIntegerInput, state._lz4IntegerDecompressed);
+    return state._lz4IntegerDecompressed.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCIntegerCompression(BenchmarkNoDictionaryIntegerCompressionState state)
+      throws IOException {
+    state.factory.highCompressor().compress(state._uncompressedInt, state._lz4CompressedIntegerOutput);
+    return state._lz4CompressedIntegerOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCIntegerDecompression(BenchmarkNoDictionaryIntegerCompressionState state)
+      throws IOException {
+    state.factory.safeDecompressor().decompress(state._lz4CompressedIntegerInput, state._lz4IntegerDecompressed);
+    return state._lz4IntegerDecompressed.position();
   }
 
   public static void main(String[] args)

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryLongCompression.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryLongCompression.java
@@ -21,11 +21,8 @@ import com.github.luben.zstd.Zstd;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
+import net.jpountz.lz4.LZ4Factory;
 import org.apache.commons.lang3.RandomUtils;
-import org.apache.pinot.segment.local.io.compression.SnappyCompressor;
-import org.apache.pinot.segment.local.io.compression.SnappyDecompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardCompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardDecompressor;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -41,6 +38,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.xerial.snappy.Snappy;
 
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -48,7 +46,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @State(Scope.Benchmark)
-// Test to get memory statistics for snappy and zstandard long compression techniques
+// Test to get memory statistics for snappy, zstandard and lz4 long compression techniques
 public class BenchmarkNoDictionaryLongCompression {
 
   @Param({"500000", "1000000", "2000000", "3000000", "4000000", "5000000"})
@@ -64,25 +62,28 @@ public class BenchmarkNoDictionaryLongCompression {
     private static ByteBuffer _zstandardCompressedLongOutput;
     private static ByteBuffer _snappyLongDecompressedOutput;
     private static ByteBuffer _zstandardLongDecompressedOutput;
-    SnappyCompressor snappyCompressor;
-    SnappyDecompressor snappyDecompressor;
-    ZstandardCompressor zstandardCompressor;
-    ZstandardDecompressor zstandardDecompressor;
+
+    private static ByteBuffer _lz4CompressedLongOutput;
+    private static ByteBuffer _lz4CompressedLongInput;
+    private static ByteBuffer _lz4LongDecompressed;
+
+    private static LZ4Factory factory;
 
     @Setup(Level.Invocation)
     public void setUp()
         throws Exception {
 
       initializeCompressors();
-
       generateRandomLongBuffer();
-
       allocateBufferMemory();
 
-      snappyCompressor.compress(_uncompressedLong,_snappyCompressedLongInput);
+      Snappy.compress(_uncompressedLong,_snappyCompressedLongInput);
       Zstd.compress(_zstandardCompressedLongInput, _uncompressedLong);
+      // ZSTD compressor with change the position of _uncompressedLong, a flip() operation over input to reset position for lz4 is required
+      _uncompressedLong.flip();
+      factory.fastCompressor().compress(_uncompressedLong, _lz4CompressedLongInput);
 
-      _zstandardCompressedLongInput.flip();_uncompressedLong.flip();_snappyLongDecompressedOutput.flip();
+      _zstandardLongDecompressedOutput.rewind();_zstandardCompressedLongInput.flip();_uncompressedLong.flip();_snappyLongDecompressedOutput.flip();_lz4CompressedLongInput.flip();
     }
 
     private void generateRandomLongBuffer() {
@@ -95,14 +96,9 @@ public class BenchmarkNoDictionaryLongCompression {
     }
 
     private void initializeCompressors() {
-      //Initialize compressors and decompressors
-      snappyCompressor = new SnappyCompressor();
-      snappyDecompressor = new SnappyDecompressor();
-
-      //Initialize compressors and decompressors for zstandard
-      zstandardCompressor = new ZstandardCompressor();
-      zstandardDecompressor = new ZstandardDecompressor();
-    }
+      //Initialize compressors and decompressors for lz4
+      factory = LZ4Factory.fastestInstance();
+   }
 
     private void allocateBufferMemory() {
       _snappyCompressedLongOutput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
@@ -111,6 +107,9 @@ public class BenchmarkNoDictionaryLongCompression {
       _zstandardLongDecompressedOutput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
       _snappyCompressedLongInput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
       _zstandardCompressedLongInput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
+      _lz4LongDecompressed = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
+      _lz4CompressedLongOutput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
+      _lz4CompressedLongInput = ByteBuffer.allocateDirect(_uncompressedLong.capacity()*2);
     }
 
     @TearDown(Level.Invocation)
@@ -120,9 +119,12 @@ public class BenchmarkNoDictionaryLongCompression {
       _snappyLongDecompressedOutput.clear();
       _zstandardCompressedLongOutput.clear();
       _zstandardLongDecompressedOutput.clear();
+      _lz4CompressedLongOutput.clear();
+      _lz4LongDecompressed.clear();
 
       _uncompressedLong.rewind();
       _zstandardCompressedLongInput.rewind();
+      _lz4CompressedLongInput.rewind();
     }
   }
 
@@ -131,7 +133,7 @@ public class BenchmarkNoDictionaryLongCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyLongCompression(BenchmarkNoDictionaryLongCompressionState state)
       throws IOException {
-    int size = state.snappyCompressor.compress(state._uncompressedLong, state._snappyCompressedLongOutput);
+    int size = Snappy.compress(state._uncompressedLong, state._snappyCompressedLongOutput);
     return size;
   }
 
@@ -140,7 +142,7 @@ public class BenchmarkNoDictionaryLongCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyLongDecompression(BenchmarkNoDictionaryLongCompressionState state)
       throws IOException {
-    int size = state.snappyDecompressor.decompress(state._snappyCompressedLongInput, state._snappyLongDecompressedOutput);
+    int size = Snappy.uncompress(state._snappyCompressedLongInput, state._snappyLongDecompressedOutput);
     return size;
   }
 
@@ -160,6 +162,46 @@ public class BenchmarkNoDictionaryLongCompression {
       throws IOException {
     int size = Zstd.decompress(state._zstandardLongDecompressedOutput, state._zstandardCompressedLongInput);
     return size;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4LongCompression(
+      BenchmarkNoDictionaryLongCompression.BenchmarkNoDictionaryLongCompressionState state)
+      throws IOException {
+    state.factory.fastCompressor().compress(state._uncompressedLong, state._lz4CompressedLongOutput);
+    return state._lz4CompressedLongOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4LongDecompression(
+      BenchmarkNoDictionaryLongCompression.BenchmarkNoDictionaryLongCompressionState state)
+      throws IOException {
+    state.factory.safeDecompressor().decompress(state._lz4CompressedLongInput, state._lz4LongDecompressed);
+    return state._lz4LongDecompressed.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCLongCompression(
+      BenchmarkNoDictionaryLongCompression.BenchmarkNoDictionaryLongCompressionState state)
+      throws IOException {
+    state.factory.highCompressor().compress(state._uncompressedLong, state._lz4CompressedLongOutput);
+    return state._lz4CompressedLongOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCLongDecompression(
+      BenchmarkNoDictionaryLongCompression.BenchmarkNoDictionaryLongCompressionState state)
+      throws IOException {
+    state.factory.safeDecompressor().decompress(state._lz4CompressedLongInput, state._lz4LongDecompressed);
+    return state._lz4LongDecompressed.position();
   }
 
   public static void main(String[] args)

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryStringCompression.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNoDictionaryStringCompression.java
@@ -23,12 +23,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import net.jpountz.lz4.LZ4Factory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.common.utils.StringUtil;
-import org.apache.pinot.segment.local.io.compression.SnappyCompressor;
-import org.apache.pinot.segment.local.io.compression.SnappyDecompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardCompressor;
-import org.apache.pinot.segment.local.io.compression.ZstandardDecompressor;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -44,6 +41,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.xerial.snappy.Snappy;
 
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -51,7 +49,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
 @State(Scope.Benchmark)
-// Test to get memory statistics for snappy and zstandard string compression techniques
+// Test to get memory statistics for snappy, zstandard and lz4 string compression techniques
 public class BenchmarkNoDictionaryStringCompression {
 
   @Param({"500000", "1000000", "2000000", "3000000", "4000000", "5000000"})
@@ -68,10 +66,11 @@ public class BenchmarkNoDictionaryStringCompression {
     private static ByteBuffer _zstandardCompressedStringOutput;
     private static ByteBuffer _snappyStringDecompressed;
     private static ByteBuffer _zstandardStringDecompressed;
-    SnappyCompressor snappyCompressor;
-    SnappyDecompressor snappyDecompressor;
-    ZstandardCompressor zstandardCompressor;
-    ZstandardDecompressor zstandardDecompressor;
+    private static ByteBuffer _lz4CompressedStringOutput;
+    private static ByteBuffer _lz4CompressedStringInput;
+    private static ByteBuffer _lz4StringDecompressed;
+
+    private static LZ4Factory factory;
 
     @Setup(Level.Invocation)
     public void setUp()
@@ -81,23 +80,18 @@ public class BenchmarkNoDictionaryStringCompression {
       generateRandomStringBuffer();
       allocateMemory();
 
-      _snappyCompressedStringOutput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
-      _zstandardCompressedStringOutput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
-
-      snappyCompressor.compress(_uncompressedString,_snappyCompressedStringInput);
+      Snappy.compress(_uncompressedString,_snappyCompressedStringInput);
       Zstd.compress(_zstandardCompressedStringInput, _uncompressedString);
+      // ZSTD compressor with change the position of _uncompressedString, a flip() operation over input to reset position for lz4 is required
+      _uncompressedString.flip();
+      factory.fastCompressor().compress(_uncompressedString, _lz4CompressedStringInput);
 
-      _zstandardStringDecompressed.flip();_zstandardCompressedStringInput.flip();_uncompressedString.flip();_snappyStringDecompressed.flip();
+      _zstandardStringDecompressed.rewind();_zstandardCompressedStringInput.flip();_uncompressedString.flip();_snappyStringDecompressed.flip();_lz4CompressedStringInput.flip();
     }
 
     private void initializeCompressors() {
-      //Initialize compressors and decompressors for snappy
-      snappyCompressor = new SnappyCompressor();
-      snappyDecompressor = new SnappyDecompressor();
-
-      //Initialize compressors and decompressors for zstandard
-      zstandardCompressor = new ZstandardCompressor();
-      zstandardDecompressor = new ZstandardDecompressor();
+      //Initialize compressors and decompressors for lz4
+      factory = LZ4Factory.fastestInstance();
     }
 
     private void generateRandomStringBuffer() {
@@ -119,10 +113,15 @@ public class BenchmarkNoDictionaryStringCompression {
     }
 
     private void allocateMemory() {
+      _snappyCompressedStringOutput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
+      _zstandardCompressedStringOutput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
       _snappyStringDecompressed = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
       _zstandardStringDecompressed = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
       _snappyCompressedStringInput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
       _zstandardCompressedStringInput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
+      _lz4StringDecompressed = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
+      _lz4CompressedStringOutput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
+      _lz4CompressedStringInput = ByteBuffer.allocateDirect(_uncompressedString.capacity()*2);
     }
 
     @TearDown(Level.Invocation)
@@ -132,9 +131,12 @@ public class BenchmarkNoDictionaryStringCompression {
       _snappyStringDecompressed.clear();
       _zstandardCompressedStringOutput.clear();
       _zstandardStringDecompressed.clear();
+      _lz4CompressedStringOutput.clear();
+      _lz4StringDecompressed.clear();
 
       _uncompressedString.rewind();
       _zstandardCompressedStringInput.rewind();
+      _lz4CompressedStringInput.rewind();
     }
   }
 
@@ -143,7 +145,7 @@ public class BenchmarkNoDictionaryStringCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyStringCompression(BenchmarkNoDictionaryStringCompressionState state)
       throws IOException {
-    int size = state.snappyCompressor.compress(state._uncompressedString, state._snappyCompressedStringOutput);
+    int size = Snappy.compress(state._uncompressedString, state._snappyCompressedStringOutput);
     return size;
   }
 
@@ -152,7 +154,7 @@ public class BenchmarkNoDictionaryStringCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkSnappyStringDecompression(BenchmarkNoDictionaryStringCompressionState state)
       throws IOException {
-    int size = state.snappyDecompressor.decompress(state._snappyCompressedStringInput, state._snappyStringDecompressed);
+    int size = Snappy.uncompress(state._snappyCompressedStringInput, state._snappyStringDecompressed);
     return size;
   }
 
@@ -161,7 +163,7 @@ public class BenchmarkNoDictionaryStringCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkZstandardStringCompression(BenchmarkNoDictionaryStringCompressionState state)
       throws IOException {
-    int size = state.zstandardCompressor.compress(state._zstandardCompressedStringOutput, state._uncompressedString);
+    int size = Zstd.compress(state._zstandardCompressedStringOutput, state._uncompressedString);
     return size;
   }
 
@@ -170,8 +172,48 @@ public class BenchmarkNoDictionaryStringCompression {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int benchmarkZstandardStringDecompression(BenchmarkNoDictionaryStringCompressionState state)
       throws IOException {
-    int size = state.zstandardDecompressor.decompress(state._zstandardStringDecompressed, state._zstandardCompressedStringInput);
+    int size = Zstd.decompress(state._zstandardStringDecompressed, state._zstandardCompressedStringInput);
     return size;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4StringCompression(
+      BenchmarkNoDictionaryStringCompression.BenchmarkNoDictionaryStringCompressionState state)
+      throws IOException {
+    state.factory.fastCompressor().compress(state._uncompressedString, state._lz4CompressedStringOutput);
+    return state._lz4CompressedStringOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4StringDecompression(
+      BenchmarkNoDictionaryStringCompression.BenchmarkNoDictionaryStringCompressionState state)
+      throws IOException {
+    state.factory.fastDecompressor().decompress(state._lz4CompressedStringInput, state._lz4StringDecompressed);
+    return state._lz4StringDecompressed.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCStringCompression(
+      BenchmarkNoDictionaryStringCompression.BenchmarkNoDictionaryStringCompressionState state)
+      throws IOException {
+    state.factory.highCompressor().compress(state._uncompressedString, state._lz4CompressedStringOutput);
+    return state._lz4CompressedStringOutput.position();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLZ4HCStringDecompression(
+      BenchmarkNoDictionaryStringCompression.BenchmarkNoDictionaryStringCompressionState state)
+      throws IOException {
+    state.factory.fastDecompressor().decompress(state._lz4CompressedStringInput, state._lz4StringDecompressed);
+    return state._lz4StringDecompressed.position();
   }
 
   public static void main(String[] args)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/ChunkCompressorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/ChunkCompressorFactory.java
@@ -51,6 +51,9 @@ public class ChunkCompressorFactory {
       case ZSTANDARD:
         return new ZstandardCompressor();
 
+      case LZ4:
+        return new LZ4Compressor();
+
       default:
         throw new IllegalArgumentException("Illegal compressor name " + compressionType);
     }
@@ -72,6 +75,9 @@ public class ChunkCompressorFactory {
 
       case ZSTANDARD:
         return new ZstandardDecompressor();
+
+      case LZ4:
+        return new LZ4Decompressor();
 
       default:
         throw new IllegalArgumentException("Illegal compressor name " + compressionType);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4Compressor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4Compressor.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.compression;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import net.jpountz.lz4.LZ4Factory;
+import org.apache.pinot.segment.spi.compression.ChunkCompressor;
+
+/**
+ * Implementation of {@link ChunkCompressor} using LZ4 compression algorithm.
+ * LZ4Factory.fastestInstance().fastCompressor().compress(sourceBuffer, destinationBuffer)
+ */
+public class LZ4Compressor implements ChunkCompressor {
+
+  private static LZ4Factory _lz4Factory;
+
+  public LZ4Compressor() {
+    _lz4Factory = LZ4Factory.fastestInstance();
+  }
+
+  @Override
+  public int compress(ByteBuffer inUncompressed, ByteBuffer outCompressed)
+      throws IOException {
+
+    _lz4Factory.fastCompressor().compress(inUncompressed, outCompressed);
+    // When the compress method returns successfully,
+    // dstBuf's position() will be set to its current position() plus the compressed size of the data.
+    // and srcBuf's position() will be set to its limit()
+    // Flip operation Make the destination ByteBuffer(outCompressed) ready for read by setting the position to 0
+    outCompressed.flip();
+    return outCompressed.limit();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4Decompressor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4Decompressor.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.compression;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import net.jpountz.lz4.LZ4Factory;
+import org.apache.pinot.segment.spi.compression.ChunkDecompressor;
+
+/**
+ * Implementation of {@link ChunkDecompressor} using LZ4 decompression algorithm.
+ * LZ4Factory.fastestInstance().safeDecompressor().decompress(sourceBuffer, destinationBuffer)
+ * Compresses the data in buffer 'sourceBuffer' using default compression level
+ */
+public class LZ4Decompressor implements ChunkDecompressor {
+
+  private static LZ4Factory _lz4Factory;
+
+  public LZ4Decompressor() {
+    _lz4Factory = LZ4Factory.fastestInstance();
+  }
+
+  @Override
+  public int decompress(ByteBuffer compressedInput, ByteBuffer decompressedOutput)
+      throws IOException {
+    // Safe Decompressor instance is used to avoid data loss
+    _lz4Factory.safeDecompressor().decompress(compressedInput, decompressedOutput);
+    // When the decompress method returns successfully,
+    // dstBuf's position() will be set to its current position() plus the decompressed size of the data.
+    // and srcBuf's position() will be set to its limit()
+    // Flip operation Make the destination ByteBuffer(decompressedOutput) ready for read by setting the position to 0
+    decompressedOutput.flip();
+    return decompressedOutput.limit();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/FixedByteChunkSVForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/FixedByteChunkSVForwardIndexTest.java
@@ -79,6 +79,16 @@ public class FixedByteChunkSVForwardIndexTest {
     testDouble(compressionType);
   }
 
+  @Test
+  public void testWithLZ4Compression()
+      throws Exception {
+    ChunkCompressionType compressionType = ChunkCompressionType.LZ4;
+    testInt(compressionType);
+    testLong(compressionType);
+    testFloat(compressionType);
+    testDouble(compressionType);
+  }
+
   public void testInt(ChunkCompressionType compressionType)
       throws Exception {
     int[] expected = new int[NUM_VALUES];

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
@@ -66,6 +66,12 @@ public class VarByteChunkSVForwardIndexTest {
     test(ChunkCompressionType.ZSTANDARD);
   }
 
+  @Test
+  public void testWithLZ4Compression()
+      throws Exception {
+    test(ChunkCompressionType.LZ4);
+  }
+
 
   /**
    * This test writes {@link #NUM_ENTRIES} using {@link VarByteChunkSVForwardIndexWriter}. It then reads
@@ -169,30 +175,37 @@ public class VarByteChunkSVForwardIndexTest {
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 10, 1000);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 10, 1000);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 10, 1000);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 10, 1000);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 100, 1000);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 100, 1000);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 100, 1000);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 100, 1000);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 1000, 1000);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 1000, 1000);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 1000, 1000);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 1000, 1000);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 10000, 100);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 10000, 100);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 10000, 100);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 10000, 100);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 100000, 10);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 100000, 10);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 100000, 10);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 100000, 10);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 1000000, 10);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 1000000, 10);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 1000000, 10);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 1000000, 10);
 
     testLargeVarcharHelper(ChunkCompressionType.SNAPPY, 2000000, 10);
     testLargeVarcharHelper(ChunkCompressionType.PASS_THROUGH, 2000000, 10);
     testLargeVarcharHelper(ChunkCompressionType.ZSTANDARD, 2000000, 10);
+    testLargeVarcharHelper(ChunkCompressionType.LZ4, 2000000, 10);
   }
 
   private void testLargeVarcharHelper(ChunkCompressionType compressionType, int numChars, int numDocs)

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/ChunkCompressionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/ChunkCompressionType.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.segment.spi.compression;
 
 public enum ChunkCompressionType {
-  PASS_THROUGH(0), SNAPPY(1), ZSTANDARD(2);
+  PASS_THROUGH(0), SNAPPY(1), ZSTANDARD(2), LZ4(3);
 
   private final int _value;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -73,7 +73,7 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   public enum CompressionCodec {
-    PASS_THROUGH, SNAPPY, ZSTANDARD
+    PASS_THROUGH, SNAPPY, ZSTANDARD, LZ4
   }
 
   public String getName() {

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <dropwizard-metrics.version>4.1.2</dropwizard-metrics.version>
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
+    <lz4-java.version>1.7.1</lz4-java.version>
     <log4j.version>2.11.2</log4j.version>
     <netty.version>4.1.54.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
@@ -539,6 +540,11 @@
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
         <version>${zstd-jni.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4-java.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This ticket is extension of adding new compression codec LZ4 after ZSTD(#6876) for Issue (#6804).

When the forward index is not dictionary encoded, we have 2 choices:
store the data as is (RAW)
store the data snappy compressed - using snappy compression codec library as default

This PR adds supports for LZ4 compression using library - https://github.com/lz4/lz4-java. 
Maven Artifact: https://mvnrepository.com/artifact/org.lz4/lz4-java

LZ4 library offers 2 choices
1. Fast Compression
2. High Compression
We get good compression and decompression speed comparable to Snappy using Fast Compression. High Compression has poor performance when compared to already added support for ZSTD. The Benchmark for both choices offered by library are part of this PR, and the perf document is updated with numbers.
So based on the user requirements, user can configure via table config on a per column basis. **The default behavior continues to remain the same. It is snappy for dimension columns and no compression for metric columns.** 

Other table level changes (column renaming, type changing, column dropping, index dropping) which are currently not allowed, changing the compression codec on an existing noDictionary column from snappy to lz4 or vice-versa will not happen since we currently don't have a mechanism for doing this in-place in the segment file. Newly pushed segments will pick up the new codec and since the codec type is written into the index buffer header, we will be able to read both old and new segments.

The library also underneath uses JNI bridge to original LZ4 library https://github.com/lz4/lz4 as Apache commons compress library similar to Snappy, ZSTD. Also,lz4-java library has been used in popular projects like Apache Spark, Apache Kafka and many more. **This library also ensures that if native support is not available, it uses pure java implementation.**

Please have a look at LZ4Factory class in lz4-java library for more information.

Compatibility docs from library
Compressors and decompressors are interchangeable: it is perfectly correct to compress with the JNI bindings and to decompress with a Java port, or the other way around.

The perf comparison document and benchmarking for Snappy, ZSTD, LZ4 are updated in doc
https://docs.google.com/document/d/1JKLhDm0-gnrRhyBUDge5u4MeGjotRSgjiexJxI_abfk/edit?usp=sharing

cc @siddharthteotia 