### PR TITLE
Add minion metrics of task queueing time and task numbers

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionGauge.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionGauge.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.metrics.AbstractMetrics;
 
 
 public enum MinionGauge implements AbstractMetrics.Gauge {
+  NUMBER_OF_TASKS("tasks", true),
   ;
 
   private final String _gaugeName;

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionQueryPhase.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/metrics/MinionQueryPhase.java
@@ -23,7 +23,8 @@ import org.apache.pinot.common.metrics.AbstractMetrics;
 
 
 public enum MinionQueryPhase implements AbstractMetrics.QueryPhase {
-  TASK_EXECUTION;
+  TASK_EXECUTION,
+  TASK_QUEUEING;
 
   private final String _queryPhaseName;
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -80,16 +80,15 @@ public class TaskFactoryRegistry {
               long jobInQueueTime = jobContext.getStartTime();
               long jobDequeueTime = System.currentTimeMillis();
               _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_QUEUEING, jobDequeueTime - jobInQueueTime);
+              long startTimeMillis = System.currentTimeMillis();
               try {
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, 1L);
-                long startTimeMillis = System.currentTimeMillis();
-                TaskResult result = runInternal();
+                return runInternal();
+              } finally {
+                _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, -1L);
                 long timeSpentInMillis = System.currentTimeMillis() - startTimeMillis;
                 _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_EXECUTION, timeSpentInMillis);
                 LOGGER.info("Task: {} completed in: {}ms", _taskConfig.getId(), timeSpentInMillis);
-                return result;
-              } finally {
-                _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, -1L);
               }
             }
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -77,18 +77,17 @@ public class TaskFactoryRegistry {
               HelixManager helixManager = context.getManager();
               JobContext jobContext = TaskDriver.getJobContext(helixManager, context.getJobConfig().getJobId());
               // jobContext.getStartTime() return the time in milliseconds of job being put into helix queue.
-              long jobInQueueTime = jobContext.getStartTime();
-              long jobDequeueTime = System.currentTimeMillis();
-              _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_QUEUEING, jobDequeueTime - jobInQueueTime);
-              long startTimeMillis = System.currentTimeMillis();
+              long jobInQueueTimeMs = jobContext.getStartTime();
+              long jobDequeueTimeMs = System.currentTimeMillis();
+              _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_QUEUEING, jobDequeueTimeMs - jobInQueueTimeMs);
               try {
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, 1L);
                 return runInternal();
               } finally {
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, -1L);
-                long timeSpentInMillis = System.currentTimeMillis() - startTimeMillis;
-                _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_EXECUTION, timeSpentInMillis);
-                LOGGER.info("Task: {} completed in: {}ms", _taskConfig.getId(), timeSpentInMillis);
+                long executionTimeMs = System.currentTimeMillis() - jobDequeueTimeMs;
+                _minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_EXECUTION, executionTimeMs);
+                LOGGER.info("Task: {} completed in: {}ms", _taskConfig.getId(), executionTimeMs);
               }
             }
 


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

This PR add minion metric/Gauge of:
* task queuing time: task_dequeue_time - task_inqueue_time (assume the time drift between helix controller and pinot minion is not large, otherwise the value may be negative)
* number of tasks in progress. Whenever minion start a task, increase the Gauge by 1, whenever minion completed (either succeeded or failed) a task, decrease it by 1.

cc @mcvsubbu @jackjlli 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
