### PR TITLE
Cleanup PinotHelixResourceManager and move the default tag handling to the controller starter

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -575,7 +576,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   private void updateInstanceConfigIfNeeded() {
     InstanceConfig instanceConfig =
         HelixHelper.getInstanceConfig(_helixParticipantManager, _helixParticipantInstanceId);
-    if (HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port)) {
+    boolean updated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
+    updated |= HelixHelper
+        .addDefaultTags(instanceConfig, () -> Collections.singletonList(CommonConstants.Helix.CONTROLLER_INSTANCE));
+    if (updated) {
       HelixHelper.updateInstanceConfig(_helixParticipantManager, instanceConfig);
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -62,7 +62,6 @@ public class ControllerConf extends PinotConfiguration {
   public static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   public static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   public static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  public static final String EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT = "controller.upload.onlineToOfflineTimeout";
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 
@@ -175,7 +174,6 @@ public class ControllerConf extends PinotConfiguration {
   // Defines the kind of storage and the underlying PinotFS implementation
   private static final String PINOT_FS_FACTORY_CLASS_LOCAL = "controller.storage.factory.class.file";
 
-  private static final long DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
   private static final int DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
   private static final int DEFAULT_DELETED_SEGMENTS_RETENTION_IN_DAYS = 7;
   private static final int DEFAULT_TABLE_MIN_REPLICAS = 1;
@@ -539,14 +537,6 @@ public class ControllerConf extends PinotConfiguration {
   public void setSegmentRelocatorFrequencyInSeconds(int segmentRelocatorFrequencyInSeconds) {
     setProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS,
         Integer.toString(segmentRelocatorFrequencyInSeconds));
-  }
-
-  public long getExternalViewOnlineToOfflineTimeout() {
-    return getProperty(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT, DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS);
-  }
-
-  public void setExternalViewOnlineToOfflineTimeout(long timeout) {
-    setProperty(EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT, timeout);
   }
 
   public boolean tenantIsolationEnabled() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.model.InstanceConfig;
@@ -28,6 +29,7 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.controller.ControllerConf.CONTROLLER_HOST;
 import static org.apache.pinot.controller.ControllerConf.CONTROLLER_PORT;
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONTROLLER_INSTANCE;
 import static org.testng.Assert.assertEquals;
 
 
@@ -57,6 +59,7 @@ public class ControllerStarterTest extends ControllerTest {
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertEquals(instanceConfig.getHostName(), "myHost");
     assertEquals(instanceConfig.getPort(), "1234");
+    assertEquals(instanceConfig.getTags(), Collections.singleton(CONTROLLER_INSTANCE));
 
     stopController();
     stopZk();
@@ -77,6 +80,7 @@ public class ControllerStarterTest extends ControllerTest {
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertEquals(instanceConfig.getHostName(), "myHost");
     assertEquals(instanceConfig.getPort(), "1234");
+    assertEquals(instanceConfig.getTags(), Collections.singleton(CONTROLLER_INSTANCE));
 
     stopController();
     stopZk();


### PR DESCRIPTION
- Move the default tag handling from PinotHelixResourceManager to BaseControllerStarter
- Clean up the unused config `controller.upload.onlineToOfflineTimeout`