### PR TITLE
Add numRowsResultSet to RequestStatistics

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -237,4 +237,8 @@ public class RequestStatistics {
   public boolean hasValidTableName() {
     return ! DEFAULT_TABLE_NAME.equals(_tableName);
   }
+
+  public int getNumRowsResultSet() {
+     return _numRowsResultSet;
+  }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequestStatistics.java
@@ -53,6 +53,7 @@ public class RequestStatistics {
   private String _offlineServerTenant;
   private String _realtimeServerTenant;
   private long _requestId;
+  private int _numRowsResultSet;
 
   public String getBrokerId() {
     return _brokerId;
@@ -122,6 +123,7 @@ public class RequestStatistics {
     _numExceptions = brokerResponse.getExceptionsSize();
     _offlineThreadCpuTimeNs = brokerResponse.getOfflineThreadCpuTimeNs();
     _realtimeThreadCpuTimeNs = brokerResponse.getRealtimeThreadCpuTimeNs();
+    _numRowsResultSet = brokerResponse.getNumRowsResultSet();
   }
 
   public void setBrokerId(String brokerId) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -62,6 +62,11 @@ public interface BrokerResponse {
   void setOfflineThreadCpuTimeNs(long offlineThreadCpuTimeNs);
 
   /**
+   * Set the total number of rows in result set
+   */
+  void setNumRowsResultSet(int numRowsResultSet);
+
+  /**
    * Convert the broker response to JSON String.
    */
   String toJsonString()
@@ -146,4 +151,9 @@ public interface BrokerResponse {
    * Get the total thread cpu time used against offline table in request handling, into the broker response.
    */
   long getOfflineThreadCpuTimeNs();
+
+  /**
+   * Get the total number of rows in result set
+   */
+  int getNumRowsResultSet();
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -65,6 +65,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _timeUsedMs = 0L;
   private long _offlineThreadCpuTimeNs = 0L;
   private long _realtimeThreadCpuTimeNs = 0L;
+  private int _numRowsResultSet = 0;
 
   private SelectionResults _selectionResults;
   private List<AggregationResult> _aggregationResults;
@@ -125,6 +126,7 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("resultTable")
   public void setResultTable(ResultTable resultTable) {
     _resultTable = resultTable;
+    _numRowsResultSet = resultTable.getRows().size();
   }
 
   @JsonProperty("exceptions")
@@ -287,12 +289,19 @@ public class BrokerResponseNative implements BrokerResponse {
     return _offlineThreadCpuTimeNs;
   }
 
+  @JsonProperty("numRowsResultSet")
+  @Override
+  public int getNumRowsResultSet() { return _numRowsResultSet; }
+
   @JsonProperty("offlineThreadCpuTimeNs")
   @Override
   public void setOfflineThreadCpuTimeNs(long timeUsedMs) {
     _offlineThreadCpuTimeNs = timeUsedMs;
   }
 
+  @JsonProperty("numRowsResultSet")
+  @Override
+  public void setNumRowsResultSet(int numRowsResultSet) { _numRowsResultSet = numRowsResultSet; }
 
   @JsonProperty("realtimeThreadCpuTimeNs")
   @Override


### PR DESCRIPTION
This PR adds numRowsResultSet to RequestStatistics. As we already have ResultTable object computed, there is no extra overhead 