### PR TITLE
Fixing pinot k8s helm for jdk11

### DIFF
--- a/kubernetes/helm/pinot/templates/controller/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/controller/configmap.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   pinot-controller.conf: |-
     controller.helix.cluster.name={{ .Values.cluster.name }}
-    controller.port={{ .Values.controller.port }}
+    controller.port={{ .Values.controller.service.port }}
 {{- if .Values.controller.vip.enabled }}
     controller.vip.host={{ .Values.controller.vip.host }}
     controller.vip.port={{ .Values.controller.vip.port }}

--- a/kubernetes/helm/pinot/templates/minion/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/minion/configmap.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "pinot.minion.config" . }}
 data:
   pinot-minion.conf: |-
-    pinot.minion.port={{ .Values.minion.port }}
+    pinot.minion.port={{ .Values.minion.service.port }}
     {{- if .Values.minion.dataDir }}
     dataDir={{ .Values.minion.dataDir }}
     {{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -21,7 +21,7 @@
 
 image:
   repository: apachepinot/pinot
-  tag: latest # release-0.7.1
+  tag: latest-jdk11 # release-0.7.1
   pullPolicy: IfNotPresent
 
 cluster:
@@ -83,7 +83,7 @@ controller:
     host: pinot-controller
     port: 9000
 
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xlog:gc*,safepoint:gc.log:time,uptime -Xlog:gc:/opt/pinot/gc-pinot-controller.log"
+  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -152,7 +152,7 @@ broker:
     # fsGroup: 2000
   securityContext: {}
 
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xlog:gc*,safepoint:gc.log:time,uptime -Xlog:gc:/opt/pinot/gc-pinot-broker.log"
+  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -244,7 +244,7 @@ server:
     storageClass: ""
     #storageClass: "ssd"
 
-  jvmOpts: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xlog:gc*,safepoint:gc.log:time,uptime -Xlog:gc:/opt/pinot/gc-pinot-server.log"
+  jvmOpts: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-server.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -317,7 +317,7 @@ minion:
     readinessEnabled: false
 
   dataDir: /var/pinot/minion/data
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -Xlog:gc*,safepoint:gc.log:time,uptime -Xlog:gc:/opt/pinot/gc-pinot-minion.log"
+  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -143,7 +143,7 @@ public class PluginManager {
       pluginsToLoad = Arrays.asList(pluginsInclude.split(","));
       LOGGER.info("Trying to load plugins: [{}]", Arrays.toString(pluginsToLoad.toArray()));
     } else {
-      LOGGER.info("Loading all plugins. Please use env variable '{}' to customize.", PLUGINS_INCLUDE_PROPERTY_NAME,
+      LOGGER.info("Loading all plugins. Please use env variable '{}' to customize. [{}]", PLUGINS_INCLUDE_PROPERTY_NAME,
           Arrays.toString(jarFiles.toArray()));
     }
     for (File jarFile : jarFiles) {
@@ -180,12 +180,12 @@ public class PluginManager {
     for (File jarFile : jarFiles) {
       try {
         urlList.add(jarFile.toURI().toURL());
-        LOGGER.info("Successfully loaded plugin [{}] from jar file [{}]", pluginName, jarFile);
       } catch (MalformedURLException e) {
         LOGGER.error("Unable to load plugin [{}] jar file [{}]", pluginName, jarFile, e);
       }
     }
     PluginClassLoader classLoader = createClassLoader(urlList);
+    LOGGER.info("Successfully loaded plugin [{}] from jar files [{}]", pluginName, Arrays.toString(urlList.toArray()));
     _registry.put(new Plugin(pluginName), classLoader);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -143,7 +143,7 @@ public class PluginManager {
       pluginsToLoad = Arrays.asList(pluginsInclude.split(","));
       LOGGER.info("Trying to load plugins: [{}]", Arrays.toString(pluginsToLoad.toArray()));
     } else {
-      LOGGER.info("Loading all plugins. Please use env variable '{}' to customize. [{}]", PLUGINS_INCLUDE_PROPERTY_NAME,
+      LOGGER.info("Please use env variable '{}' to customize plugins to load. Loading all plugins: {}", PLUGINS_INCLUDE_PROPERTY_NAME,
           Arrays.toString(jarFiles.toArray()));
     }
     for (File jarFile : jarFiles) {
@@ -185,7 +185,7 @@ public class PluginManager {
       }
     }
     PluginClassLoader classLoader = createClassLoader(urlList);
-    LOGGER.info("Successfully loaded plugin [{}] from jar files [{}]", pluginName, Arrays.toString(urlList.toArray()));
+    LOGGER.info("Successfully loaded plugin [{}] from jar files: {}", pluginName, Arrays.toString(urlList.toArray()));
     _registry.put(new Plugin(pluginName), classLoader);
   }
 


### PR DESCRIPTION
## Description
Move k8s helm example to use pinot jdk11 image and fix JVM options issues.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
