### PR TITLE
Wire TaskMetricsEmitter to controller starter

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -80,7 +80,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   TASK_STATUS("taskStatus", false),
 
   // Number of dropped minion instances
-  DROPPED_MINION_INSTANCES("droppedMinionInstances", true);
+  DROPPED_MINION_INSTANCES("droppedMinionInstances", true),
+
+  // Number of online minion instances
+  ONLINE_MINION_INSTANCES("onlineMinionInstances", true);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -69,6 +69,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.MinionInstancesCleanupTask;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.controller.helix.core.minion.TaskMetricsEmitter;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
@@ -147,6 +148,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected LeadControllerManager _leadControllerManager;
   protected List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbackList;
   protected MinionInstancesCleanupTask _minionInstancesCleanupTask;
+  protected TaskMetricsEmitter _taskMetricsEmitter;
 
   @Override
   public void init(PinotConfiguration pinotConfiguration)
@@ -618,7 +620,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     periodicTasks.add(_segmentRelocator);
     _minionInstancesCleanupTask = new MinionInstancesCleanupTask(_helixResourceManager, _config, _controllerMetrics);
     periodicTasks.add(_minionInstancesCleanupTask);
-
+    _taskMetricsEmitter =
+        new TaskMetricsEmitter(_helixResourceManager, _helixTaskResourceManager, _leadControllerManager, _config,
+            _controllerMetrics);
+    periodicTasks.add(_taskMetricsEmitter);
     return periodicTasks;
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
@@ -56,7 +56,7 @@ public class ControllerPeriodicTaskStarterStatelessTest extends ControllerTest {
   }
 
   private class MockControllerStarter extends ControllerStarter {
-    private static final int NUM_PERIODIC_TASKS = 8;
+    private static final int NUM_PERIODIC_TASKS = 9;
 
     public MockControllerStarter() {
       super();


### PR DESCRIPTION
## Description
This PR wires TaskMetricsEmitter into controller starter, and adds a controller gauge to count the number of online minion instances.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
