### PR TITLE
improve robustness of basic auth (tls) realtime integration tests

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/util/TestUtils.java
+++ b/pinot-common/src/test/java/org/apache/pinot/util/TestUtils.java
@@ -106,4 +106,34 @@ public class TestUtils {
       Assert.fail("Failed to meet condition in " + timeoutMs + "ms" + errorMessageSuffix);
     }
   }
+
+  /**
+   * Wait for a result to be returned
+   *
+   * @param supplier result value supplier
+   * @param timeoutMs timeout
+   * @return result value (non-throwable)
+   * @throws InterruptedException if {@code Thread.sleep()} is interrupted
+   */
+  public static <T> T waitForResult(SupplierWithException<T> supplier, long timeoutMs)
+      throws InterruptedException {
+    long tEnd = System.currentTimeMillis() + timeoutMs;
+    while (tEnd > System.currentTimeMillis()) {
+      try {
+        return supplier.get();
+      } catch (Throwable ignore) {
+        // ignore
+      }
+
+      Thread.sleep(1000);
+    }
+
+    throw new IllegalStateException("Failed to return result in " + timeoutMs + "ms");
+  }
+
+  @FunctionalInterface
+  public interface SupplierWithException<T> {
+    T get()
+        throws Exception;
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTlsRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthTlsRealtimeIntegrationTest.java
@@ -230,20 +230,21 @@ public class BasicAuthTlsRealtimeIntegrationTest extends BaseClusterIntegrationT
 
     // schedule offline segment generation
     Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks());
-    Thread.sleep(5000);
 
-    ResultSetGroup resultAfterOffline = getPinotConnection().execute(query);
+    // wait for offline segments
+    JsonNode offlineSegments = TestUtils.waitForResult(() -> {
+      JsonNode segmentSets = JsonUtils.stringToJsonNode(
+          sendGetRequest(_controllerRequestURLBuilder.forSegmentListAPI(getTableName()), AUTH_HEADER));
+      JsonNode currentOfflineSegments =
+          new IntRange(0, segmentSets.size()).stream().map(segmentSets::get).filter(s -> s.has("OFFLINE"))
+              .map(s -> s.get("OFFLINE")).findFirst().get();
+      Assert.assertFalse(currentOfflineSegments.isEmpty());
+      return currentOfflineSegments;
+    }, 30000);
 
     // Verify constant row count
+    ResultSetGroup resultAfterOffline = getPinotConnection().execute(query);
     Assert.assertEquals(resultBeforeOffline.getResultSet(0).getLong(0), resultAfterOffline.getResultSet(0).getLong(0));
-
-    // list offline segments
-    JsonNode segmentSets = JsonUtils
-        .stringToJsonNode(sendGetRequest(_controllerRequestURLBuilder.forSegmentListAPI(getTableName()), AUTH_HEADER));
-    JsonNode offlineSegments =
-        new IntRange(0, segmentSets.size()).stream().map(segmentSets::get).filter(s -> s.has("OFFLINE"))
-            .map(s -> s.get("OFFLINE")).findFirst().get();
-    Assert.assertFalse(offlineSegments.isEmpty());
 
     // download and sanity-check size of offline segment(s)
     for (int i = 0; i < offlineSegments.size(); i++) {


### PR DESCRIPTION
## Description
Add checked wait to BasicAuth(Tls)RealtimeIntegrationTest to reduce flakiness on slow environments.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes?
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)

## Release Notes
none

## Documentation
none
