### PR TITLE
Validate the length of preprocessing operations from custom config

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/utils/preprocess/DataPreprocessingUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/utils/preprocess/DataPreprocessingUtils.java
@@ -75,12 +75,14 @@ public class DataPreprocessingUtils {
     }
   }
 
-  public static Set<Operation> getOperations(Set<Operation> operationSet, String preprocessingOperationsString) {
+  public static void getOperations(Set<Operation> operationSet, String preprocessingOperationsString) {
     String[] preprocessingOpsArray = preprocessingOperationsString.split(",");
     for (String preprocessingOps : preprocessingOpsArray) {
-      operationSet.add(Operation.getOperation(preprocessingOps.trim().toUpperCase()));
+      String trimmedOps = preprocessingOps.trim().toUpperCase();
+      if (!trimmedOps.isEmpty()) {
+        operationSet.add(Operation.getOperation(trimmedOps));
+      }
     }
-    return operationSet;
   }
 
   public enum Operation {


### PR DESCRIPTION
## Description
This PR validates the length of preprocessing operations from custom config.
By default the value would be `""` if it's missing. Thus, check the length of the string before parsing the operations.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
