### PR TITLE
Fixing helm broker port issue

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/broker/configmap.yaml
@@ -23,6 +23,6 @@ metadata:
   name: {{ include "pinot.broker.config" . }}
 data:
   pinot-broker.conf: |-
-    pinot.broker.client.queryPort={{ .Values.broker.port }}
+    pinot.broker.client.queryPort={{ .Values.broker.service.port }}
     pinot.broker.routing.table.builder.class={{ .Values.broker.routingTable.builderClass }}
 {{ .Values.broker.extra.configs | indent 4 }}


### PR DESCRIPTION
## Description
broker port should refer to `{{ .Values.broker.service.port }}`

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
