### PR TITLE
Add system info on instance config for servers.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SystemResourceInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SystemResourceInfo.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.google.common.collect.ImmutableMap;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Class to represent system resources (CPU, Memory, etc) for an instance.
+ */
+@SuppressWarnings("unused")
+public class SystemResourceInfo {
+  private static final int MEGA_BYTES = 1024 * 1024;
+
+  private final String NUM_CORES_KEY = "numCores";
+  private final String TOTAL_MEMORY_MB_KEY = "totalMemoryMB";
+  private final String MAX_HEAP_SIZE_MB_KEY = "maxHeapSizeMB";
+
+  private final int _numCores;
+  private final long _totalMemoryMB;
+  private final long _maxHeapSizeMB;
+
+  /**
+   * Constructor that initializes the values from reading system properties.
+   */
+  public SystemResourceInfo() {
+    Runtime runtime = Runtime.getRuntime();
+    _numCores = runtime.availableProcessors();
+    OperatingSystemMXBean osMXBean = ManagementFactory.getOperatingSystemMXBean();
+
+    // Not all platforms may implement this, and so we may not have access to some of the api's.
+    if (osMXBean instanceof com.sun.management.OperatingSystemMXBean) {
+      com.sun.management.OperatingSystemMXBean sunOsMXBean = (com.sun.management.OperatingSystemMXBean) osMXBean;
+      _totalMemoryMB = sunOsMXBean.getTotalPhysicalMemorySize() / MEGA_BYTES;
+    } else {
+      _totalMemoryMB = runtime.totalMemory() / MEGA_BYTES;
+    }
+
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
+    _maxHeapSizeMB = heapMemoryUsage.getMax() / MEGA_BYTES;
+  }
+
+  /**
+   * Constructor of class from map.
+   * @param map Map containing values for member variables.
+   */
+  public SystemResourceInfo(Map<String, String> map) {
+    _numCores = Integer.parseInt(map.get(NUM_CORES_KEY));
+    _totalMemoryMB = Long.parseLong(map.get(TOTAL_MEMORY_MB_KEY));
+    _maxHeapSizeMB = Long.parseLong(map.get(MAX_HEAP_SIZE_MB_KEY));
+  }
+
+  public int getNumCores() {
+    return _numCores;
+  }
+
+  public long getTotalMemoryMB() {
+    return _totalMemoryMB;
+  }
+
+  public long getMaxHeapSizeMB() {
+    return _maxHeapSizeMB;
+  }
+
+  /**
+   * Returns a map containing names of fields along with their String values.
+   *
+   * @return Map of field names to values
+   */
+  public Map<String, String> toMap() {
+    Map<String, String> map = new HashMap<>();
+    map.put(NUM_CORES_KEY, Integer.toString(_numCores));
+    map.put(TOTAL_MEMORY_MB_KEY, Long.toString(_totalMemoryMB));
+    map.put(MAX_HEAP_SIZE_MB_KEY, Long.toString(_maxHeapSizeMB));
+    return ImmutableMap.copyOf(map);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -124,6 +124,7 @@ public class CommonConstants {
       public static final String ADMIN_HTTPS_PORT_KEY = "adminHttpsPort";
       public static final String GRPC_PORT_KEY = "grpcPort";
       public static final String NETTYTLS_PORT_KEY = "nettyTlsPort";
+      public static final String SYSTEM_RESOURCE_INFO_KEY = "SYSTEM_RESOURCE_INFO";
     }
 
     public static final String SET_INSTANCE_ID_TO_HOSTNAME_KEY = "pinot.set.instance.id.to.hostname";


### PR DESCRIPTION
## Description
There are cases where we want to be able to system info of
instances in the cluster, for example, we would like to know how many
cores, RAM, heap etc do each server for a table in the cluster have.

In this PR, we add this information as a `mapFields` property in the
instance config. Storing this information in ZK can provide a global view
of the cluster, as opposed to each instance individually knowing about itself.
```
  "mapFields": {
    "SYSTEM_RESOURCE_INFO": {
      "numCores": "16",
      "totalMemoryMB": "32768",
      "maxHeapSizeMB": "8192"
    }
  }
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
