### PR TITLE
SumFunction: skip number format exception

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SumFunction.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SumFunction.java
@@ -31,10 +31,13 @@ public class SumFunction extends AggregationFunc {
 
   @Override
   public ResultTable run() {
-    Double sum = 0.0;
+    double sum = 0.0;
 
     for (ResultTable.Row row : _rows) {
-      sum += new Double((row.get(_column, _name)).toString());
+      try {
+        sum += Double.parseDouble((row.get(_column, _name)).toString());
+      } catch (NumberFormatException ignored) { // if encounter a NumberFormatException, skip it
+      }
     }
 
     ResultTable resultTable = new ResultTable(new ArrayList<Pair>(), 1);


### PR DESCRIPTION
Skip the number format exception in SumFunction:
When SumFunction failed convert a column from string value to double, it will just throw exception to user. For column with double or int, long type, this happens when there is a null value, I think it's better catch the exception and skip it. Although users can filter that out, it's better we have a default behavior handle this rather than throwing exceptions to user.