### PR TITLE
Adding Additional JMX Metrics to Prometheus config

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/README.md
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/README.md
@@ -1,0 +1,22 @@
+#### What is Prometheus?
+
+Prometheus is an open-source event monitoring system. It records real-time metrics in a time series database and can be queried with its own query language PromQL. Prometheus has 4 metric types (Gauge, Counter, Histogram, Summary).
+
+Prometheus is not a full-fledged dashboarding solution and needs to be hooked up with Grafana to generate dashboards. 
+
+#### How do Pinot metrics end up in Prometheus?
+
+Currently, Pinot metrics are exposed as JMX mbeans through the PinotJmxReporter. These JMX mbeans are consumed by Prometheus using the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter). A fairly comprehensive Prometheus JMX Exporter config can be found under `docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml`.
+
+See the [Pinot docs](https://docs.pinot.apache.org/operators/operating-pinot/monitoring) for more info.
+
+#### How can I view and test metrics?
+
+First, you need to make sure the metrics are exposed though JMX. Note, that if no metric has been published (e.g. no values recorded), the metric will not show up in JMX or Prometheus server.
+With a local Pinot deployment, you can launch `jconsole`, select your local deployment and view all the metrics exposed as jmx mbeans. To see if the metrics are being consumed with the Prometheus JMX Exporter and your config file, you can set the JAVA_OPTS env variable before running Pinot locally.
+
+`export JAVA_OPTS="-javaagent:jmx_prometheus_javaagent-0.12.0.jar=8080:pinot.yml -Xms4G -Xmx4G -XX:MaxDirectMemorySize=30g -Dlog4j2.configurationFile=conf/pinot-admin-log4j2.xml -Dplugins.dir=$BASEDIR/plugins"
+bin/pinot-admin.sh ....
+`
+
+This will expose a port at 8080 to dump metrics as Prometheus format for Prometheus scraper to fetch.

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -79,8 +79,6 @@ rules:
     status: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.pinotLeadControllerResourceEnabled\"><>(\\w+)"
   name: "pinot_controller_pinotLeadControllerResourceEnabled_$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.controllerLeaderPartitionCount\"><>(\\w+)"
-  name: "pinot_controller_controllerLeaderPartitionCount_$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.offlineTableEstimatedSize.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_offlineTableEstimatedSize_$2"
   labels:
@@ -100,8 +98,6 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.leadershipChangeWithoutCallback\"><>(\\w+)"
-  name: "pinot_controller_leadershipChangeWithoutCallback_$1"
 
   # Pinot Broker
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+).authorization\"><>(\\w+)"
@@ -199,8 +195,6 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.nettyConnectionBytesReceived\"\"><>(\\w+)"
-  name: "pinot_broker_nettyConnectionBytesReceived_$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.deserialization\"><>(\\w+)"
   name: "pinot_broker_deserialization_$2"
   labels:
@@ -209,7 +203,6 @@ rules:
   name: "pinot_broker_requestConnectionWait_$2"
   labels:
     table: "$1"
-
 
 # Pinot Server
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.documentCount.(\\w+)_(\\w+)\"><>(\\w+)"
@@ -290,80 +283,18 @@ rules:
   name: "pinot_server_netty_tcp_$2_$3"
   labels:
     id: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).deletedSegmentCount\"><>(\\w+)"
-  name: "pinot_server_deletedSegmentCount_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).realtimePartitionMismatch\"><>(\\w+)"
-  name: "pinot_server_realtimePartitionMismatch_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numDocsScanned\"><>(\\w+)"
-  name: "pinot_server_numDocsScanned_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numEntriesScannedInFilter\"><>(\\w+)"
-  name: "pinot_server_numEntriesScannedInFilter_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numEntriesScannedPostFilter\"><>(\\w+)"
-  name: "pinot_server_numEntriesScannedPostFilter_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsQueried\"><>(\\w+)"
-  name: "pinot_server_numSegmentsQueried_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsProcessed\"><>(\\w+)"
-  name: "pinot_server_numSegmentsProcessed_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsMatched\"><>(\\w+)"
-  name: "pinot_server_numSegmentsMatched_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numMissingSegments\"><>(\\w+)"
-  name: "pinot_server_numMissingSegments_$3"
-  labels:
-    table: "$1"
-    tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionBytesReceived\"><>(\\w+)"
-  name: "pinot_server_nettyConnectionBytesReceived_$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionResponsesSent\"><>(\\w+)"
-  name: "pinot_server_nettyConnectionResponsesSent_$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionBytesSent\"><>(\\w+)"
-  name: "pinot_server_nettyConnectionBytesSent_$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.lastRealtimeSegmentCreationDurationSeconds.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
-  name: "pinot_server_lastRealtimeSegmentCreationDurationSeconds_$5"
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.(\\w+)\"><>(\\w+)"
-  name: "pinot_server_realtimeOffheapMemoryUsed_$2"
-  labels:
-    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnection(\\w+)\"><>(\\w+)"
+  name: "pinot_server_nettyConnection_$1_$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeSegmentNumPartitions.(\\w+)\"><>(\\w+)"
   name: "pinot_server_realtimeSegmentNumPartitions_$2"
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcSimultaneousSegmentBuilds\"><>(\\w+)"
-  name: "pinot_server_llcSimultaneousSegmentBuilds_$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.resizeTimeMs.(\\w+)_(\\w+)\"><>(\\w+)"
-  name: "pinot_server_resizeTimeMs_$1"
+  name: "pinot_server_resizeTimeMs_$3"
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.(\\w+)_(\\w+).\\(\\w+)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.(\\w+)_(\\w+).(\\w+)\"><>(\\w+)"
   name: "pinot_server_upsertPrimaryKeysCount_$4"
   labels:
     table: "$1"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -77,7 +77,33 @@ rules:
   labels:
     taskType: "$1"
     status: "$2"
-# Pinot Broker
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.pinotLeadControllerResourceEnabled\"><>(\\w+)"
+  name: "pinot_controller_pinotLeadControllerResourceEnabled_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.controllerLeaderPartitionCount\"><>(\\w+)"
+  name: "pinot_controller_controllerLeaderPartitionCount_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.offlineTableEstimatedSize.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_offlineTableEstimatedSize_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableQuota.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableQuota_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableStorageQuotaUtilization.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableStorageQuotaUtilization_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableStorageEstMissingSegmentPercent.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableStorageEstMissingSegmentPercent_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.leadershipChangeWithoutCallback\"><>(\\w+)"
+  name: "pinot_controller_leadershipChangeWithoutCallback_$1"
+
+  # Pinot Broker
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+).authorization\"><>(\\w+)"
   name: "pinot_broker_authorization_$2"
   labels:
@@ -152,6 +178,8 @@ rules:
   name: "pinot_broker_exceptions_$1_$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.routingTableUpdateTime\"><>(\\w+)"
   name: "pinot_broker_routingTableUpdateTime_$1"
+
+
 # Pinot Server
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.documentCount.(\\w+)_(\\w+)\"><>(\\w+)"
   name: "pinot_server_documentCount_$3"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -178,6 +178,37 @@ rules:
   name: "pinot_broker_exceptions_$1_$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.routingTableUpdateTime\"><>(\\w+)"
   name: "pinot_broker_routingTableUpdateTime_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.brokerResponsesWithPartialServersResponded\"><>(\\w+)"
+  name: "pinot_broker_brokerResponsesWithPartialServersResponded_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.brokerResponsesWithNumGroupsLimitReached\"><>(\\w+)"
+  name: "pinot_broker_brokerResponsesWithNumGroupsLimitReached_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.requestConnectionTimeouts\"><>(\\w+)"
+  name: "pinot_broker_requestConnectionTimeouts_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.queryQuotaExceeded\"><>(\\w+)"
+  name: "pinot_broker_queryQuotaExceeded_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)_(\\w+).serverMissingForRouting\"><>(\\w+)"
+  name: "pinot_broker_serverMissingForRouting_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.nettyConnectionBytesReceived\"\"><>(\\w+)"
+  name: "pinot_broker_nettyConnectionBytesReceived_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.deserialization\"><>(\\w+)"
+  name: "pinot_broker_deserialization_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.requestConnectionWait\"><>(\\w+)"
+  name: "pinot_broker_requestConnectionWait_$2"
+  labels:
+    table: "$1"
 
 
 # Pinot Server
@@ -259,6 +290,86 @@ rules:
   name: "pinot_server_netty_tcp_$2_$3"
   labels:
     id: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).deletedSegmentCount\"><>(\\w+)"
+  name: "pinot_server_deletedSegmentCount_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).realtimePartitionMismatch\"><>(\\w+)"
+  name: "pinot_server_realtimePartitionMismatch_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numDocsScanned\"><>(\\w+)"
+  name: "pinot_server_numDocsScanned_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numEntriesScannedInFilter\"><>(\\w+)"
+  name: "pinot_server_numEntriesScannedInFilter_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numEntriesScannedPostFilter\"><>(\\w+)"
+  name: "pinot_server_numEntriesScannedPostFilter_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsQueried\"><>(\\w+)"
+  name: "pinot_server_numSegmentsQueried_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsProcessed\"><>(\\w+)"
+  name: "pinot_server_numSegmentsProcessed_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numSegmentsMatched\"><>(\\w+)"
+  name: "pinot_server_numSegmentsMatched_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)_(\\w+).numMissingSegments\"><>(\\w+)"
+  name: "pinot_server_numMissingSegments_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionBytesReceived\"><>(\\w+)"
+  name: "pinot_server_nettyConnectionBytesReceived_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionResponsesSent\"><>(\\w+)"
+  name: "pinot_server_nettyConnectionResponsesSent_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.nettyConnectionBytesSent\"><>(\\w+)"
+  name: "pinot_server_nettyConnectionBytesSent_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.lastRealtimeSegmentCreationDurationSeconds.(\\w+)_(\\w+)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+  name: "pinot_server_lastRealtimeSegmentCreationDurationSeconds_$5"
+  labels:
+    table: "$1"
+    tableType: "$2"
+    topic: "$3"
+    partition: "$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.(\\w+)\"><>(\\w+)"
+  name: "pinot_server_realtimeOffheapMemoryUsed_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeSegmentNumPartitions.(\\w+)\"><>(\\w+)"
+  name: "pinot_server_realtimeSegmentNumPartitions_$2"
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcSimultaneousSegmentBuilds\"><>(\\w+)"
+  name: "pinot_server_llcSimultaneousSegmentBuilds_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.resizeTimeMs.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_server_resizeTimeMs_$1"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.(\\w+)_(\\w+).\\(\\w+)\"><>(\\w+)"
+  name: "pinot_server_upsertPrimaryKeysCount_$4"
+  labels:
+    table: "$1"
+    tableType: "$2"
+    partition: "$3"
+
 # Pinot Minions
 - pattern: "\"org.apache.pinot.minion.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(\\w+)\"><>(\\w+)"
   name: "pinot_minion_$1_$2"


### PR DESCRIPTION
## Description

Adding additional JMX metrics to the Prometheus config which in turn will be consumed by Grafana. This is an immediate short term change to expose additional requested metrics to Prometheus. In the future, we should look into replacing JMXReporter with a PrometheusReporter that can directly convert metrics to Prometheus format.

Verified metrics show up locally with Prometheus jmx javaagent.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
Yes

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
- Exposes additional JMX metrics to Prometheus server


