### PR TITLE
Add support to skip tests if docker is not available

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
@@ -23,7 +23,6 @@ import cloud.localstack.docker.annotation.LocalstackDockerAnnotationProcessor;
 import cloud.localstack.docker.annotation.LocalstackDockerConfiguration;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import cloud.localstack.docker.command.Command;
-import cloud.localstack.docker.exception.LocalstackDockerException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.common.base.Function;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeKinesisIntegrationTest.java
@@ -219,14 +219,10 @@ public class RealtimeKinesisIntegrationTest extends BaseClusterIntegrationTestSe
 
   public void startKinesis()
       throws Exception {
-    try {
-      final LocalstackDockerConfiguration dockerConfig = PROCESSOR.process(this.getClass());
-      StopAllLocalstackDockerCommand stopAllLocalstackDockerCommand = new StopAllLocalstackDockerCommand();
-      stopAllLocalstackDockerCommand.execute();
-      localstackDocker.startup(dockerConfig);
-    } catch (LocalstackDockerException e) {
-      LOGGER.error("Cannot start Localstack Kinesis container", e);
-    }
+    final LocalstackDockerConfiguration dockerConfig = PROCESSOR.process(this.getClass());
+    StopAllLocalstackDockerCommand stopAllLocalstackDockerCommand = new StopAllLocalstackDockerCommand();
+    stopAllLocalstackDockerCommand.execute();
+    localstackDocker.startup(dockerConfig);
 
     kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder()
         .buildWithDefaults(


### PR DESCRIPTION
## Description
Currently kinesis integration test fails if docker is not installed or is not running in the environment. This creates issues for users who want to build pinot locally or use it in CI/CD setups without docker.

The PR add code in integration test which will skip the test if docker is not available locally.

The future plan is to move away from docker in this test and use an embedded kinesis server.
