### PR TITLE
Add `PinotHelixResourceManager` to `TableConfigTuner.init()` method.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -149,7 +149,7 @@ public class PinotTableRestletResource {
 
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
 
-      TableConfigTunerUtils.applyTunerConfig(tableConfig, schema);
+      TableConfigTunerUtils.applyTunerConfig(_pinotHelixResourceManager, tableConfig, schema);
 
       // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -352,7 +352,7 @@ public class TableConfigsRestletResource {
   }
 
   private void tuneConfig(TableConfig tableConfig, Schema schema) {
-    TableConfigTunerUtils.applyTunerConfig(tableConfig, schema);
+    TableConfigTunerUtils.applyTunerConfig(_pinotHelixResourceManager, tableConfig, schema);
     TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -26,7 +27,7 @@ import org.apache.pinot.spi.data.Schema;
 @Tuner(name = "noopConfigTuner")
 public class NoOpTableTableConfigTuner implements TableConfigTuner {
   @Override
-  public void init(TunerConfig props, Schema schema) {
+  public void init(PinotHelixResourceManager pinotHelixResourceManager, TunerConfig tunerConfig, Schema schema) {
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
@@ -35,7 +36,7 @@ public class RealTimeAutoIndexTuner implements TableConfigTuner {
   private Schema _schema;
 
   @Override
-  public void init(TunerConfig props, Schema schema) {
+  public void init(PinotHelixResourceManager pinotHelixResourceManager, TunerConfig tunerConfig, Schema schema) {
     _schema = schema;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
@@ -18,20 +18,32 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import javax.annotation.Nullable;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.yetus.audience.InterfaceStability;
 
 
 /**
  * Interface for Table Config Tuner.
+ *
+ * Currently, we have a very simplistic implementation, which only needs the schema.
+ * But we anticipate that more sophisticated implementations would need more information,
+ * hence marking the interface as evolving.
  */
+@InterfaceStability.Evolving
 public interface TableConfigTuner {
   /**
    * Used to initialize underlying implementation with Schema
    * and custom properties (eg: metrics end point)
+   *
+   * @param pinotHelixResourceManager Pinot Helix Resource Manager to access Helix resources
+   * @param tunerConfig Tuner configurations
+   * @param schema Table schema
    */
-  void init(TunerConfig props, Schema schema);
+  void init(@Nullable PinotHelixResourceManager pinotHelixResourceManager, TunerConfig tunerConfig, Schema schema);
 
   /**
    * Takes the original TableConfig and returns a tuned one

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TunerConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -28,11 +29,11 @@ public class TableConfigTunerUtils {
   /**
    * Apply TunerConfig to the tableConfig
    */
-  public static void applyTunerConfig(TableConfig tableConfig, Schema schema) {
+  public static void applyTunerConfig(PinotHelixResourceManager pinotHelixResourceManager, TableConfig tableConfig, Schema schema) {
     TunerConfig tunerConfig = tableConfig.getTunerConfig();
     if (tunerConfig != null && tunerConfig.getName() != null && !tunerConfig.getName().isEmpty()) {
       TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(tunerConfig.getName());
-      tuner.init(tunerConfig, schema);
+      tuner.init(pinotHelixResourceManager, tunerConfig, schema);
       tuner.apply(tableConfig);
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
@@ -61,7 +61,7 @@ public class RealTimeAutoIndexTunerTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTunerConfig(_tunerConfig).build();
     TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
-    tuner.init(_tunerConfig, schema);
+    tuner.init(null, _tunerConfig, schema);
     TableConfig result = tuner.apply(tableConfig);
 
     IndexingConfig newConfig = result.getIndexingConfig();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
@@ -51,7 +51,7 @@ public class TunerRegistryTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTunerConfig(_tunerConfig).build();
     TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
-    tuner.init(_tunerConfig, schema);
+    tuner.init(null, _tunerConfig, schema);
     TableConfig result = tuner.apply(tableConfig);
     Assert.assertEquals(result, tableConfig);
   }


### PR DESCRIPTION
## Description
The current tuner interface only has access to table config, schema, and tuner
specific properties. Most tuners would also need more information from the
system, such as server resource info, etc.

- Added `PinotHelixResourceManager` as a parameter to the init method for the interface.
- The parameter is `@Nullable`, since the existing simple implementations do not need it.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
