### PR TITLE
Add timestamp datatype support in JDBC

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
@@ -106,4 +107,37 @@
       <artifactId>jsr305</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -34,7 +34,7 @@ import org.apache.pinot.client.utils.DriverUtils;
 public class PinotPreparedStatement extends AbstractBasePreparedStatement {
 
   private static final String QUERY_FORMAT = "sql";
-  public static final String LIMIT_STATEMENT = "LIMIT";
+  private static final String LIMIT_STATEMENT = "LIMIT";
   private Connection _connection;
   private org.apache.pinot.client.Connection _session;
   private ResultSetGroup _resultSetGroup;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -33,6 +33,7 @@ import org.apache.pinot.client.utils.DateTimeUtils;
 public class PinotPreparedStatement extends AbstractBasePreparedStatement {
 
   private static final String QUERY_FORMAT = "sql";
+  public static final String LIMIT_STATEMENT = "LIMIT";
   private Connection _connection;
   private org.apache.pinot.client.Connection _session;
   private ResultSetGroup _resultSetGroup;
@@ -40,13 +41,17 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   private String _query;
   private boolean _closed;
   private ResultSet _resultSet;
+  private Integer _maxRows = Integer.MAX_VALUE;
 
   public PinotPreparedStatement(PinotConnection connection, String query) {
     _connection = connection;
     _session = connection.getSession();
-    _query = query;
     _closed = false;
-    _preparedStatement = new PreparedStatement(_session, new Request(QUERY_FORMAT, query));
+    _query = query;
+    if(!_query.contains(LIMIT_STATEMENT)) {
+      _query = _query.concat(" " + LIMIT_STATEMENT + " " + _maxRows);
+    }
+    _preparedStatement = new PreparedStatement(_session, new Request(QUERY_FORMAT, _query));
   }
 
   @Override
@@ -234,7 +239,6 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
     return execute(sql);
   }
 
-
   @Override
   public ResultSet getResultSet()
       throws SQLException {
@@ -255,6 +259,30 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
       throws SQLException {
     validateState();
     return _connection;
+  }
+
+  @Override
+  public int getFetchSize()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setFetchSize(int rows)
+      throws SQLException {
+    _maxRows = rows;
+  }
+
+  @Override
+  public int getMaxRows()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setMaxRows(int max)
+      throws SQLException {
+    _maxRows = max;
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -42,7 +42,7 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   private String _query;
   private boolean _closed;
   private ResultSet _resultSet;
-  private int _maxRows = Integer.MAX_VALUE;
+  private int _maxRows = Short.MAX_VALUE;
 
   public PinotPreparedStatement(PinotConnection connection, String query) {
     _connection = connection;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -28,6 +28,7 @@ import java.sql.Timestamp;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.client.base.AbstractBasePreparedStatement;
 import org.apache.pinot.client.utils.DateTimeUtils;
+import org.apache.pinot.client.utils.DriverUtils;
 
 
 public class PinotPreparedStatement extends AbstractBasePreparedStatement {
@@ -41,14 +42,14 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   private String _query;
   private boolean _closed;
   private ResultSet _resultSet;
-  private Integer _maxRows = Integer.MAX_VALUE;
+  private int _maxRows = Integer.MAX_VALUE;
 
   public PinotPreparedStatement(PinotConnection connection, String query) {
     _connection = connection;
     _session = connection.getSession();
     _closed = false;
     _query = query;
-    if(!_query.contains(LIMIT_STATEMENT)) {
+    if(!DriverUtils.queryContainsLimitStatement(_query)) {
       _query = _query.concat(" " + LIMIT_STATEMENT + " " + _maxRows);
     }
     _preparedStatement = new PreparedStatement(_session, new Request(QUERY_FORMAT, _query));

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -42,7 +42,7 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   private String _query;
   private boolean _closed;
   private ResultSet _resultSet;
-  private int _maxRows = Short.MAX_VALUE;
+  private int _maxRows = Integer.MAX_VALUE;
 
   public PinotPreparedStatement(PinotConnection connection, String query) {
     _connection = connection;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
@@ -34,7 +34,7 @@ public class PinotStatement extends AbstractBaseStatement {
   private ResultSetGroup _resultSetGroup;
   private boolean _closed;
   private ResultSet _resultSet;
-  private int _maxRows = Short.MAX_VALUE;
+  private int _maxRows = Integer.MAX_VALUE;
 
   public PinotStatement(PinotConnection connection) {
     _connection = connection;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
@@ -22,18 +22,19 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.apache.pinot.client.base.AbstractBaseStatement;
+import org.apache.pinot.client.utils.DriverUtils;
 
 
 public class PinotStatement extends AbstractBaseStatement {
 
   private static final String QUERY_FORMAT = "sql";
-  public static final String LIMIT_STATEMENT = "LIMIT";
+  private static final String LIMIT_STATEMENT = "LIMIT";
   private Connection _connection;
   private org.apache.pinot.client.Connection _session;
   private ResultSetGroup _resultSetGroup;
   private boolean _closed;
   private ResultSet _resultSet;
-  private Integer _maxRows = Integer.MAX_VALUE;
+  private int _maxRows = Integer.MAX_VALUE;
 
   public PinotStatement(PinotConnection connection) {
     _connection = connection;
@@ -61,7 +62,7 @@ public class PinotStatement extends AbstractBaseStatement {
       throws SQLException {
     validateState();
     try {
-      if(!sql.contains(LIMIT_STATEMENT)) {
+      if(!DriverUtils.queryContainsLimitStatement(sql)) {
         sql = sql.concat(" " + LIMIT_STATEMENT + " " + _maxRows);
       }
       Request request = new Request(QUERY_FORMAT, sql);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
@@ -27,11 +27,13 @@ import org.apache.pinot.client.base.AbstractBaseStatement;
 public class PinotStatement extends AbstractBaseStatement {
 
   private static final String QUERY_FORMAT = "sql";
+  public static final String LIMIT_STATEMENT = "LIMIT";
   private Connection _connection;
   private org.apache.pinot.client.Connection _session;
   private ResultSetGroup _resultSetGroup;
   private boolean _closed;
   private ResultSet _resultSet;
+  private Integer _maxRows = Integer.MAX_VALUE;
 
   public PinotStatement(PinotConnection connection) {
     _connection = connection;
@@ -59,6 +61,9 @@ public class PinotStatement extends AbstractBaseStatement {
       throws SQLException {
     validateState();
     try {
+      if(!sql.contains(LIMIT_STATEMENT)) {
+        sql = sql.concat(" " + LIMIT_STATEMENT + " " + _maxRows);
+      }
       Request request = new Request(QUERY_FORMAT, sql);
       _resultSetGroup = _session.execute(request);
       if (_resultSetGroup.getResultSetCount() == 0) {
@@ -114,6 +119,30 @@ public class PinotStatement extends AbstractBaseStatement {
       throws SQLException {
     validateState();
     return _connection;
+  }
+
+  @Override
+  public int getFetchSize()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setFetchSize(int rows)
+      throws SQLException {
+    _maxRows = rows;
+  }
+
+  @Override
+  public int getMaxRows()
+      throws SQLException {
+    return _maxRows;
+  }
+
+  @Override
+  public void setMaxRows(int max)
+      throws SQLException {
+    _maxRows = max;
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
@@ -34,7 +34,7 @@ public class PinotStatement extends AbstractBaseStatement {
   private ResultSetGroup _resultSetGroup;
   private boolean _closed;
   private ResultSet _resultSet;
-  private int _maxRows = Integer.MAX_VALUE;
+  private int _maxRows = Short.MAX_VALUE;
 
   public PinotStatement(PinotConnection connection) {
     _connection = connection;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -23,6 +23,8 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +36,7 @@ public class DriverUtils {
   public static final String QUERY_SEPERATOR = "&";
   public static final String PARAM_SEPERATOR = "=";
   public static final String CONTROLLER = "controller";
+  private static final String LIMIT_STATEMENT_REGEX = "\\s(limit)\\s";
 
   private DriverUtils() {
   }
@@ -143,5 +146,11 @@ public class DriverUtils {
         columnsJavaClassName = String.class.getTypeName();
     }
     return columnsJavaClassName;
+  }
+
+  public static boolean queryContainsLimitStatement(String query) {
+    Pattern pattern = Pattern.compile(LIMIT_STATEMENT_REGEX, Pattern.CASE_INSENSITIVE);
+    Matcher matcher = pattern.matcher(query);
+    return matcher.find();
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.client.utils;
 
 import java.net.URI;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
@@ -99,6 +100,9 @@ public class DriverUtils {
       case "BYTES":
         columnsSQLDataType = Types.BINARY;
         break;
+      case "TIMESTAMP":
+        columnsSQLDataType = Types.TIMESTAMP;
+        break;
       default:
         columnsSQLDataType = Types.NULL;
     }
@@ -131,6 +135,9 @@ public class DriverUtils {
         break;
       case "BYTES":
         columnsJavaClassName = byte.class.getTypeName();
+        break;
+      case "TIMESTAMP":
+        columnsJavaClassName = Timestamp.class.getTypeName();
         break;
       default:
         columnsJavaClassName = String.class.getTypeName();

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
@@ -51,7 +51,9 @@ public class PinotPreparedStatementTest {
     preparedStatement.setFloat(6, 1.4f);
     preparedStatement.executeQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
         "SELECT * FROM dummy WHERE name = 'foo' and age = 20 and score = 98.1 and ts = 123456789 and eligible = 'true' and sub_score = 1.4");
 
     preparedStatement.clearParameters();
@@ -63,7 +65,9 @@ public class PinotPreparedStatementTest {
     preparedStatement.setFloat(6, 0);
     preparedStatement.executeQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
         "SELECT * FROM dummy WHERE name = '' and age = 0 and score = 0.0 and ts = 0 and eligible = 'false' and sub_score = 0.0");
   }
 
@@ -81,8 +85,9 @@ public class PinotPreparedStatementTest {
 
     String expectedDate = DateTimeUtils.dateToString(new Date(currentTimestamp));
     String expectedTime = DateTimeUtils.timeStampToString(new Timestamp(currentTimestamp));
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
 
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(), String
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(), String
         .format("SELECT * FROM dummy WHERE date = '%s' and updated_at = '%s' and created_at = '%s'", expectedDate,
             expectedTime, expectedTime));
   }
@@ -96,13 +101,16 @@ public class PinotPreparedStatementTest {
     String value = "1234567891011121314151617181920";
     preparedStatement.setBigDecimal(1, new BigDecimal(value));
     preparedStatement.executeQuery();
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+
+    String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", value));
 
     preparedStatement.clearParameters();
     preparedStatement.setBytes(1, value.getBytes());
     preparedStatement.executeQuery();
-    Assert.assertEquals(_dummyPinotClientTransport.getLastQuery(),
+    lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", Hex.encodeHexString(value.getBytes())));
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
@@ -53,7 +53,7 @@ public class PinotPreparedStatementTest {
 
     String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
 
-    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         "SELECT * FROM dummy WHERE name = 'foo' and age = 20 and score = 98.1 and ts = 123456789 and eligible = 'true' and sub_score = 1.4");
 
     preparedStatement.clearParameters();
@@ -67,7 +67,7 @@ public class PinotPreparedStatementTest {
 
     lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
 
-    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         "SELECT * FROM dummy WHERE name = '' and age = 0 and score = 0.0 and ts = 0 and eligible = 'false' and sub_score = 0.0");
   }
 
@@ -87,7 +87,7 @@ public class PinotPreparedStatementTest {
     String expectedTime = DateTimeUtils.timeStampToString(new Timestamp(currentTimestamp));
     String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
 
-    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(), String
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(), String
         .format("SELECT * FROM dummy WHERE date = '%s' and updated_at = '%s' and created_at = '%s'", expectedDate,
             expectedTime, expectedTime));
   }
@@ -103,14 +103,14 @@ public class PinotPreparedStatementTest {
     preparedStatement.executeQuery();
 
     String lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
-    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", value));
 
     preparedStatement.clearParameters();
     preparedStatement.setBytes(1, value.getBytes());
     preparedStatement.executeQuery();
     lastExecutedQuery = _dummyPinotClientTransport.getLastQuery();
-    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).stripTrailing(),
+    Assert.assertEquals(lastExecutedQuery.substring(0, lastExecutedQuery.indexOf("LIMIT")).trim(),
         String.format("SELECT * FROM dummy WHERE value = '%s'", Hex.encodeHexString(value.getBytes())));
   }
 }


### PR DESCRIPTION
## Description

The PR addresses 3 issues with JDBC drivers - 

 - Adds support for Timestamp datatype so that function returning that datatype can be queried by JDBC
 -  Append `LIMIT [maxRows]` to the query so that the number of rows configured with `setMaxRows` or `setFetchSize` are returned rather than the default 10 rows.
 - Include all the dependencies in JDBC shaded jar so that java-client and pinot-all jars are not required to be copied to the Drivers.