### PR TITLE
Cancel running Kinesis consumer tasks when timeout occurs

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -28,10 +28,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
 import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
@@ -85,7 +87,10 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
 
     try {
       return kinesisFetchResultFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
+    } catch (TimeoutException e){
+      kinesisFetchResultFuture.cancel(true);
+      return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
+    } catch(Exception e) {
       return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
     }
   }
@@ -138,13 +143,18 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
           }
         }
 
-        if (getRecordsResponse.hasChildShards()) {
+        if (getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty()) {
           //This statement returns true only when end of current shard has reached.
+          // hasChildShards only checks if the childShard is null and is a valid instance.
           isEndOfShard = true;
           break;
         }
 
         shardIterator = getRecordsResponse.nextShardIterator();
+
+        if (Thread.interrupted()) {
+          break;
+        }
       }
 
       return new KinesisRecordsBatch(recordList, startShardToSequenceNum.getKey(), isEndOfShard);
@@ -164,6 +174,9 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     } catch (KinesisException e) {
       LOGGER.warn("Encountered unknown unrecoverable AWS exception", e);
       throw new RuntimeException(e);
+    } catch (AbortedException e){
+      LOGGER.warn("Task aborted due to exception.", e);
+      return handleException(kinesisStartCheckpoint, recordList);
     } catch (Throwable e) {
       // non transient errors
       LOGGER.error("Unknown fetchRecords exception", e);
@@ -198,5 +211,19 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   @Override
   public void close() {
     super.close();
+    shutdownAndAwaitTermination();
   }
+
+  void shutdownAndAwaitTermination() {
+    _executorService.shutdown();
+    try {
+      if (!_executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+        _executorService.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      _executorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -87,10 +87,10 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
 
     try {
       return kinesisFetchResultFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e){
+    } catch (TimeoutException e) {
       kinesisFetchResultFuture.cancel(true);
       return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
-    } catch(Exception e) {
+    } catch (Exception e) {
       return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
     }
   }
@@ -174,7 +174,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     } catch (KinesisException e) {
       LOGGER.warn("Encountered unknown unrecoverable AWS exception", e);
       throw new RuntimeException(e);
-    } catch (AbortedException e){
+    } catch (AbortedException e) {
       LOGGER.warn("Task aborted due to exception.", e);
       return handleException(kinesisStartCheckpoint, recordList);
     } catch (Throwable e) {
@@ -225,5 +225,4 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       Thread.currentThread().interrupt();
     }
   }
-
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
@@ -65,8 +65,7 @@ public class KinesisConsumerTest {
   private KinesisConfig getKinesisConfig() {
     Map<String, String> props = new HashMap<>();
     props.put(StreamConfigProperties.STREAM_TYPE, STREAM_TYPE);
-    props.put(StreamConfigProperties
-            .constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_TOPIC_NAME),
+    props.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_TOPIC_NAME),
         STREAM_NAME);
     props.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_CONSUMER_TYPES),
         StreamConfig.ConsumerType.LOWLEVEL.toString());
@@ -74,7 +73,7 @@ public class KinesisConsumerTest {
             .constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
         KinesisConsumerFactory.class.getName());
     props.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE, StreamConfigProperties.STREAM_DECODER_CLASS),
-        "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+        "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder");
     props.put(KinesisConfig.REGION, AWS_REGION);
     props.put(KinesisConfig.MAX_RECORDS_TO_FETCH, String.valueOf(MAX_RECORDS_TO_FETCH));
     props.put(KinesisConfig.SHARD_ITERATOR_TYPE, ShardIteratorType.AT_SEQUENCE_NUMBER.toString());


### PR DESCRIPTION
## Description

Currently the Kinesis consumer tasks are only cancelled when the thread terminates. However, if the executor service is still running, the tasks keep running in background even though the timout has occured.

The PR fixes this issue.

The PR also fixes a small bug whereby sometimes endOfShard is returned true even though the shard has not expired.