### PR TITLE
Fix custom instance id for controller/broker/minion

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
@@ -52,7 +52,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
-    properties.put(INSTANCE_ID_KEY, "myInstance");
+    properties.put(INSTANCE_ID_KEY, "Broker_myInstance");
     properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
     properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
 
@@ -61,13 +61,27 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
     brokerStarter.start();
 
     String instanceId = brokerStarter.getInstanceId();
-    assertEquals(instanceId, "myInstance");
+    assertEquals(instanceId, "Broker_myInstance");
     InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertEquals(instanceConfig.getHostName(), "myHost");
     assertEquals(instanceConfig.getPort(), "1234");
 
     brokerStarter.stop();
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testInvalidInstanceId()
+      throws Exception {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    properties.put(INSTANCE_ID_KEY, "myInstance");
+    properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
+    properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
+
+    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
+    brokerStarter.init(new PinotConfiguration(properties));
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/LeadControllerUtils.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class LeadControllerUtils {
-  public static final Logger LOGGER = LoggerFactory.getLogger(LeadControllerUtils.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LeadControllerUtils.class);
 
   /**
    * Given a raw table name and number of partitions, returns the partition id in lead controller resource.
@@ -52,13 +52,6 @@ public class LeadControllerUtils {
    */
   public static String generateParticipantInstanceId(String controllerHost, int controllerPort) {
     return Helix.PREFIX_OF_CONTROLLER_INSTANCE + controllerHost + "_" + controllerPort;
-  }
-
-  /**
-   * Extracts controller instance id, e.g. returns localhost_9000 given Controller_localhost_9000 as the participant instance id.
-   */
-  public static String extractControllerInstanceId(String participantInstanceId) {
-    return participantInstanceId.substring(participantInstanceId.indexOf('_') + 1);
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
@@ -33,7 +33,7 @@ public class HelixHelperTest {
 
   @Test
   public void testUpdateHostName() {
-    String instanceId = "myInstance";
+    String instanceId = "Server_myInstance";
     InstanceConfig instanceConfig = new InstanceConfig(instanceId);
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertNull(instanceConfig.getHostName());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -207,7 +207,7 @@ public class PinotQueryResource {
     String hostName = instanceConfig.getHostName();
     // Backward-compatible with legacy hostname of format 'Broker_<hostname>'
     if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
-      hostName = hostName.substring(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE.length());
+      hostName = hostName.substring(CommonConstants.Helix.BROKER_INSTANCE_PREFIX_LENGTH);
     }
 
     String protocol = _controllerConf.getControllerBrokerProtocol();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -193,7 +193,7 @@ public class PinotHelixResourceManager {
                 // Backward-compatible with legacy hostname of format 'Server_<hostname>'
                 String hostname = instanceConfig.getHostName();
                 if (hostname.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
-                  hostname = hostname.substring(Helix.PREFIX_OF_SERVER_INSTANCE.length());
+                  hostname = hostname.substring(Helix.SERVER_INSTANCE_PREFIX_LENGTH);
                 }
 
                 String protocol = CommonConstants.HTTP_PROTOCOL;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterTest.java
@@ -31,6 +31,7 @@ import static org.apache.pinot.controller.ControllerConf.CONTROLLER_PORT;
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_INSTANCE_ID;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONTROLLER_INSTANCE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 
 public class ControllerStarterTest extends ControllerTest {
@@ -46,7 +47,8 @@ public class ControllerStarterTest extends ControllerTest {
   @Test
   public void testHostnamePortOverride()
       throws Exception {
-    _configOverride.put(CONFIG_OF_INSTANCE_ID, "myInstance");
+    _configOverride.clear();
+    _configOverride.put(CONFIG_OF_INSTANCE_ID, "Controller_myInstance");
     _configOverride.put(CONTROLLER_HOST, "myHost");
     _configOverride.put(CONTROLLER_PORT, 1234);
 
@@ -54,7 +56,7 @@ public class ControllerStarterTest extends ControllerTest {
     startController();
 
     String instanceId = _controllerStarter.getInstanceId();
-    assertEquals(instanceId, "myInstance");
+    assertEquals(instanceId, "Controller_myInstance");
     InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertEquals(instanceConfig.getHostName(), "myHost");
@@ -66,8 +68,28 @@ public class ControllerStarterTest extends ControllerTest {
   }
 
   @Test
+  public void testInvalidInstanceId()
+      throws Exception {
+    _configOverride.clear();
+    _configOverride.put(CONFIG_OF_INSTANCE_ID, "myInstance");
+    _configOverride.put(CONTROLLER_HOST, "myHost");
+    _configOverride.put(CONTROLLER_PORT, 1234);
+
+    startZk();
+    try {
+      startController();
+      fail();
+    } catch (IllegalStateException e) {
+      // Expected
+    } finally {
+      stopZk();
+    }
+  }
+
+  @Test
   public void testDefaultInstanceId()
       throws Exception {
+    _configOverride.clear();
     _configOverride.put(CONTROLLER_HOST, "myHost");
     _configOverride.put(CONTROLLER_PORT, 1234);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/LeadControllerManagerTest.java
@@ -38,8 +38,7 @@ import static org.mockito.Mockito.when;
 
 
 public class LeadControllerManagerTest {
-  private static final String CONTROLLER_HOST = "localhost";
-  private static final int CONTROLLER_PORT = 18998;
+  private static final String HELIX_CONTROLLER_INSTANCE_ID = "localhost_18998";
 
   private HelixManager _helixManager;
   private ControllerMetrics _controllerMetrics;
@@ -61,9 +60,6 @@ public class LeadControllerManagerTest {
     _liveInstance = mock(LiveInstance.class);
     when(helixDataAccessor.getProperty(controllerLeader)).thenReturn(_liveInstance);
 
-    String instanceId = LeadControllerUtils.generateParticipantInstanceId(CONTROLLER_HOST, CONTROLLER_PORT);
-    when(_helixManager.getInstanceName()).thenReturn(instanceId);
-
     ConfigAccessor configAccessor = mock(ConfigAccessor.class);
     when(_helixManager.getConfigAccessor()).thenReturn(configAccessor);
     _resourceConfig = mock(ResourceConfig.class);
@@ -72,7 +68,8 @@ public class LeadControllerManagerTest {
 
   @Test
   public void testLeadControllerManager() {
-    LeadControllerManager leadControllerManager = new LeadControllerManager(_helixManager, _controllerMetrics);
+    LeadControllerManager leadControllerManager =
+        new LeadControllerManager(HELIX_CONTROLLER_INSTANCE_ID, _helixManager, _controllerMetrics);
     String tableName = "leadControllerTestTable";
     int expectedPartitionIndex = LeadControllerUtils.getPartitionIdForTable(tableName);
     String partitionName = LeadControllerUtils.generatePartitionName(expectedPartitionIndex);
@@ -108,7 +105,7 @@ public class LeadControllerManagerTest {
     leadControllerManager.addPartitionLeader(partitionName);
     Assert.assertFalse(leadControllerManager.isLeaderForTable(tableName));
 
-    // When the current controller becomes helix leader and resource is disabled, leadControllerManager should return false.
+    // When the current controller becomes helix leader and resource is disabled, leadControllerManager should return true.
     becomeHelixLeader(true);
     leadControllerManager.onHelixControllerChange();
     Assert.assertTrue(leadControllerManager.isLeaderForTable(tableName));
@@ -116,7 +113,7 @@ public class LeadControllerManagerTest {
 
   private void becomeHelixLeader(boolean becomeHelixLeader) {
     if (becomeHelixLeader) {
-      when(_liveInstance.getInstanceName()).thenReturn(CONTROLLER_HOST + "_" + CONTROLLER_PORT);
+      when(_liveInstance.getInstanceName()).thenReturn(HELIX_CONTROLLER_INSTANCE_ID);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1417,7 +1417,8 @@ public class SegmentCompletionTest {
 
     protected MockSegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager,
         boolean isLeader, ControllerMetrics controllerMetrics) {
-      super(helixManager, segmentManager, controllerMetrics, new LeadControllerManager(helixManager, controllerMetrics),
+      super(helixManager, segmentManager, controllerMetrics,
+          new LeadControllerManager("localhost_1234", helixManager, controllerMetrics),
           SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds());
       _isLeader = isLeader;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -19,14 +19,14 @@
 package org.apache.pinot.core.transport;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 
 
 public class ServerInstance {
-  private static final int SERVER_INSTANCE_PREFIX_LENGTH = Helix.PREFIX_OF_SERVER_INSTANCE.length();
-  private static final String HOSTNAME_PORT_DELIMITER = "_";
+  private static final char HOSTNAME_PORT_DELIMITER = '_';
 
   private final String _hostname;
   private final int _port;
@@ -40,7 +40,7 @@ public class ServerInstance {
     String hostname = instanceConfig.getHostName();
     if (hostname != null) {
       if (hostname.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
-        _hostname = hostname.substring(SERVER_INSTANCE_PREFIX_LENGTH);
+        _hostname = hostname.substring(Helix.SERVER_INSTANCE_PREFIX_LENGTH);
       } else {
         _hostname = hostname;
       }
@@ -49,7 +49,10 @@ public class ServerInstance {
       // Hostname might be null in some tests (InstanceConfig created by calling the constructor instead of fetching
       // from ZK), directly parse the instance name
       String instanceName = instanceConfig.getInstanceName();
-      String[] hostnameAndPort = instanceName.split(Helix.PREFIX_OF_SERVER_INSTANCE)[1].split(HOSTNAME_PORT_DELIMITER);
+      if (instanceName.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
+        instanceName = instanceName.substring(Helix.SERVER_INSTANCE_PREFIX_LENGTH);
+      }
+      String[] hostnameAndPort = StringUtils.split(instanceName, HOSTNAME_PORT_DELIMITER);
       _hostname = hostnameAndPort[0];
       _port = Integer.parseInt(hostnameAndPort[1]);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ControllerLeaderLocator.java
@@ -21,9 +21,11 @@ package org.apache.pinot.server.realtime;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.pql.parsers.utils.Pair;
@@ -123,42 +125,47 @@ public class ControllerLeaderLocator {
    */
   private void refreshControllerLeaderMapFromLeadControllerResource() {
     try {
-      ExternalView leadControllerResourceExternalView = _helixManager.getClusterManagmentTool()
-          .getResourceExternalView(_helixManager.getClusterName(), Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+      HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
+      PropertyKey.Builder keyBuilder = dataAccessor.keyBuilder();
+      ExternalView leadControllerResourceExternalView =
+          dataAccessor.getProperty(keyBuilder.externalView(Helix.LEAD_CONTROLLER_RESOURCE_NAME));
       if (leadControllerResourceExternalView == null) {
         LOGGER.error("External view of {} is null.", Helix.LEAD_CONTROLLER_RESOURCE_NAME);
         return;
       }
-      Set<String> partitionNames = leadControllerResourceExternalView.getPartitionSet();
-      if (partitionNames.size() != Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE) {
+      Map<String, Map<String, String>> partitionStateMap =
+          leadControllerResourceExternalView.getRecord().getMapFields();
+      if (partitionStateMap.size() != Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE) {
         LOGGER.error("The partition size of {} is not {}. Actual size: {}", Helix.LEAD_CONTROLLER_RESOURCE_NAME,
-            Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE, partitionNames.size());
+            Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE, partitionStateMap.size());
         return;
       }
-      for (String partitionName : partitionNames) {
-        int partitionId = LeadControllerUtils.extractPartitionId(partitionName);
-        Map<String, String> partitionStateMap = leadControllerResourceExternalView.getStateMap(partitionName);
-        boolean masterFound = false;
-        // Get master host from partition map. Return null if no master found.
-        for (Map.Entry<String, String> entry : partitionStateMap.entrySet()) {
-          if (MasterSlaveSMD.States.MASTER.name().equals(entry.getValue())) {
-            // Found the controller in master state.
-            // Converts participant id (with Prefix "Controller_") to controller id and assigns it as the leader,
-            // since realtime segment completion protocol doesn't need the prefix in controller instance id.
-            String participantInstanceId = entry.getKey();
-            String controllerInstanceId = LeadControllerUtils.extractControllerInstanceId(participantInstanceId);
-            Pair<String, Integer> leadControllerPair = convertToHostAndPortPair(controllerInstanceId);
-            masterFound = true;
-            _cachedControllerLeaderMap.put(partitionId, leadControllerPair);
+      for (Map.Entry<String, Map<String, String>> entry : partitionStateMap.entrySet()) {
+        String partitionName = entry.getKey();
+        Map<String, String> instanceStateMap = entry.getValue();
+        String masterInstanceId = null;
+        for (Map.Entry<String, String> instanceStateEntry : instanceStateMap.entrySet()) {
+          if (instanceStateEntry.getValue().equals(MasterSlaveSMD.States.MASTER.name())) {
+            masterInstanceId = instanceStateEntry.getKey();
+            break;
           }
         }
-        if (!masterFound) {
+        if (masterInstanceId == null) {
           // It's ok to log a warning since we can be in this state for some small time during the migration.
           // Otherwise, we are attempted to mark this as an error.
           LOGGER.warn("There is no controller in MASTER state for partition: {} in {}", partitionName,
               Helix.LEAD_CONTROLLER_RESOURCE_NAME);
           return;
         }
+        InstanceConfig instanceConfig = dataAccessor.getProperty(keyBuilder.instanceConfig(masterInstanceId));
+        if (instanceConfig == null) {
+          LOGGER.error("Failed to find instance config for MASTER controller: {}", masterInstanceId);
+          return;
+        }
+        int partitionId = LeadControllerUtils.extractPartitionId(partitionName);
+        Pair<String, Integer> hostnamePortPair =
+            new Pair<>(instanceConfig.getHostName(), Integer.parseInt(instanceConfig.getPort()));
+        _cachedControllerLeaderMap.put(partitionId, hostnamePortPair);
       }
       _cachedControllerLeaderValid = true;
       LOGGER.info("Refreshed controller leader map successfully.");
@@ -196,7 +203,7 @@ public class ControllerLeaderLocator {
   /**
    * Converts instance id to a pair of hostname and port.
    * @param instanceId instance id without any prefix, e.g. localhost_9000
-   * */
+   */
   private Pair<String, Integer> convertToHostAndPortPair(String instanceId) {
     // TODO: improve the exception handling.
     if (instanceId == null) {
@@ -204,7 +211,7 @@ public class ControllerLeaderLocator {
     }
     int index = instanceId.lastIndexOf('_');
     String leaderHost = instanceId.substring(0, index);
-    int leaderPort = Integer.valueOf(instanceId.substring(index + 1));
+    int leaderPort = Integer.parseInt(instanceId.substring(index + 1));
     return new Pair<>(leaderHost, leaderPort);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorIntegrationTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.server.realtime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
@@ -29,6 +28,7 @@ import org.apache.pinot.controller.ControllerStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.pql.parsers.utils.Pair;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Controller;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -68,6 +68,8 @@ public class ControllerLeaderLocatorIntegrationTest extends ControllerTest {
     validateResultSet(controllerLeaderLocator, resultSet, 1, "Failed to get only one pair of controller");
 
     Map<String, Object> properties = getDefaultControllerConfiguration();
+    // Use custom instance id
+    properties.put(Controller.CONFIG_OF_INSTANCE_ID, "Controller_myInstance");
     ControllerStarter secondControllerStarter = new ControllerStarter();
     secondControllerStarter.init(new PinotConfiguration(properties));
     secondControllerStarter.start();
@@ -90,12 +92,12 @@ public class ControllerLeaderLocatorIntegrationTest extends ControllerTest {
         controllerLeaderLocator.getCurrentTimeMs() + 2 * controllerLeaderLocator.getMinInvalidateIntervalMs());
     controllerLeaderLocator.invalidateCachedControllerLeader();
 
-    // Randomly pick a table name to get a controller leader, and this leader should be the same as the helix leader.
-    Pair<String, Integer> pair = controllerLeaderLocator.getControllerLeader(
-        _partitionToTableMap.get(new Random().nextInt(Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE)));
-
-    Assert.assertEquals(pair.getFirst(), ControllerTest.LOCAL_HOST);
-    Assert.assertEquals((int) pair.getSecond(), getControllerPort());
+    // All tables should have Helix leader as the controller leader
+    for (int i = 0; i < Helix.NUMBER_OF_PARTITIONS_IN_LEAD_CONTROLLER_RESOURCE; i++) {
+      Pair<String, Integer> hostnamePortPair = controllerLeaderLocator.getControllerLeader(_partitionToTableMap.get(i));
+      Assert.assertEquals(hostnamePortPair.getFirst(), ControllerTest.LOCAL_HOST);
+      Assert.assertEquals((int) hostnamePortPair.getSecond(), getControllerPort());
+    }
 
     // Stop the second controller.
     secondControllerStarter.stop();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -59,6 +59,11 @@ public class CommonConstants {
     public static final String PREFIX_OF_SERVER_INSTANCE = "Server_";
     public static final String PREFIX_OF_MINION_INSTANCE = "Minion_";
 
+    public static int CONTROLLER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_CONTROLLER_INSTANCE.length();
+    public static int BROKER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_BROKER_INSTANCE.length();
+    public static int SERVER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_SERVER_INSTANCE.length();
+    public static int MINION_INSTANCE_PREFIX_LENGTH = PREFIX_OF_MINION_INSTANCE.length();
+
     public static final String BROKER_RESOURCE_INSTANCE = "brokerResource";
     public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
 


### PR DESCRIPTION
## Description
Relate to  #7064 
- Fix `LeadControllerManager` and `ControllerLeadLocator` to properly handle the custom instance id for the controller. Currently these 2 classes assume that the Helix controller instance id is of the format `<hostname>_<port>` and the Helix participant instance id is of the format `Controller_<hostname>_<port>`.
- Enforce custom instance id for controller/broker/minion to follow the instance type prefix convention because the prefix is used to determine the instance type.
- Log warning for server custom instance id that does not follow the instance type prefix (not throwing exception for backward compatibility)

## Upgrade Notes
In order to use custom controller instance id, servers must have been deployed with the new code because it relies on the fix in `ControllerLeadLocator` to read the lead controller hostname and port

## Release Notes
The custom instance id should follow the instance type prefix convention:
- Controller: `Controller_`
- Broker: `Broker_`
- Server: `Server_`
- Minion: `Minion_`