### PR TITLE
Support Dictionary Based Plan For DISTINCT

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -1,0 +1,144 @@
+package org.apache.pinot.core.operator.query;
+
+import it.unimi.dsi.fastutil.ints.IntHeapPriorityQueue;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntPriorityQueue;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
+import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Operator which executes DISTINCT operation based on dictionary
+ */
+public class DictionaryBasedDistinctOperator extends DistinctOperator {
+    private static final String OPERATOR_NAME = "DictionaryBasedDistinctOperator";
+    int MAX_INITIAL_CAPACITY = 10000;
+
+    private final DistinctAggregationFunction _distinctAggregationFunction;
+    private final Map<String, Dictionary> _dictionaryMap;
+    private final int _numTotalDocs;
+    private final TransformOperator _transformOperator;
+    private final IntOpenHashSet _dictIdSet;
+
+    private IntPriorityQueue _priorityQueue;
+
+    private boolean _hasOrderBy;
+
+    public DictionaryBasedDistinctOperator(IndexSegment indexSegment, DistinctAggregationFunction distinctAggregationFunction,
+                                           Map<String, Dictionary> dictionaryMap, int numTotalDocs,
+                                           TransformOperator transformOperator) {
+        super(indexSegment, distinctAggregationFunction, transformOperator);
+
+        _distinctAggregationFunction = distinctAggregationFunction;
+        _dictionaryMap = dictionaryMap;
+        _numTotalDocs = numTotalDocs;
+        _transformOperator = transformOperator;
+        _dictIdSet = new IntOpenHashSet();
+
+        List<OrderByExpressionContext> orderByExpressionContexts = _distinctAggregationFunction.getOrderByExpressions();
+
+        if (orderByExpressionContexts != null) {
+            OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+            int limit = _distinctAggregationFunction.getLimit();
+            int comparisonFactor = orderByExpressionContext.isAsc() ? -1 : 1;
+            _priorityQueue =
+                    new IntHeapPriorityQueue(Math.min(limit, MAX_INITIAL_CAPACITY), (i1, i2) -> (i1 - i2) * comparisonFactor);
+            _hasOrderBy = true;
+        }
+    }
+
+    @Override
+    protected IntermediateResultsBlock getNextBlock() {
+        int limit = _distinctAggregationFunction.getLimit();
+        String column = _distinctAggregationFunction.getInputExpressions().get(0).getIdentifier();
+
+        assert _distinctAggregationFunction.getType() == AggregationFunctionType.DISTINCT;
+
+        Dictionary dictionary = _dictionaryMap.get(column);
+        int dictionarySize = dictionary.length();
+
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+            if (!_hasOrderBy) {
+                if (_dictIdSet.size() >= limit) {
+                    break;
+                }
+
+                _dictIdSet.add(dictId);
+            } else {
+                if (!_dictIdSet.contains(dictId)) {
+                    if (_dictIdSet.size() < limit) {
+                        _dictIdSet.add(dictId);
+                        _priorityQueue.enqueue(dictId);
+                    } else {
+                        int firstDictId = _priorityQueue.firstInt();
+                        if (_priorityQueue.comparator().compare(dictId, firstDictId) > 0) {
+                            _dictIdSet.remove(firstDictId);
+                            _dictIdSet.add(dictId);
+                            _priorityQueue.dequeueInt();
+                            _priorityQueue.enqueue(dictId);
+                        }
+                    }
+                }
+            }
+        }
+
+        DistinctTable distinctTable = buildResult();
+
+        return new IntermediateResultsBlock(new AggregationFunction[]{_distinctAggregationFunction},
+                Collections.singletonList(distinctTable), false);
+    }
+
+    /**
+     * Build the final result for this operation
+     */
+    private DistinctTable buildResult() {
+        String column = _distinctAggregationFunction.getInputExpressions().get(0).getIdentifier();
+
+        assert _distinctAggregationFunction.getType() == AggregationFunctionType.DISTINCT;
+
+        Dictionary dictionary = _dictionaryMap.get(column);
+
+        List<ExpressionContext> expressions = _distinctAggregationFunction.getInputExpressions();
+        ExpressionContext expression = expressions.get(0);
+        FieldSpec.DataType dataType = _transformOperator.getResultMetadata(expression).getDataType();
+
+        DataSchema dataSchema = new DataSchema(new String[]{expression.toString()},
+                new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.fromDataTypeSV(dataType)});
+        List<Record> records = new ArrayList<>(_dictIdSet.size());
+        Iterator<Integer> dictIdIterator = _dictIdSet.iterator();
+
+        for(int i = 0; i < _dictIdSet.size(); i++) {
+            records.add(new Record(new Object[]{dictionary.getInternal(dictIdIterator.next())}));
+        }
+
+        return new DistinctTable(dataSchema, records);
+    }
+
+    @Override
+    public String getOperatorName() {
+        return OPERATOR_NAME;
+    }
+
+    @Override
+    public ExecutionStatistics getExecutionStatistics() {
+        // NOTE: Set numDocsScanned to numTotalDocs for backward compatibility.
+        return new ExecutionStatistics(_numTotalDocs, 0, 0, _numTotalDocs);
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -1,12 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.query;
 
 import it.unimi.dsi.fastutil.ints.IntHeapPriorityQueue;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntPriorityQueue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -18,12 +40,6 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Operator which executes DISTINCT operation based on dictionary

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -119,7 +119,10 @@ public class DictionaryBasedDistinctOperator extends DistinctOperator {
                     }
                 }
             } else {
-                records = new ArrayList<>(_dictionary.length());
+  DistinctTable distinctTable = new DistinctTable(dataSchema, _distinctAggregationFunction.getOrderByExpressions(), limit);
+  for (int i = 0; i < dictionarySize; i++) {
+    distinctTable.addWithOrderBy(new Record(new Object[]{_dictionary.getInternal(i)}));
+  }
                 for (int i = 0; i < _dictionary.length(); i++) {
                     records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
                 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.ints.IntPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -76,12 +77,14 @@ public class DictionaryBasedDistinctOperator extends DistinctOperator {
 
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
             if (!_hasOrderBy) {
+                _dictIdSet.add(dictId);
+
                 if (_dictIdSet.size() >= limit) {
                     break;
                 }
-
-                _dictIdSet.add(dictId);
             } else {
+                // We already ascertained that the dictionary is sorted, hence we can use IDs instead of actual values
+                // to determine order
                 if (!_dictIdSet.contains(dictId)) {
                     if (_dictIdSet.size() < limit) {
                         _dictIdSet.add(dictId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
@@ -1,0 +1,52 @@
+package org.apache.pinot.core.plan;
+
+import org.apache.pinot.core.operator.query.DictionaryBasedDistinctOperator;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Execute a DISTINCT operation using dictionary based plan
+ */
+public class DictionaryBasedDistinctPlanNode implements PlanNode {
+    private final IndexSegment _indexSegment;
+    private final DistinctAggregationFunction _distinctAggregationFunction;
+    private final Map<String, Dictionary> _dictionaryMap;
+    private final TransformPlanNode _transformPlanNode;
+
+    /**
+     * Constructor for the class.
+     *
+     * @param indexSegment Segment to process
+     * @param queryContext Query context
+     */
+    public DictionaryBasedDistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
+        _indexSegment = indexSegment;
+        AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+
+        assert aggregationFunctions != null && aggregationFunctions.length == 1
+                && aggregationFunctions[0] instanceof DistinctAggregationFunction;
+
+        _distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
+
+        _dictionaryMap = new HashMap<>();
+
+        String column = _distinctAggregationFunction.getInputExpressions().get(0).getIdentifier();
+        _dictionaryMap.computeIfAbsent(column, k -> _indexSegment.getDataSource(k).getDictionary());
+
+        _transformPlanNode =
+                new TransformPlanNode(_indexSegment, queryContext, _distinctAggregationFunction.getInputExpressions(),
+                        DocIdSetPlanNode.MAX_DOC_PER_CALL);
+    }
+
+    @Override
+    public DictionaryBasedDistinctOperator run() {
+        return new DictionaryBasedDistinctOperator(_indexSegment, _distinctAggregationFunction, _dictionaryMap,
+                _indexSegment.getSegmentMetadata().getTotalDocs(), _transformPlanNode.run());
+    }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
@@ -1,14 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.plan;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.pinot.core.operator.query.DictionaryBasedDistinctOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Execute a DISTINCT operation using dictionary based plan

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
@@ -32,7 +32,6 @@ public class DictionaryBasedDistinctPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
   private final DistinctAggregationFunction _distinctAggregationFunction;
   private final Dictionary _dictionary;
-  private final TransformPlanNode _transformPlanNode;
 
   /**
    * Constructor for the class.
@@ -50,15 +49,11 @@ public class DictionaryBasedDistinctPlanNode implements PlanNode {
     _distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
 
     _dictionary = dictionary;
-
-    _transformPlanNode =
-        new TransformPlanNode(_indexSegment, queryContext, _distinctAggregationFunction.getInputExpressions(),
-            DocIdSetPlanNode.MAX_DOC_PER_CALL);
   }
 
   @Override
   public DictionaryBasedDistinctOperator run() {
     return new DictionaryBasedDistinctOperator(_indexSegment, _distinctAggregationFunction, _dictionary,
-        _indexSegment.getSegmentMetadata().getTotalDocs(), _transformPlanNode.run());
+        _indexSegment.getSegmentMetadata().getTotalDocs());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DictionaryBasedDistinctPlanNode.java
@@ -29,36 +29,36 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
  * Execute a DISTINCT operation using dictionary based plan
  */
 public class DictionaryBasedDistinctPlanNode implements PlanNode {
-    private final IndexSegment _indexSegment;
-    private final DistinctAggregationFunction _distinctAggregationFunction;
-    private final Dictionary _dictionary;
-    private final TransformPlanNode _transformPlanNode;
+  private final IndexSegment _indexSegment;
+  private final DistinctAggregationFunction _distinctAggregationFunction;
+  private final Dictionary _dictionary;
+  private final TransformPlanNode _transformPlanNode;
 
-    /**
-     * Constructor for the class.
-     *
-     * @param indexSegment Segment to process
-     * @param queryContext Query context
-     */
-    public DictionaryBasedDistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext, Dictionary dictionary) {
-        _indexSegment = indexSegment;
-        AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+  /**
+   * Constructor for the class.
+   *
+   * @param indexSegment Segment to process
+   * @param queryContext Query context
+   */
+  public DictionaryBasedDistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext, Dictionary dictionary) {
+    _indexSegment = indexSegment;
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
 
-        assert aggregationFunctions != null && aggregationFunctions.length == 1
-                && aggregationFunctions[0] instanceof DistinctAggregationFunction;
+    assert aggregationFunctions != null && aggregationFunctions.length == 1
+        && aggregationFunctions[0] instanceof DistinctAggregationFunction;
 
-        _distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
+    _distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
 
-        _dictionary = dictionary;
+    _dictionary = dictionary;
 
-        _transformPlanNode =
-                new TransformPlanNode(_indexSegment, queryContext, _distinctAggregationFunction.getInputExpressions(),
-                        DocIdSetPlanNode.MAX_DOC_PER_CALL);
-    }
+    _transformPlanNode =
+        new TransformPlanNode(_indexSegment, queryContext, _distinctAggregationFunction.getInputExpressions(),
+            DocIdSetPlanNode.MAX_DOC_PER_CALL);
+  }
 
-    @Override
-    public DictionaryBasedDistinctOperator run() {
-        return new DictionaryBasedDistinctOperator(_indexSegment, _distinctAggregationFunction, _dictionary,
-                _indexSegment.getSegmentMetadata().getTotalDocs(), _transformPlanNode.run());
-    }
+  @Override
+  public DictionaryBasedDistinctOperator run() {
+    return new DictionaryBasedDistinctOperator(_indexSegment, _distinctAggregationFunction, _dictionary,
+        _indexSegment.getSegmentMetadata().getTotalDocs(), _transformPlanNode.run());
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -277,6 +277,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
     // If we have gotten here, it must have been verified that there is only on aggregation function in the context
     // and it is a DistinctAggregationFunction
+
     DistinctAggregationFunction distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
     List<ExpressionContext> expressions = distinctAggregationFunction.getInputExpressions();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -191,7 +191,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       return new SelectionPlanNode(indexSegment, queryContext);
     } else {
       assert QueryContextUtils.isDistinctQuery(queryContext);
-      return getDistinctExecutionNode(indexSegment, queryContext);
+      return getDistinctPlanNode(indexSegment, queryContext);
     }
   }
 
@@ -271,7 +271,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   /**
    * Returns dictionary based distinct plan node iff supported, else distinct plan node
    */
-  private PlanNode getDistinctExecutionNode(IndexSegment indexSegment, QueryContext queryContext) {
+  private PlanNode getDistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
 
     // If we have gotten here, it must have been verified that there is only on aggregation function in the context
@@ -286,8 +286,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
         String column = expression.getIdentifier();
         Dictionary dictionary = indexSegment.getDataSource(column).getDictionary();
-        if (dictionary != null && dictionary.isSorted()) {
-          return new DictionaryBasedDistinctPlanNode(indexSegment, queryContext);
+        if (dictionary != null) {
+          return new DictionaryBasedDistinctPlanNode(indexSegment, queryContext, dictionary);
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.common.proto.Server;
-import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.core.plan.AggregationGroupByOrderByPlanNode;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -298,8 +298,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
         DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
         DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
         DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
-        for (DistinctTable distinctTable : Arrays
-                .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
+        for (DistinctTable distinctTable : Arrays.asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
           assertEquals(distinctTable.size(), 10);
           Set<Integer> actualValues = new HashSet<>();
           for (Record record : distinctTable.getRecords()) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -266,6 +266,8 @@ public class DistinctQueriesTest extends BaseQueriesTest {
             assertTrue(values[0] instanceof String);
             actualValues.add(Integer.parseInt((String) values[0]));
           }
+          //TODO: atri
+          System.out.println("QUERY IS" + " " + query);
           assertEquals(actualValues, expectedValues);
         }
       }
@@ -336,6 +338,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
             assertTrue(values[0] instanceof Number);
             actualValues.add(((Number) values[0]).intValue());
           }
+          System.out.println("QUERY IS " + query);
           assertEquals(actualValues, expectedValues);
         }
       }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -245,21 +245,13 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       // String columns
       //@formatter:off
       List<String> queries = Arrays
-          .asList("SELECT DISTINCT(stringColumn) FROM testTable ORDER BY stringColumn");
+          .asList("SELECT DISTINCT(stringColumn) FROM testTable");
       //@formatter:on
       Set<Integer> expectedValues = new HashSet<>();
 
-      expectedValues.add(0);
-      expectedValues.add(16);
-      expectedValues.add(17);
-      expectedValues.add(1);
-      expectedValues.add(10);
-      expectedValues.add(11);
-      expectedValues.add(12);
-      expectedValues.add(13);
-      expectedValues.add(14);
-      expectedValues.add(15);
-
+      for (int i = 0; i < 10; i++) {
+        expectedValues.add(i);
+      }
 
       for (String query : queries) {
         DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -242,59 +242,51 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       }
     }
     {
-      // String columns
-      //@formatter:off
-      List<String> queries = Arrays
-          .asList("SELECT DISTINCT(stringColumn) FROM testTable");
-      //@formatter:on
+      // String column
+      String query = "SELECT DISTINCT(stringColumn) FROM testTable";
+      // We define a specific result set here since the data read from dictionary is in alphabetically sorted order
       Set<Integer> expectedValues =
           new HashSet<>(Arrays.asList(0, 1, 10, 11, 12, 13, 14, 15, 16, 17));
-      for (String query : queries) {
-        DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
-        DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
-        DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
-        DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
-        for (DistinctTable distinctTable : Arrays
-            .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
-          assertEquals(distinctTable.size(), 10);
-          Set<Integer> actualValues = new HashSet<>();
-          for (Record record : distinctTable.getRecords()) {
-            Object[] values = record.getValues();
-            assertEquals(values.length, 1);
-            assertTrue(values[0] instanceof String);
-            actualValues.add(Integer.parseInt((String) values[0]));
-          }
-          assertEquals(actualValues, expectedValues);
+      DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
+      DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
+      DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
+      DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
+      for (DistinctTable distinctTable : Arrays
+          .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
+        assertEquals(distinctTable.size(), 10);
+        Set<Integer> actualValues = new HashSet<>();
+        for (Record record : distinctTable.getRecords()) {
+          Object[] values = record.getValues();
+          assertEquals(values.length, 1);
+          assertTrue(values[0] instanceof String);
+          actualValues.add(Integer.parseInt((String) values[0]));
         }
+        assertEquals(actualValues, expectedValues);
       }
     }
     {
-      // String columns
-      //@formatter:off
-      List<String> queries = Arrays
-          .asList("SELECT DISTINCT(rawStringColumn) FROM testTable");
-      //@formatter:on
+      // Raw String column
+      String query = "SELECT DISTINCT(rawStringColumn) FROM testTable";
       Set<Integer> expectedValues = new HashSet<>();
       for (int i = 0; i < 10; i++) {
         expectedValues.add(i);
       }
-      for (String query : queries) {
-        DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
-        DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
-        DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
-        DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
-        for (DistinctTable distinctTable : Arrays
-            .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
-          assertEquals(distinctTable.size(), 10);
-          Set<Integer> actualValues = new HashSet<>();
-          for (Record record : distinctTable.getRecords()) {
-            Object[] values = record.getValues();
-            assertEquals(values.length, 1);
-            assertTrue(values[0] instanceof String);
-            actualValues.add(Integer.parseInt((String) values[0]));
-          }
-          assertEquals(actualValues, expectedValues);
+
+      DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
+      DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
+      DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
+      DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
+      for (DistinctTable distinctTable : Arrays
+          .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
+        assertEquals(distinctTable.size(), 10);
+        Set<Integer> actualValues = new HashSet<>();
+        for (Record record : distinctTable.getRecords()) {
+          Object[] values = record.getValues();
+          assertEquals(values.length, 1);
+          assertTrue(values[0] instanceof String);
+          actualValues.add(Integer.parseInt((String) values[0]));
         }
+        assertEquals(actualValues, expectedValues);
       }
     }
     {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -247,12 +247,8 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       List<String> queries = Arrays
           .asList("SELECT DISTINCT(stringColumn) FROM testTable");
       //@formatter:on
-      Set<Integer> expectedValues = new HashSet<>();
-
-      for (int i = 0; i < 10; i++) {
-        expectedValues.add(i);
-      }
-
+      Set<Integer> expectedValues =
+          new HashSet<>(Arrays.asList(0, 16, 17, 1, 10, 11, 12, 13, 14, 15));
       for (String query : queries) {
         DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
         DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
@@ -273,24 +269,22 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       }
     }
     {
-      // Raw String column
+      // String columns
       //@formatter:off
       List<String> queries = Arrays
-              .asList("SELECT DISTINCT(rawStringColumn) FROM testTable");
+          .asList("SELECT DISTINCT(rawStringColumn) FROM testTable");
       //@formatter:on
       Set<Integer> expectedValues = new HashSet<>();
-
       for (int i = 0; i < 10; i++) {
         expectedValues.add(i);
       }
-
-
       for (String query : queries) {
         DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
         DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
         DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
         DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
-        for (DistinctTable distinctTable : Arrays.asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
+        for (DistinctTable distinctTable : Arrays
+            .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
           assertEquals(distinctTable.size(), 10);
           Set<Integer> actualValues = new HashSet<>();
           for (Record record : distinctTable.getRecords()) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -248,7 +248,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
           .asList("SELECT DISTINCT(stringColumn) FROM testTable");
       //@formatter:on
       Set<Integer> expectedValues =
-          new HashSet<>(Arrays.asList(0, 16, 17, 1, 10, 11, 12, 13, 14, 15));
+          new HashSet<>(Arrays.asList(0, 1, 10, 11, 12, 13, 14, 15, 16, 17));
       for (String query : queries) {
         DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
         DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -40,7 +40,8 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.data.table.Record;
-import org.apache.pinot.core.operator.query.DistinctOperator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.reduce.BrokerReduceService;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -609,7 +610,7 @@ public class DistinctQueriesTest extends BaseQueriesTest {
    * Helper method to get the DistinctTable result for one single segment for the given query.
    */
   private DistinctTable getDistinctTableInnerSegment(String query, boolean isPql) {
-    DistinctOperator distinctOperator = isPql ? getOperatorForPqlQuery(query) : getOperatorForSqlQuery(query);
+    BaseOperator<IntermediateResultsBlock> distinctOperator = isPql ? getOperatorForPqlQuery(query) : getOperatorForSqlQuery(query);
     List<Object> operatorResult = distinctOperator.nextBlock().getAggregationResult();
     assertNotNull(operatorResult);
     assertEquals(operatorResult.size(), 1);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -245,12 +245,22 @@ public class DistinctQueriesTest extends BaseQueriesTest {
       // String columns
       //@formatter:off
       List<String> queries = Arrays
-          .asList("SELECT DISTINCT(stringColumn) FROM testTable", "SELECT DISTINCT(rawStringColumn) FROM testTable");
+          .asList("SELECT DISTINCT(stringColumn) FROM testTable ORDER BY stringColumn");
       //@formatter:on
       Set<Integer> expectedValues = new HashSet<>();
-      for (int i = 0; i < 10; i++) {
-        expectedValues.add(i);
-      }
+
+      expectedValues.add(0);
+      expectedValues.add(16);
+      expectedValues.add(17);
+      expectedValues.add(1);
+      expectedValues.add(10);
+      expectedValues.add(11);
+      expectedValues.add(12);
+      expectedValues.add(13);
+      expectedValues.add(14);
+      expectedValues.add(15);
+
+
       for (String query : queries) {
         DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
         DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
@@ -266,8 +276,38 @@ public class DistinctQueriesTest extends BaseQueriesTest {
             assertTrue(values[0] instanceof String);
             actualValues.add(Integer.parseInt((String) values[0]));
           }
-          //TODO: atri
-          System.out.println("QUERY IS" + " " + query);
+          assertEquals(actualValues, expectedValues);
+        }
+      }
+    }
+    {
+      // Raw String column
+      //@formatter:off
+      List<String> queries = Arrays
+              .asList("SELECT DISTINCT(rawStringColumn) FROM testTable");
+      //@formatter:on
+      Set<Integer> expectedValues = new HashSet<>();
+
+      for (int i = 0; i < 10; i++) {
+        expectedValues.add(i);
+      }
+
+
+      for (String query : queries) {
+        DistinctTable pqlDistinctTable = getDistinctTableInnerSegment(query, true);
+        DistinctTable pqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(pqlDistinctTable.toBytes()));
+        DistinctTable sqlDistinctTable = getDistinctTableInnerSegment(query, false);
+        DistinctTable sqlDistinctTable2 = DistinctTable.fromByteBuffer(ByteBuffer.wrap(sqlDistinctTable.toBytes()));
+        for (DistinctTable distinctTable : Arrays
+                .asList(pqlDistinctTable, pqlDistinctTable2, sqlDistinctTable, sqlDistinctTable2)) {
+          assertEquals(distinctTable.size(), 10);
+          Set<Integer> actualValues = new HashSet<>();
+          for (Record record : distinctTable.getRecords()) {
+            Object[] values = record.getValues();
+            assertEquals(values.length, 1);
+            assertTrue(values[0] instanceof String);
+            actualValues.add(Integer.parseInt((String) values[0]));
+          }
           assertEquals(actualValues, expectedValues);
         }
       }
@@ -338,7 +378,6 @@ public class DistinctQueriesTest extends BaseQueriesTest {
             assertTrue(values[0] instanceof Number);
             actualValues.add(((Number) values[0]).intValue());
           }
-          System.out.println("QUERY IS " + query);
           assertEquals(actualValues, expectedValues);
         }
       }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.queries;
 import java.util.List;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
@@ -178,7 +179,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
   @Test
   public void testSingleColumnDistinct() {
     String query = "SELECT DISTINCT(column1) FROM testTable LIMIT 1000000";
-    DistinctOperator distinctOperator = getOperatorForPqlQuery(query);
+    BaseOperator<IntermediateResultsBlock> distinctOperator = getOperatorForPqlQuery(query);
     IntermediateResultsBlock resultsBlock = distinctOperator.nextBlock();
     List<Object> operatorResult = resultsBlock.getAggregationResult();
 


### PR DESCRIPTION
## Description
This PR introduces the ability to execute DISTINCT using a dictionary based plan when the DISTINCT query has a single column, no filters and the column is dictionary encoded.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
