### PR TITLE
Fix race condition in MinionInstancesCleanupTask

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -612,7 +612,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _segmentRelocator = new SegmentRelocator(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
         _executorService);
     periodicTasks.add(_segmentRelocator);
-    _minionInstancesCleanupTask = new MinionInstancesCleanupTask(_helixResourceManager, _config, _controllerMetrics);
+    _minionInstancesCleanupTask = new MinionInstancesCleanupTask(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics);
     periodicTasks.add(_minionInstancesCleanupTask);
 
     return periodicTasks;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -99,7 +99,10 @@ public class ControllerConf extends PinotConfiguration {
         "controller.minion.instances.cleanup.task.frequencyInSeconds";
     public static final String MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS =
         "controller.minion.instances.cleanup.task.initialDelaySeconds";
-    public static final String TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS = "controller.minion.task.metrics.emitter.frequencyInSeconds";
+    public static final String MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS =
+        "controller.minion.instances.cleanup.task.minOfflineTimeBeforeDeletionSeconds";
+    public static final String TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS =
+        "controller.minion.task.metrics.emitter.frequencyInSeconds";
 
     public static final String PINOT_TASK_MANAGER_SCHEDULER_ENABLED = "controller.task.scheduler.enabled";
     @Deprecated
@@ -146,6 +149,7 @@ public class ControllerConf extends PinotConfiguration {
     private static final int DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS = 10 * 60; // 10 minutes
     private static final int DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS = -1; // Disabled
     private static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
+    private static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_IN_SECONDS = 60 * 60; // 1 Hour.
 
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
@@ -600,6 +604,16 @@ public class ControllerConf extends PinotConfiguration {
   public void setMinionInstancesCleanupTaskInitialDelaySeconds(int initialDelaySeconds) {
     setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
         Integer.toString(initialDelaySeconds));
+  }
+
+  public int getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() {
+    return getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
+        ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_IN_SECONDS);
+  }
+
+  public void setMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds(int maxOfflineTimeRangeInSeconds) {
+    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
+        Integer.toString(maxOfflineTimeRangeInSeconds));
   }
 
   public int getDefaultTableMinReplicas() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -66,6 +66,7 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.ParticipantHistory;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
@@ -459,6 +460,35 @@ public class PinotHelixResourceManager {
           .failure("Unable to update instance: " + instanceIdToUpdate + " to tags: " + tags);
     }
     return PinotResourceManagerResponse.SUCCESS;
+  }
+
+  /**
+   * Validates whether an instance is offline for certain amount of time.
+   * Since ZNodes under "/LIVEINSTANCES" are ephemeral, if there is a ZK session expire (e.g. due to network issue),
+   * the ZNode under "/LIVEINSTANCES" will be deleted. Thus, such race condition can happen when this task is running.
+   * In order to double confirm the live status of an instance, the field "LAST_OFFLINE_TIME" in ZNode under
+   * "/INSTANCES/<instance_id>/HISTORY" needs to be checked. If the value is "-1", that means the instance is ONLINE;
+   * if the value is a timestamp, that means the instance starts to be OFFLINE since that time.
+   * @param instanceId instance id
+   * @param offlineTimeRangeMs the time range in milliseconds that it's valid for an instance to be offline
+   */
+  public boolean isInstanceOfflineFor(String instanceId, long offlineTimeRangeMs) {
+    // Check if the instance is included in /LIVEINSTANCES
+    if (_helixDataAccessor.getProperty(_keyBuilder.liveInstance(instanceId)) != null) {
+      return false;
+    }
+    ParticipantHistory participantHistory = _helixDataAccessor.getProperty(_keyBuilder.participantHistory(instanceId));
+    long lastOfflineTime = participantHistory.getLastOfflineTime();
+    // returns false if the last offline time is a negative number.
+    if (lastOfflineTime < 0) {
+      return false;
+    }
+    if (System.currentTimeMillis() - lastOfflineTime > offlineTimeRangeMs) {
+      LOGGER.info("Instance: {} has been offline for more than {}ms", instanceId, offlineTimeRangeMs);
+      return true;
+    }
+    // Still within the offline time range (e.g. due to zk session expire).
+    return false;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTask.java
@@ -23,36 +23,61 @@ import java.util.List;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.core.periodictask.BasePeriodicTask;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * A periodic task to clean up offline Minion instances to not spam Helix.
  */
 public class MinionInstancesCleanupTask extends BasePeriodicTask {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MinionInstancesCleanupTask.class);
+  private final static String TASK_NAME = "MinionInstancesCleanupTask";
   protected final PinotHelixResourceManager _pinotHelixResourceManager;
+  protected final LeadControllerManager _leadControllerManager;
   protected final ControllerMetrics _controllerMetrics;
+  private final long _minionInstanceCleanupTaskMinOfflineTimeBeforeDeletionInMilliseconds;
 
-  public MinionInstancesCleanupTask(PinotHelixResourceManager pinotHelixResourceManager, ControllerConf controllerConf,
-      ControllerMetrics controllerMetrics) {
-    super("MinionInstancesCleanupTask", controllerConf.getMinionInstancesCleanupTaskFrequencyInSeconds(),
+  public MinionInstancesCleanupTask(PinotHelixResourceManager pinotHelixResourceManager,
+      LeadControllerManager leadControllerManager, ControllerConf controllerConf, ControllerMetrics controllerMetrics) {
+    super(TASK_NAME, controllerConf.getMinionInstancesCleanupTaskFrequencyInSeconds(),
         controllerConf.getMinionInstancesCleanupTaskInitialDelaySeconds());
     _pinotHelixResourceManager = pinotHelixResourceManager;
+    _leadControllerManager = leadControllerManager;
     _controllerMetrics = controllerMetrics;
+    _minionInstanceCleanupTaskMinOfflineTimeBeforeDeletionInMilliseconds =
+        controllerConf.getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() * 1000L;
   }
 
   @Override
   protected void runTask() {
+    // Make it so that only one controller is responsible for cleaning up minion instances.
+    if (!_leadControllerManager.isLeaderForTable(TASK_NAME)) {
+      return;
+    }
+
     List<String> offlineInstances = new ArrayList<>(_pinotHelixResourceManager.getAllInstances());
     offlineInstances.removeAll(_pinotHelixResourceManager.getOnlineInstanceList());
     for (String offlineInstance : offlineInstances) {
+      // Since ZNodes under "/LIVEINSTANCES" are ephemeral, if there is a ZK session expire (e.g. due to network issue),
+      // the ZNode under "/LIVEINSTANCES" will be deleted. Thus, such race condition can happen when this task is running.
+      // In order to double confirm the live status of an instance, the field "LAST_OFFLINE_TIME" in ZNode under
+      // "/INSTANCES/<instance_id>/HISTORY" needs to be checked. If the value is "-1", that means the instance is ONLINE;
+      // if the value is a timestamp, that means the instance starts to be OFFLINE since that time.
       if (offlineInstance.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
-        PinotResourceManagerResponse response = _pinotHelixResourceManager.dropInstance(offlineInstance);
-        if (response.isSuccessful()) {
-          _controllerMetrics.addValueToGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES, 1);
+        // Drop the minion instance if it has been offline for more than a period of this task.
+        if (_pinotHelixResourceManager
+            .isInstanceOfflineFor(offlineInstance, _minionInstanceCleanupTaskMinOfflineTimeBeforeDeletionInMilliseconds)) {
+          LOGGER.info("Dropping minion instance: {}", offlineInstance);
+          PinotResourceManagerResponse response = _pinotHelixResourceManager.dropInstance(offlineInstance);
+          if (response.isSuccessful()) {
+            _controllerMetrics.addValueToGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES, 1);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
This PR fixes a race condition in `MinionInstancesCleanupTask`, where a minion instance doesn't show up in `/LIVEINSTANCES`.
This is because ZNodes under "/LIVEINSTANCES" are ephemeral; if there is a ZK session expire (e.g. due to network issue), the ZNode under "/LIVEINSTANCES" will be deleted.

In order to double confirm the live status of an instance, the field "LAST_OFFLINE_TIME" in ZNode under  "/INSTANCES/<instance_id>/HISTORY" needs to be checked. 
If the value is "-1", that means the instance is ONLINE; if the value is a timestamp, that means the instance starts to be OFFLINE since that time.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
