### PR TITLE
Revert "Query options in quickstart"

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -63,13 +63,6 @@ public class Quickstart extends QuickStartBase {
     return null;
   }
 
-  /**
-   * Set query options which will be appended to end of the query e.g. option(timeoutMs=60000)
-   */
-  public String getQueryOptions() {
-    return null;
-  }
-
   public static void printStatus(Color color, String message) {
     System.out.println(color._code + message + Color.RESET._code);
   }
@@ -188,7 +181,7 @@ public class Quickstart extends QuickStartBase {
     QuickstartTableRequest request = new QuickstartTableRequest(baseDir.getAbsolutePath());
     QuickstartRunner runner =
         new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, getNumMinions(), dataDir, true, getAuthToken(),
-            getConfigOverrides(), getQueryOptions());
+            getConfigOverrides());
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -76,7 +75,6 @@ public class QuickstartRunner {
   private final boolean _enableTenantIsolation;
   private final String _authToken;
   private final Map<String, Object> _configOverrides;
-  private final String _queryOptions;
 
   private final List<Integer> _controllerPorts = new ArrayList<>();
   private final List<Integer> _brokerPorts = new ArrayList<>();
@@ -84,7 +82,7 @@ public class QuickstartRunner {
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, int numMinions, File tempDir, boolean enableIsolation, String authToken,
-      Map<String, Object> configOverrides, String queryOptions)
+      Map<String, Object> configOverrides)
       throws Exception {
     _tableRequests = tableRequests;
     _numControllers = numControllers;
@@ -95,14 +93,13 @@ public class QuickstartRunner {
     _enableTenantIsolation = enableIsolation;
     _authToken = authToken;
     _configOverrides = configOverrides;
-    _queryOptions = queryOptions;
     clean();
   }
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, File tempDir)
       throws Exception {
-    this(tableRequests, numControllers, numBrokers, numServers, 0, tempDir, true, null, null, null);
+    this(tableRequests, numControllers, numBrokers, numServers, 0, tempDir, true, null, null);
   }
 
   private void startZookeeper()
@@ -251,9 +248,6 @@ public class QuickstartRunner {
   public JsonNode runQuery(String query)
       throws Exception {
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
-    if (StringUtils.isNotBlank(_queryOptions)) {
-      query = query + " " + _queryOptions;
-    }
     return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort))
         .setQueryType(CommonConstants.Broker.Request.SQL).setAuthToken(_authToken).setQuery(query).run());
   }


### PR DESCRIPTION
Reverts apache/incubator-pinot#7042. As per discussion with @Jackie-Jiang this is not needed for the particular case I was trying to solve (query timeout can be set via broker conf)