### PR TITLE
Support Dictionary Based Plan for DISTINCT Aggregates

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.combine;
 
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
@@ -1,0 +1,106 @@
+package org.apache.pinot.core.operator.combine;
+
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.utils.ByteArray;
+
+import java.util.AbstractCollection;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class DistinctUsingDictionaryCombineOperator extends BaseCombineOperator {
+    private static final String OPERATOR_NAME = "DistinctCombineOperator";
+
+    private final boolean _hasOrderBy;
+
+    public DistinctUsingDictionaryCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
+                                   long endTimeMs) {
+        super(operators, queryContext, executorService, endTimeMs);
+        _hasOrderBy = queryContext.getOrderByExpressions() != null;
+    }
+
+    @Override
+    public String getOperatorName() {
+        return OPERATOR_NAME;
+    }
+
+    @Override
+    protected boolean isQuerySatisfied(IntermediateResultsBlock resultsBlock) {
+        if (_hasOrderBy) {
+            return false;
+        }
+        List<Object> result = resultsBlock.getAggregationResult();
+        assert result != null && result.size() == 1 && result.get(0) instanceof AbstractCollection;
+        AbstractCollection abstractCollection = (AbstractCollection) result.get(0);
+        return abstractCollection.size() >= _queryContext.getLimit();
+    }
+
+    @Override
+    protected void mergeResultsBlocks(IntermediateResultsBlock mergedBlock, IntermediateResultsBlock blockToMerge) {
+        // TODO: Use a separate way to represent DISTINCT instead of aggregation.
+        List<Object> mergedResults = mergedBlock.getAggregationResult();
+        assert mergedResults != null && mergedResults.size() == 1 && mergedResults.get(0) instanceof AbstractCollection;
+
+        List<Object> resultsToMerge = blockToMerge.getAggregationResult();
+        assert resultsToMerge != null && resultsToMerge.size() == 1 && resultsToMerge.get(0) instanceof AbstractCollection;
+
+        if (mergedResults.get(0) instanceof IntOpenHashSet) {
+            assert resultsToMerge.get(0) instanceof IntOpenHashSet;
+            IntOpenHashSet mergedSet = (IntOpenHashSet) mergedResults.get(0);
+            IntOpenHashSet toMergeSet = (IntOpenHashSet) resultsToMerge.get(0);
+
+            mergedSet.addAll(toMergeSet);
+        } else if (mergedResults.get(0) instanceof LongOpenHashSet) {
+            assert resultsToMerge.get(0) instanceof LongOpenHashSet;
+            LongOpenHashSet mergedSet = (LongOpenHashSet) mergedResults.get(0);
+            LongOpenHashSet toMergeSet = (LongOpenHashSet) resultsToMerge.get(0);
+
+            mergedSet.addAll(toMergeSet);
+        } else if (mergedResults.get(0) instanceof FloatOpenHashSet) {
+            assert resultsToMerge.get(0) instanceof FloatOpenHashSet;
+            FloatOpenHashSet mergedSet = (FloatOpenHashSet) mergedResults.get(0);
+            FloatOpenHashSet toMergeSet = (FloatOpenHashSet) resultsToMerge.get(0);
+
+             mergedSet.addAll(toMergeSet);
+        } else if (mergedResults.get(0) instanceof DoubleOpenHashSet) {
+            assert resultsToMerge.get(0) instanceof DoubleOpenHashSet;
+            DoubleOpenHashSet mergedSet = (DoubleOpenHashSet) mergedResults.get(0);
+            DoubleOpenHashSet toMergeSet = (DoubleOpenHashSet) resultsToMerge.get(0);
+
+            mergedSet.addAll( toMergeSet);
+        } else if (mergedResults.get(0) instanceof ObjectOpenHashSet) {
+            assert resultsToMerge.get(0) instanceof ObjectOpenHashSet;
+
+            ObjectOpenHashSet mergedSet = (ObjectOpenHashSet) mergedResults.get(0);
+            ObjectOpenHashSet toMergeSet = (ObjectOpenHashSet) resultsToMerge.get(0);
+
+            validateArgumentTypes(mergedSet, toMergeSet);
+
+            mergedSet.addAll( toMergeSet);
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Validate that merged set and set to be merged are of the same type
+     */
+    private void validateArgumentTypes(ObjectOpenHashSet mergedSet, ObjectOpenHashSet toMergeSet) {
+        Object setObject = mergedSet.iterator().next();
+        Object toMergeObject = toMergeSet.iterator().next();
+
+        if (setObject instanceof String) {
+            assert toMergeObject instanceof String;
+        } else if (setObject instanceof ByteArray) {
+            assert toMergeObject instanceof ByteArray;
+        } else {
+            throw new IllegalStateException("Unknown type encountered");
+        }
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
@@ -5,14 +5,13 @@ import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.util.AbstractCollection;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.spi.utils.ByteArray;
-
-import java.util.AbstractCollection;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Operator which combines partial results for DISTINCT operation when being executed

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctUsingDictionaryCombineOperator.java
@@ -14,8 +14,12 @@ import java.util.AbstractCollection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+/**
+ * Operator which combines partial results for DISTINCT operation when being executed
+ * using the dictionary
+ */
 public class DistinctUsingDictionaryCombineOperator extends BaseCombineOperator {
-    private static final String OPERATOR_NAME = "DistinctCombineOperator";
+    private static final String OPERATOR_NAME = "DistinctUsingDictionaryCombineOperator";
 
     private final boolean _hasOrderBy;
 
@@ -89,7 +93,7 @@ public class DistinctUsingDictionaryCombineOperator extends BaseCombineOperator 
     }
 
     /**
-     * Validate that merged set and set to be merged are of the same type
+     * Validate that merged set and set to be merged are of the same type when the sets are of ObjectOpenHashSet type
      */
     private void validateArgumentTypes(ObjectOpenHashSet mergedSet, ObjectOpenHashSet toMergeSet) {
         Object setObject = mergedSet.iterator().next();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -53,12 +53,14 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
   private final AggregationFunction[] _aggregationFunctions;
   private final Map<String, Dictionary> _dictionaryMap;
   private final int _numTotalDocs;
+  private final int _limit;
 
   public DictionaryBasedAggregationOperator(AggregationFunction[] aggregationFunctions,
-      Map<String, Dictionary> dictionaryMap, int numTotalDocs) {
+      Map<String, Dictionary> dictionaryMap, int numTotalDocs, int limit) {
     _aggregationFunctions = aggregationFunctions;
     _dictionaryMap = dictionaryMap;
     _numTotalDocs = numTotalDocs;
+    _limit = limit;
   }
 
   @Override
@@ -80,11 +82,16 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
           aggregationResults
               .add(new MinMaxRangePair(dictionary.getDoubleValue(0), dictionary.getDoubleValue(dictionarySize - 1)));
           break;
+        case DISTINCT:
         case DISTINCTCOUNT:
           switch (dictionary.getValueType()) {
             case INT:
               IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 intSet.add(dictionary.getIntValue(dictId));
               }
               aggregationResults.add(intSet);
@@ -92,6 +99,10 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case LONG:
               LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 longSet.add(dictionary.getLongValue(dictId));
               }
               aggregationResults.add(longSet);
@@ -99,6 +110,10 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case FLOAT:
               FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 floatSet.add(dictionary.getFloatValue(dictId));
               }
               aggregationResults.add(floatSet);
@@ -106,6 +121,10 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case DOUBLE:
               DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 doubleSet.add(dictionary.getDoubleValue(dictId));
               }
               aggregationResults.add(doubleSet);
@@ -113,6 +132,10 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case STRING:
               ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 stringSet.add(dictionary.getStringValue(dictId));
               }
               aggregationResults.add(stringSet);
@@ -120,6 +143,10 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case BYTES:
               ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
+                if (dictId == _limit) {
+                  break;
+                }
+
                 bytesSet.add(new ByteArray(dictionary.getBytesValue(dictId)));
               }
               aggregationResults.add(bytesSet);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -35,6 +35,8 @@ import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.utils.ByteArray;
 
+import static org.apache.pinot.segment.spi.AggregationFunctionType.DISTINCT;
+
 
 /**
  * Aggregation operator that utilizes dictionary for serving aggregation queries.
@@ -88,7 +90,9 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case INT:
               IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+
+                // Enforce limits only for DISTINCT
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 
@@ -99,7 +103,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case LONG:
               LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 
@@ -110,7 +114,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case FLOAT:
               FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 
@@ -121,7 +125,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case DOUBLE:
               DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 
@@ -132,7 +136,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case STRING:
               ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 
@@ -143,7 +147,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
             case BYTES:
               ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
               for (int dictId = 0; dictId < dictionarySize; dictId++) {
-                if (dictId == _limit) {
+                if (aggregationFunction.getType() == DISTINCT && dictId == _limit) {
                   break;
                 }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedAggregationPlanNode.java
@@ -36,6 +36,7 @@ public class DictionaryBasedAggregationPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
   private final AggregationFunction[] _aggregationFunctions;
   private final Map<String, Dictionary> _dictionaryMap;
+  private final int _limit;
 
   /**
    * Constructor for the class.
@@ -52,11 +53,13 @@ public class DictionaryBasedAggregationPlanNode implements PlanNode {
       String column = ((ExpressionContext) aggregationFunction.getInputExpressions().get(0)).getIdentifier();
       _dictionaryMap.computeIfAbsent(column, k -> _indexSegment.getDataSource(k).getDictionary());
     }
+
+    _limit = queryContext.getLimit();
   }
 
   @Override
   public DictionaryBasedAggregationOperator run() {
     return new DictionaryBasedAggregationOperator(_aggregationFunctions, _dictionaryMap,
-        _indexSegment.getSegmentMetadata().getTotalDocs());
+        _indexSegment.getSegmentMetadata().getTotalDocs(), _limit);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -180,6 +180,7 @@ public class AggregationFunctionUtils {
     return functionName.equalsIgnoreCase(AggregationFunctionType.MIN.name())
         || functionName.equalsIgnoreCase(AggregationFunctionType.MAX.name())
         || functionName.equalsIgnoreCase(AggregationFunctionType.MINMAXRANGE.name())
+            || functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCT.name())
         || functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())
         || functionName.equalsIgnoreCase(AggregationFunctionType.SEGMENTPARTITIONEDDISTINCTCOUNT.name());
     //@formatter:on

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -272,7 +272,10 @@ public class BrokerReduceService {
     }
 
     QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
-    DataTableReducer dataTableReducer = ResultReducerFactory.getResultReducer(queryContext);
+
+    // Assuming all elements in the merged data table are of same type
+    Object internalObject = dataTableMap.values().iterator().next().getObject(0, 0);
+    DataTableReducer dataTableReducer = ResultReducerFactory.getResultReducer(queryContext, internalObject);
     dataTableReducer.reduceAndSetResults(rawTableName, cachedDataSchema, dataTableMap, brokerResponseNative,
         new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
             _groupByTrimThreshold), brokerMetrics);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.reduce;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.nio.BufferUnderflowException;
 import java.util.Iterator;
 import java.util.List;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.reduce;
 
 import java.io.Serializable;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,6 +72,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
 
     // Gather all non-empty DistinctTables
     List<DistinctTable> nonEmptyDistinctTables = new ArrayList<>(dataTableMap.size());
+
     for (DataTable dataTable : dataTableMap.values()) {
       DistinctTable distinctTable = dataTable.getObject(0, 0);
       if (distinctTable.size() > 0) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.reduce;
 
 import java.io.Serializable;
-import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,7 +71,6 @@ public class DistinctDataTableReducer implements DataTableReducer {
 
     // Gather all non-empty DistinctTables
     List<DistinctTable> nonEmptyDistinctTables = new ArrayList<>(dataTableMap.size());
-
     for (DataTable dataTable : dataTableMap.values()) {
       DistinctTable distinctTable = dataTable.getObject(0, 0);
       if (distinctTable.size() > 0) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
@@ -26,6 +26,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Reducer for reducing partial results for DISTINCT operation when being executed using dictionary based plan
+ */
 public class DistinctUsingDictionaryDataTableReducer implements DataTableReducer {
     private final DistinctAggregationFunction _distinctAggregationFunction;
     private final boolean _responseFormatSql;
@@ -110,12 +113,14 @@ public class DistinctUsingDictionaryDataTableReducer implements DataTableReducer
         int numColumns = columnDataTypes.length;
         Iterator<Record> iterator = abstractCollection.iterator();
 
+        assert numColumns == 1;
+
         while (iterator.hasNext()) {
-            Object[] values = iterator.next().getValues();
+            Object value = iterator.next();
             Serializable[] row = new Serializable[numColumns];
-            for (int i = 0; i < numColumns; i++) {
-                row[i] = columnDataTypes[i].convertAndFormat(values[i]);
-            }
+
+            row[0] = (Serializable) value;
+
             rows.add(row);
         }
         return new SelectionResults(Arrays.asList(dataSchema.getColumnNames()), rows);
@@ -126,12 +131,15 @@ public class DistinctUsingDictionaryDataTableReducer implements DataTableReducer
         DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
         int numColumns = columnDataTypes.length;
         Iterator<Record> iterator = abstractCollection.iterator();
+
+        assert numColumns == 1;
+
         while (iterator.hasNext()) {
-            Object[] values = iterator.next().getValues();
+            Object value = iterator.next();
             Object[] row = new Object[numColumns];
-            for (int i = 0; i < numColumns; i++) {
-                row[i] = columnDataTypes[i].convertAndFormat(values[i]);
-            }
+
+            row[0] = value;
+
             rows.add(row);
         }
         return new ResultTable(dataSchema, rows);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
@@ -1,0 +1,139 @@
+package org.apache.pinot.core.query.reduce;
+
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.core.util.QueryOptions;
+
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class DistinctUsingDictionaryDataTableReducer implements DataTableReducer {
+    private final DistinctAggregationFunction _distinctAggregationFunction;
+    private final boolean _responseFormatSql;
+
+    // TODO: queryOptions.isPreserveType() is ignored for DISTINCT queries.
+    DistinctUsingDictionaryDataTableReducer(QueryContext queryContext, DistinctAggregationFunction distinctAggregationFunction) {
+        _distinctAggregationFunction = distinctAggregationFunction;
+        _responseFormatSql = new QueryOptions(queryContext.getQueryOptions()).isResponseFormatSQL();
+    }
+
+    /**
+     * Reduces and sets results of distinct into
+     * 1. ResultTable if _responseFormatSql is true
+     * 2. SelectionResults by default
+     */
+    @Override
+    public void reduceAndSetResults(String tableName, DataSchema dataSchema,
+                                    Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
+                                    DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
+        // Gather all non-empty AbstractCollections
+        List<AbstractCollection> nonEmptyAbstractCollections = new ArrayList<>(dataTableMap.size());
+
+        for (DataTable dataTable : dataTableMap.values()) {
+            AbstractCollection abstractCollection = dataTable.getObject(0, 0);
+            if (abstractCollection.size() > 0) {
+                nonEmptyAbstractCollections.add(abstractCollection);
+            }
+        }
+
+        if (nonEmptyAbstractCollections.isEmpty()) {
+            // All the AbstractCollections are empty, construct an empty response
+            String[] columns = _distinctAggregationFunction.getColumns();
+            if (_responseFormatSql) {
+                int numColumns = columns.length;
+                DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
+                Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
+                brokerResponseNative
+                        .setResultTable(new ResultTable(new DataSchema(columns, columnDataTypes), Collections.emptyList()));
+            } else {
+                brokerResponseNative.setSelectionResults(new SelectionResults(Arrays.asList(columns), Collections.emptyList()));
+            }
+        } else {
+            // Construct a main AbstractCollection and merge all non-empty AbstractCollections into it
+            AbstractCollection mainAbstractCollection = null;
+
+            if (nonEmptyAbstractCollections.get(0) instanceof IntOpenHashSet) {
+                mainAbstractCollection = new IntOpenHashSet();
+            } else if (nonEmptyAbstractCollections.get(0) instanceof LongOpenHashSet) {
+                mainAbstractCollection = new LongOpenHashSet();
+            } else if (nonEmptyAbstractCollections.get(0) instanceof FloatOpenHashSet) {
+                mainAbstractCollection = new FloatOpenHashSet();
+            } else if (nonEmptyAbstractCollections.get(0) instanceof DoubleOpenHashSet) {
+                mainAbstractCollection = new DoubleOpenHashSet();
+            } else if (nonEmptyAbstractCollections.get(0) instanceof ObjectOpenHashSet) {
+                mainAbstractCollection = new ObjectOpenHashSet();
+            } else {
+                throw new IllegalStateException();
+            }
+
+            assert mainAbstractCollection != null;
+
+            for (AbstractCollection abstractCollection : nonEmptyAbstractCollections) {
+                mainAbstractCollection.addAll(abstractCollection);
+            }
+
+            // Up until now, we have treated DISTINCT similar to another aggregation function even in terms
+            // of the result from function and merging results.
+            // However, the DISTINCT query is just another SELECTION style query from the user's point
+            // of view and will return one or records in the result table for the column(s) selected and so
+            // for that reason, response from broker should be a selection query result.
+            if (_responseFormatSql) {
+                brokerResponseNative.setResultTable(reduceToResultTable(mainAbstractCollection, dataSchema));
+            } else {
+                brokerResponseNative.setSelectionResults(reduceToSelectionResult(mainAbstractCollection, dataSchema));
+            }
+        }
+    }
+
+    private SelectionResults reduceToSelectionResult(AbstractCollection abstractCollection, DataSchema dataSchema) {
+        List<Serializable[]> rows = new ArrayList<>(abstractCollection.size());
+        DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+        int numColumns = columnDataTypes.length;
+        Iterator<Record> iterator = abstractCollection.iterator();
+
+        while (iterator.hasNext()) {
+            Object[] values = iterator.next().getValues();
+            Serializable[] row = new Serializable[numColumns];
+            for (int i = 0; i < numColumns; i++) {
+                row[i] = columnDataTypes[i].convertAndFormat(values[i]);
+            }
+            rows.add(row);
+        }
+        return new SelectionResults(Arrays.asList(dataSchema.getColumnNames()), rows);
+    }
+
+    private ResultTable reduceToResultTable(AbstractCollection abstractCollection, DataSchema dataSchema) {
+        List<Object[]> rows = new ArrayList<>(abstractCollection.size());
+        DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+        int numColumns = columnDataTypes.length;
+        Iterator<Record> iterator = abstractCollection.iterator();
+        while (iterator.hasNext()) {
+            Object[] values = iterator.next().getValues();
+            Object[] row = new Object[numColumns];
+            for (int i = 0; i < numColumns; i++) {
+                row[i] = columnDataTypes[i].convertAndFormat(values[i]);
+            }
+            rows.add(row);
+        }
+        return new ResultTable(dataSchema, rows);
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
@@ -5,6 +5,14 @@ import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
@@ -16,15 +24,6 @@ import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunct
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.QueryOptions;
-
-import java.io.Serializable;
-import java.util.AbstractCollection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Reducer for reducing partial results for DISTINCT operation when being executed using dictionary based plan

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctUsingDictionaryDataTableReducer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.query.reduce;
 
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pinot.core.query.reduce;
 
-import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
-import javax.swing.plaf.DesktopIconUI;
 import java.util.AbstractCollection;
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.core.query.reduce;
 
+import java.util.AbstractCollection;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-
-import java.util.AbstractCollection;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ResultReducerFactory.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pinot.core.query.reduce;
 
+import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+import javax.swing.plaf.DesktopIconUI;
+import java.util.AbstractCollection;
 
 
 /**
@@ -33,7 +37,7 @@ public final class ResultReducerFactory {
   /**
    * Constructs the right result reducer based on the given query context.
    */
-  public static DataTableReducer getResultReducer(QueryContext queryContext) {
+  public static DataTableReducer getResultReducer(QueryContext queryContext, Object object) {
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
     if (aggregationFunctions == null) {
       // Selection query
@@ -44,6 +48,10 @@ public final class ResultReducerFactory {
         // Aggregation only query
         if (aggregationFunctions.length == 1 && aggregationFunctions[0].getType() == AggregationFunctionType.DISTINCT) {
           // Distinct query
+          if (object != null && object instanceof AbstractCollection) {
+            return new DistinctUsingDictionaryDataTableReducer(queryContext, (DistinctAggregationFunction) aggregationFunctions[0]);
+          }
+
           return new DistinctDataTableReducer(queryContext, (DistinctAggregationFunction) aggregationFunctions[0]);
         } else {
           return new AggregationDataTableReducer(queryContext);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
@@ -12,6 +12,9 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 
 import static org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.USE_DICTIONARY_FOR_DISTINCT;
 
+/**
+ * Base class for tests that wish to use DISTINCT with Dictionary based plan
+ */
 public abstract class BaseQueriesWithDictBasedDistinctEnabledTest extends BaseQueriesTest {
 
     protected static PlanMaker PLAN_MAKER_WITH_DICTAGG;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.queries;
 
 import org.apache.commons.configuration.ConfigurationException;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesWithDictBasedDistinctEnabledTest.java
@@ -1,0 +1,51 @@
+package org.apache.pinot.queries;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.core.plan.maker.PlanMaker;
+import org.apache.pinot.core.query.config.QueryExecutorConfig;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+import static org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.USE_DICTIONARY_FOR_DISTINCT;
+
+public abstract class BaseQueriesWithDictBasedDistinctEnabledTest extends BaseQueriesTest {
+
+    protected static PlanMaker PLAN_MAKER_WITH_DICTAGG;
+
+    public BaseQueriesWithDictBasedDistinctEnabledTest() {
+        PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
+
+        queryExecutorConfig.setDelimiterParsingDisabled(false);
+        queryExecutorConfig.setProperty(USE_DICTIONARY_FOR_DISTINCT, true);
+
+        try {
+            PLAN_MAKER_WITH_DICTAGG = new InstancePlanMakerImplV2(new QueryExecutorConfig(new PinotConfiguration(queryExecutorConfig)));
+        } catch (ConfigurationException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    /**
+     * Run PQL query on single index segment with the Dictionary based Distinct Plan enabled.
+     * <p>Use this to test a single operator.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected <T extends Operator> T getOperatorForPqlQueryWithDictBasedDistinct(String pqlQuery) {
+        QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromPQL(pqlQuery);
+        return (T) PLAN_MAKER_WITH_DICTAGG.makeSegmentPlanNode(getIndexSegment(), queryContext).run();
+    }
+
+    /**
+     * Run SQL query on single index segment with dictionary based distinct plan enabled.
+     * <p>Use this to test a single operator.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected <T extends Operator> T getOperatorForSqlQueryWithDictBasedDistinct(String sqlQuery) {
+        QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(sqlQuery);
+        return (T) PLAN_MAKER_WITH_DICTAGG.makeSegmentPlanNode(getIndexSegment(), queryContext).run();
+    }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
@@ -2,6 +2,10 @@ package org.apache.pinot.queries;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.response.broker.SelectionResults;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -23,6 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +40,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * Tests for DISTINCT with Dictionary based plan enabled
+ */
 public class DistinctQueriesWithDictionaryTest extends BaseQueriesWithDictBasedDistinctEnabledTest {
     private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "DistinctQueriesWithDictionaryTest");
     private static final String RAW_TABLE_NAME = "testTable";
@@ -106,71 +114,8 @@ public class DistinctQueriesWithDictionaryTest extends BaseQueriesWithDictBasedD
         FileUtils.deleteQuietly(INDEX_DIR);
     }
 
-    /**
-     * Helper method to generate records based on the given base value.
-     *
-     * All columns will have the same value but different data types (BYTES values are encoded STRING values).
-     * For the {i}th unique record, the value will be {baseValue + i}.
-     */
-    private List<GenericRow> generateRecords(int baseValue) {
-        List<GenericRow> uniqueRecords = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT);
-        for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
-            int value = baseValue + i;
-            GenericRow record = new GenericRow();
-            record.putValue(INT_COLUMN, value);
-            record.putValue(LONG_COLUMN, (long) value);
-            record.putValue(FLOAT_COLUMN, (float) value);
-            record.putValue(DOUBLE_COLUMN, (double) value);
-            String stringValue = Integer.toString(value);
-            record.putValue(STRING_COLUMN, stringValue);
-            record.putValue(BYTES_COLUMN, StringUtil.encodeUtf8(StringUtils.leftPad(stringValue, 4)));
-            record.putValue(RAW_INT_COLUMN, value);
-            record.putValue(RAW_LONG_COLUMN, (long) value);
-            record.putValue(RAW_FLOAT_COLUMN, (float) value);
-            record.putValue(RAW_DOUBLE_COLUMN, (double) value);
-            record.putValue(RAW_STRING_COLUMN, stringValue);
-            record.putValue(RAW_BYTES_COLUMN, StringUtil.encodeUtf8(stringValue));
-            uniqueRecords.add(record);
-        }
-
-        List<GenericRow> records = new ArrayList<>(NUM_RECORDS_PER_SEGMENT);
-        for (int i = 0; i < NUM_RECORDS_PER_SEGMENT; i += NUM_UNIQUE_RECORDS_PER_SEGMENT) {
-            records.addAll(uniqueRecords);
-        }
-        return records;
-    }
-
-    private ImmutableSegment createSegment(int index, List<GenericRow> records)
-            throws Exception {
-        String segmentName = SEGMENT_NAME_PREFIX + index;
-
-        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE, SCHEMA);
-        segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
-        segmentGeneratorConfig.setSegmentName(segmentName);
-        segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
-
-        SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
-        driver.build();
-
-        return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);
-    }
-
-    /**
-     * Helper method to get the AbstractCollection result for one single segment for the given query.
-     */
-    private AbstractCollection getAbstractCollection(String query, boolean isPql) {
-        DictionaryBasedAggregationOperator dictionaryBasedAggregationOperator = isPql ? getOperatorForPqlQueryWithDictBasedDistinct(query) : getOperatorForSqlQueryWithDictBasedDistinct(query);
-        List<Object> operatorResult = dictionaryBasedAggregationOperator.nextBlock().getAggregationResult();
-        assertNotNull(operatorResult);
-        assertEquals(operatorResult.size(), 1);
-        assertTrue(operatorResult.get(0) instanceof AbstractCollection);
-        return (AbstractCollection) operatorResult.get(0);
-    }
-
     @Test
-    public void testSingleColumnDistinctOnly()
-            throws Exception {
+    public void testSingleColumnDistinctOnly() {
         {
             // Numeric columns
             //@formatter:off
@@ -261,5 +206,141 @@ public class DistinctQueriesWithDictionaryTest extends BaseQueriesWithDictBasedD
                 }
             }
         }
+    }
+
+    @Test
+    public void testDistinctInterSegmentWithDictionaryBasedPlan() {
+        //@formatter:off
+        String[] pqlQueries = new String[]{
+                "SELECT DISTINCT(intColumn) FROM testTable LIMIT 10000",
+                "SELECT DISTINCT(stringColumn) FROM testTable WHERE intColumn >= 60 LIMIT 10000",
+                "SELECT DISTINCT(intColumn FROM testTable ORDER BY rawBytesColumn LIMIT 5",
+                "SELECT DISTINCT(ADD(intColumn, floatColumn), stringColumn) FROM testTable WHERE longColumn < 60 ORDER BY stringColumn DESC, ADD(intColumn, floatColumn) ASC LIMIT 10",
+        };
+        String[] sqlQueries = new String[]{"SELECT DISTINCT floatColumn FROM testTable LIMIT 10000",
+                "SELECT DISTINCT stringColumn FROM testTable WHERE intColumn >= 60 LIMIT 10000",
+                "SELECT DISTINCT intColumn FROM testTable ORDER BY rawBytesColumn LIMIT 5",
+                "SELECT DISTINCT ADD(intColumn, floatColumn), stringColumn FROM testTable WHERE longColumn < 60 ORDER BY stringColumn DESC, ADD(intColumn, floatColumn) ASC LIMIT 10",
+        };
+        //@formatter:on
+        testDistinctInterSegmentHelper(pqlQueries, sqlQueries);
+    }
+
+    /**
+     * Helper method which tests single column DISTINCT queries with no predicates across two segments
+     */
+    private void testDistinctInterSegmentHelper(String[] pqlQueries, String[] sqlQueries) {
+        {
+            // Test selecting all columns
+            String pqlQuery = pqlQueries[0];
+            String sqlQuery = sqlQueries[0];
+
+            // Check data schema
+            BrokerResponseNative pqlResponse = getBrokerResponseForPqlQuery(pqlQuery, PLAN_MAKER_WITH_DICTAGG);
+            SelectionResults selectionResults = pqlResponse.getSelectionResults();
+            assertNotNull(selectionResults);
+            assertEquals(selectionResults.getColumns(),
+                    Arrays.asList("distinct_intColumn"));
+            BrokerResponseNative sqlResponse = getBrokerResponseForSqlQuery(sqlQuery, PLAN_MAKER_WITH_DICTAGG);
+            ResultTable resultTable = sqlResponse.getResultTable();
+            assertNotNull(resultTable);
+            DataSchema dataSchema = resultTable.getDataSchema();
+            assertEquals(dataSchema.getColumnNames(),
+                    new String[]{"distinct_floatColumn"});
+
+            // Check values, where all 200 unique values should be returned
+            List<Serializable[]> pqlRows = selectionResults.getRows();
+            assertEquals(pqlRows.size(), 2 * NUM_UNIQUE_RECORDS_PER_SEGMENT);
+            List<Object[]> sqlRows = resultTable.getRows();
+            assertEquals(sqlRows.size(), 2 * NUM_UNIQUE_RECORDS_PER_SEGMENT);
+            Set<Integer> expectedValues = new HashSet<>();
+            for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+                expectedValues.add(i);
+                expectedValues.add(1000 + i);
+            }
+            Set<Integer> pqlValues = new HashSet<>();
+            for (Serializable[] row : pqlRows) {
+                int intValue = (int) row[0];
+                assertEquals(((Integer) row[0]).intValue(), intValue);
+                pqlValues.add(intValue);
+            }
+            assertEquals(pqlValues, expectedValues);
+
+            Set<Float> expectedValuesFloat = new HashSet<>();
+            for (float i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+                expectedValuesFloat.add(i);
+                expectedValuesFloat.add((float) (1000.0 + i));
+            }
+
+            Set<Float> sqlValues = new HashSet<>();
+            for (Object[] row : sqlRows) {
+                float floatValue = (float) row[0];
+                assertEquals(((Float) row[0]).floatValue(), floatValue);
+                sqlValues.add(floatValue);
+            }
+            assertEquals(sqlValues, expectedValuesFloat);
+        }
+    }
+
+    /**
+     * Helper method to generate records based on the given base value.
+     *
+     * All columns will have the same value but different data types (BYTES values are encoded STRING values).
+     * For the {i}th unique record, the value will be {baseValue + i}.
+     */
+    private List<GenericRow> generateRecords(int baseValue) {
+        List<GenericRow> uniqueRecords = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT);
+        for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+            int value = baseValue + i;
+            GenericRow record = new GenericRow();
+            record.putValue(INT_COLUMN, value);
+            record.putValue(LONG_COLUMN, (long) value);
+            record.putValue(FLOAT_COLUMN, (float) value);
+            record.putValue(DOUBLE_COLUMN, (double) value);
+            String stringValue = Integer.toString(value);
+            record.putValue(STRING_COLUMN, stringValue);
+            record.putValue(BYTES_COLUMN, StringUtil.encodeUtf8(StringUtils.leftPad(stringValue, 4)));
+            record.putValue(RAW_INT_COLUMN, value);
+            record.putValue(RAW_LONG_COLUMN, (long) value);
+            record.putValue(RAW_FLOAT_COLUMN, (float) value);
+            record.putValue(RAW_DOUBLE_COLUMN, (double) value);
+            record.putValue(RAW_STRING_COLUMN, stringValue);
+            record.putValue(RAW_BYTES_COLUMN, StringUtil.encodeUtf8(stringValue));
+            uniqueRecords.add(record);
+        }
+
+        List<GenericRow> records = new ArrayList<>(NUM_RECORDS_PER_SEGMENT);
+        for (int i = 0; i < NUM_RECORDS_PER_SEGMENT; i += NUM_UNIQUE_RECORDS_PER_SEGMENT) {
+            records.addAll(uniqueRecords);
+        }
+        return records;
+    }
+
+    private ImmutableSegment createSegment(int index, List<GenericRow> records)
+            throws Exception {
+        String segmentName = SEGMENT_NAME_PREFIX + index;
+
+        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE, SCHEMA);
+        segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+        segmentGeneratorConfig.setSegmentName(segmentName);
+        segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+
+        SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+        driver.build();
+
+        return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);
+    }
+
+    /**
+     * Helper method to get the AbstractCollection result for one single segment for the given query.
+     */
+    private AbstractCollection getAbstractCollection(String query, boolean isPql) {
+        DictionaryBasedAggregationOperator dictionaryBasedAggregationOperator = isPql ? getOperatorForPqlQueryWithDictBasedDistinct(query) : getOperatorForSqlQueryWithDictBasedDistinct(query);
+        List<Object> operatorResult = dictionaryBasedAggregationOperator.nextBlock().getAggregationResult();
+        assertNotNull(operatorResult);
+        assertEquals(operatorResult.size(), 1);
+        assertTrue(operatorResult.get(0) instanceof AbstractCollection);
+        return (AbstractCollection) operatorResult.get(0);
     }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
@@ -1,0 +1,265 @@
+package org.apache.pinot.queries;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class DistinctQueriesWithDictionaryTest extends BaseQueriesWithDictBasedDistinctEnabledTest {
+    private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "DistinctQueriesWithDictionaryTest");
+    private static final String RAW_TABLE_NAME = "testTable";
+    private static final String SEGMENT_NAME_PREFIX = "testSegment_";
+
+    private static final int NUM_RECORDS_PER_SEGMENT = 10000;
+    private static final int NUM_UNIQUE_RECORDS_PER_SEGMENT = 100;
+
+    private static final String INT_COLUMN = "intColumn";
+    private static final String LONG_COLUMN = "longColumn";
+    private static final String FLOAT_COLUMN = "floatColumn";
+    private static final String DOUBLE_COLUMN = "doubleColumn";
+    private static final String STRING_COLUMN = "stringColumn";
+    private static final String BYTES_COLUMN = "bytesColumn";
+    private static final String RAW_INT_COLUMN = "rawIntColumn";
+    private static final String RAW_LONG_COLUMN = "rawLongColumn";
+    private static final String RAW_FLOAT_COLUMN = "rawFloatColumn";
+    private static final String RAW_DOUBLE_COLUMN = "rawDoubleColumn";
+    private static final String RAW_STRING_COLUMN = "rawStringColumn";
+    private static final String RAW_BYTES_COLUMN = "rawBytesColumn";
+    private static final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
+            .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG).addSingleValueDimension(FLOAT_COLUMN, FieldSpec.DataType.FLOAT)
+            .addSingleValueDimension(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE).addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+            .addSingleValueDimension(BYTES_COLUMN, FieldSpec.DataType.BYTES).addSingleValueDimension(RAW_INT_COLUMN, FieldSpec.DataType.INT)
+            .addSingleValueDimension(RAW_LONG_COLUMN, FieldSpec.DataType.LONG).addSingleValueDimension(RAW_FLOAT_COLUMN, FieldSpec.DataType.FLOAT)
+            .addSingleValueDimension(RAW_DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE)
+            .addSingleValueDimension(RAW_STRING_COLUMN, FieldSpec.DataType.STRING)
+            .addSingleValueDimension(RAW_BYTES_COLUMN, FieldSpec.DataType.BYTES).build();
+    private static final TableConfig TABLE = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .setNoDictionaryColumns(Arrays
+                    .asList(RAW_INT_COLUMN, RAW_LONG_COLUMN, RAW_FLOAT_COLUMN, RAW_DOUBLE_COLUMN, RAW_STRING_COLUMN,
+                            RAW_BYTES_COLUMN)).build();
+
+    private IndexSegment _indexSegment;
+    private List<IndexSegment> _indexSegments;
+
+    @Override
+    protected String getFilter() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected IndexSegment getIndexSegment() {
+        return _indexSegment;
+    }
+
+    @Override
+    protected List<IndexSegment> getIndexSegments() {
+        return _indexSegments;
+    }
+
+    @BeforeClass
+    public void setUp()
+            throws Exception {
+        FileUtils.deleteQuietly(INDEX_DIR);
+
+        ImmutableSegment segment0 = createSegment(0, generateRecords(0));
+        ImmutableSegment segment1 = createSegment(1, generateRecords(1000));
+        _indexSegment = segment0;
+        _indexSegments = Arrays.asList(segment0, segment1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        for (IndexSegment indexSegment : _indexSegments) {
+            indexSegment.destroy();
+        }
+
+        FileUtils.deleteQuietly(INDEX_DIR);
+    }
+
+    /**
+     * Helper method to generate records based on the given base value.
+     *
+     * All columns will have the same value but different data types (BYTES values are encoded STRING values).
+     * For the {i}th unique record, the value will be {baseValue + i}.
+     */
+    private List<GenericRow> generateRecords(int baseValue) {
+        List<GenericRow> uniqueRecords = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT);
+        for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+            int value = baseValue + i;
+            GenericRow record = new GenericRow();
+            record.putValue(INT_COLUMN, value);
+            record.putValue(LONG_COLUMN, (long) value);
+            record.putValue(FLOAT_COLUMN, (float) value);
+            record.putValue(DOUBLE_COLUMN, (double) value);
+            String stringValue = Integer.toString(value);
+            record.putValue(STRING_COLUMN, stringValue);
+            record.putValue(BYTES_COLUMN, StringUtil.encodeUtf8(StringUtils.leftPad(stringValue, 4)));
+            record.putValue(RAW_INT_COLUMN, value);
+            record.putValue(RAW_LONG_COLUMN, (long) value);
+            record.putValue(RAW_FLOAT_COLUMN, (float) value);
+            record.putValue(RAW_DOUBLE_COLUMN, (double) value);
+            record.putValue(RAW_STRING_COLUMN, stringValue);
+            record.putValue(RAW_BYTES_COLUMN, StringUtil.encodeUtf8(stringValue));
+            uniqueRecords.add(record);
+        }
+
+        List<GenericRow> records = new ArrayList<>(NUM_RECORDS_PER_SEGMENT);
+        for (int i = 0; i < NUM_RECORDS_PER_SEGMENT; i += NUM_UNIQUE_RECORDS_PER_SEGMENT) {
+            records.addAll(uniqueRecords);
+        }
+        return records;
+    }
+
+    private ImmutableSegment createSegment(int index, List<GenericRow> records)
+            throws Exception {
+        String segmentName = SEGMENT_NAME_PREFIX + index;
+
+        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE, SCHEMA);
+        segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+        segmentGeneratorConfig.setSegmentName(segmentName);
+        segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+
+        SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+        driver.build();
+
+        return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);
+    }
+
+    /**
+     * Helper method to get the AbstractCollection result for one single segment for the given query.
+     */
+    private AbstractCollection getAbstractCollection(String query, boolean isPql) {
+        DictionaryBasedAggregationOperator dictionaryBasedAggregationOperator = isPql ? getOperatorForPqlQueryWithDictBasedDistinct(query) : getOperatorForSqlQueryWithDictBasedDistinct(query);
+        List<Object> operatorResult = dictionaryBasedAggregationOperator.nextBlock().getAggregationResult();
+        assertNotNull(operatorResult);
+        assertEquals(operatorResult.size(), 1);
+        assertTrue(operatorResult.get(0) instanceof AbstractCollection);
+        return (AbstractCollection) operatorResult.get(0);
+    }
+
+    @Test
+    public void testSingleColumnDistinctOnly()
+            throws Exception {
+        {
+            // Numeric columns
+            //@formatter:off
+            List<String> queries = Arrays
+                    .asList("SELECT DISTINCT(intColumn) FROM testTable", "SELECT DISTINCT(longColumn) FROM testTable",
+                            "SELECT DISTINCT(floatColumn) FROM testTable", "SELECT DISTINCT(doubleColumn) FROM testTable");
+            //@formatter:on
+            Set<Integer> expectedValues = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                expectedValues.add(i);
+            }
+            for (String query : queries) {
+                AbstractCollection pqlDistinctSet = getAbstractCollection(query, true);
+                AbstractCollection sqlDistinctSet = getAbstractCollection(query, false);
+                for (AbstractCollection distinctSet : Arrays
+                        .asList(pqlDistinctSet, sqlDistinctSet)) {
+                    assertEquals(distinctSet.size(), 10);
+                    Set<Integer> actualValues = new HashSet<>();
+                    Iterator iterator = distinctSet.iterator();
+
+                    while (iterator.hasNext()) {
+                        Object value = iterator.next();
+
+                        assertTrue(value instanceof Integer || value instanceof Long || value instanceof Double || value instanceof Float);
+                        actualValues.add(((Number) value).intValue());
+                    }
+                    assertEquals(actualValues, expectedValues);
+                }
+            }
+        }
+        {
+            // String columns
+            //@formatter:off
+            List<String> queries = Arrays
+                    .asList("SELECT DISTINCT(stringColumn) FROM testTable LIMIT 100");
+            //@formatter:on
+            Set<Integer> expectedValues = new HashSet<>();
+            for (int i = 0; i < 100; i++) {
+                expectedValues.add(i);
+            }
+            for (String query : queries) {
+                AbstractCollection pqlDistinctSet = getAbstractCollection(query, true);
+                AbstractCollection sqlDistinctSet = getAbstractCollection(query, false);
+
+                for (AbstractCollection distinctSet : Arrays
+                        .asList(pqlDistinctSet,  sqlDistinctSet)) {
+                    assertEquals(distinctSet.size(), 100);
+                    Set<Integer> actualValues = new HashSet<>();
+                    Iterator iterator = distinctSet.iterator();
+
+                    while (iterator.hasNext()) {
+                        Object value = iterator.next();
+
+                        assertTrue(value instanceof String);
+                        actualValues.add(Integer.parseInt((String) value));
+                    }
+                    assertEquals(actualValues, expectedValues);
+                }
+            }
+        }
+        {
+            // Bytes columns
+            //@formatter:off
+            List<String> queries = Arrays
+                    .asList("SELECT DISTINCT(bytesColumn) FROM testTable");
+            //@formatter:on
+            Set<Integer> expectedValues = new HashSet<>();
+            for (int i = 0; i < 10; i++) {
+                expectedValues.add(i);
+            }
+            for (String query : queries) {
+                AbstractCollection pqlDistinctSet = getAbstractCollection(query, true);
+                AbstractCollection sqlDistinctSet = getAbstractCollection(query, false);
+
+                for (AbstractCollection distinctSet : Arrays
+                        .asList(pqlDistinctSet, sqlDistinctSet)) {
+                    assertEquals(distinctSet.size(), 10);
+                    Set<Integer> actualValues = new HashSet<>();
+                    Iterator iterator = distinctSet.iterator();
+                    while (iterator.hasNext()){
+                        Object value = iterator.next();
+
+                        assertTrue(value instanceof ByteArray);
+                        actualValues.add(Integer.parseInt(
+                                org.apache.pinot.spi.utils.StringUtils.decodeUtf8(((ByteArray) value).getBytes()).trim()));
+                    }
+                    assertEquals(actualValues, expectedValues);
+                }
+            }
+        }
+    }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.queries;
 
 import java.io.File;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesWithDictionaryTest.java
@@ -1,5 +1,14 @@
 package org.apache.pinot.queries;
 
+import java.io.File;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -25,16 +34,6 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.io.Serializable;
-import java.util.AbstractCollection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;


### PR DESCRIPTION
## Description
This PR introduces the notion of dictionary based execution for DISTINCT aggregates when the aggregate contains only a single, dictionary enabled column and no predicates.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options.  YES
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

pinot.server.query.executor.use.dictionary.for.distinct -- Use this parameter to enable query planner to use dictionary based execution plan for single column, no predicate DISTINCT aggregates

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
