### PR TITLE
Fix bug for AggregateMetrics rule in Recommendation Engine

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRule.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.controller.recommender.exceptions.InvalidInputException;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRuleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRuleTest.java
@@ -101,6 +101,17 @@ public class AggregateMetricsRuleTest {
   }
 
   @Test
+  public void testRun_withGroupBy()
+      throws Exception {
+    Set<String> metrics = ImmutableSet.of("a", "b", "c");
+    InputManager input = createInput(metrics, "select d1, d2, sum(a), sum(b) from tableT group by d1, d2");
+    ConfigManager output = new ConfigManager();
+    AggregateMetricsRule rule = new AggregateMetricsRule(input, output);
+    rule.run();
+    assertTrue(output.isAggregateMetrics());
+  }
+
+  @Test
   public void testRun_offlineTable()
       throws Exception {
     Set<String> metrics = ImmutableSet.of("a", "b", "c");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRuleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/rules/impl/AggregateMetricsRuleTest.java
@@ -112,6 +112,20 @@ public class AggregateMetricsRuleTest {
   }
 
   @Test
+  public void testRun_withTransformationFunctionInGroupBy()
+      throws Exception {
+    Set<String> metrics = ImmutableSet.of("a", "b", "c");
+    InputManager input = createInput(metrics,
+        "select d, dateTimeConvert(t, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES'), sum(a), sum(b)"
+            + " from tableT"
+            + " group by d, dateTimeConvert(t, '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '15:MINUTES')");
+    ConfigManager output = new ConfigManager();
+    AggregateMetricsRule rule = new AggregateMetricsRule(input, output);
+    rule.run();
+    assertTrue(output.isAggregateMetrics());
+  }
+
+  @Test
   public void testRun_offlineTable()
       throws Exception {
     Set<String> metrics = ImmutableSet.of("a", "b", "c");

--- a/pinot-controller/src/test/resources/recommenderInput/AggregateMetricsRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/AggregateMetricsRuleInput.json
@@ -45,7 +45,8 @@
   "queriesWithWeights":{
     "select sum(k) from tableName where a in (2,4)": 1,
     "select sum(l), sum(m) from tableName where a in (1,3)": 1,
-    "select sum(2 * k + 3 * l - 4 / m) from tableName where a = 5": 1
+    "select sum(2 * k + 3 * l - 4 / m) from tableName where a = 5": 1,
+    "select a, sum(k), sum(l) from tableName group by a": 1
   },
   "qps": 150,
   "numMessagesPerSecInKafkaTopic":1000,


### PR DESCRIPTION
## Description
 Currently AggregateMetric rule looks at selection columns and all of them have to be metric and inside a SUM function. It misses the fact that for group-by queries, groupby columns appear in selection with no function and that's a valid case for which AggergateMetrics can be turned on. This PR checks that scenario and acts accordingly.

## Testing Done
- unit test
- integration test