### PR TITLE
Added a query param to /tables for getting sorted table names based on time metadata

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -211,7 +211,7 @@ public class PinotTableRestletResource {
   @Path("/tables")
   @ApiOperation(value = "Lists all tables in cluster", notes = "Lists all tables in cluster")
   public String listTableData(@ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr,
-      @ApiParam(value = "name|creationTime|lastModifiedTime") @QueryParam("sortType") @DefaultValue("name") String sortType,
+      @ApiParam(value = "name|creationTime|lastModifiedTime") @QueryParam("sortType") String sortType,
       @ApiParam(value = "true|false") @QueryParam("sortAsc") @DefaultValue("true") boolean sortAsc) {
     try {
       List<String> tableNames;
@@ -226,6 +226,9 @@ public class PinotTableRestletResource {
         tableNames = _pinotHelixResourceManager.getAllRealtimeTables();
       } else {
         tableNames = _pinotHelixResourceManager.getAllOfflineTables();
+      }
+      if (sortType == null) {
+        return JsonUtils.newObjectNode().set("tables", JsonUtils.objectToJsonNode(tableNames)).toString();
       }
 
       if (sortType == "name") {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -210,7 +210,7 @@ public class PinotTableRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables")
   @ApiOperation(value = "Lists all tables in cluster", notes = "Lists all tables in cluster")
-  public String listTableData(@ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr,
+  public String listTables(@ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "name|creationTime|lastModifiedTime") @QueryParam("sortType") String sortType,
       @ApiParam(value = "true|false") @QueryParam("sortAsc") @DefaultValue("true") boolean sortAsc) {
     try {
@@ -227,16 +227,12 @@ public class PinotTableRestletResource {
       } else {
         tableNames = _pinotHelixResourceManager.getAllOfflineTables();
       }
-      if (sortType == null) {
-        return JsonUtils.newObjectNode().set("tables", JsonUtils.objectToJsonNode(tableNames)).toString();
-      }
 
-      if (sortType == "name") {
+      if (sortType == null || sortType.equalsIgnoreCase("name")) {
         // Sort table names alphabetically
         Collections.sort(tableNames, sortAsc ? null : Collections.reverseOrder());
       } else {
         // Sort table names based on (1) Create Time or (2) Last Modified Time
-        TableType finalTableType = tableType;
         HashMap<String, String> cache = new HashMap<>();
         Collections.sort(tableNames, (Comparator<String>) (o1, o2) -> {
           String d1 = getString(sortType, cache, o1);
@@ -266,7 +262,7 @@ public class PinotTableRestletResource {
 
     String timeStat;
     TableStats stat = _pinotHelixResourceManager.getTableStats(tableName);
-    if (sortType == "creationTime") {
+    if (sortType.equalsIgnoreCase("creationTime")) {
       timeStat = stat.getCreationTime();
     } else {
       timeStat = stat.getLastModifiedTime();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2799,7 +2799,7 @@ public class PinotHelixResourceManager {
     ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
     String creationTime = SIMPLE_DATE_FORMAT.format(znRecord.getCreationTime());
     String lastModifiedTime = SIMPLE_DATE_FORMAT.format(znRecord.getModifiedTime());
-    return new TableStats(creationTime, lastModifiedTime);
+    return new TableStats(creationTime, lastModifiedTime, tableNameWithType);
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2799,7 +2799,7 @@ public class PinotHelixResourceManager {
     ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
     String creationTime = SIMPLE_DATE_FORMAT.format(znRecord.getCreationTime());
     String lastModifiedTime = SIMPLE_DATE_FORMAT.format(znRecord.getModifiedTime());
-    return new TableStats(creationTime, lastModifiedTime, tableNameWithType);
+    return new TableStats(tableNameWithType, creationTime, lastModifiedTime);
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2798,7 +2798,8 @@ public class PinotHelixResourceManager {
     String zkPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(tableNameWithType);
     ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
     String creationTime = SIMPLE_DATE_FORMAT.format(znRecord.getCreationTime());
-    return new TableStats(creationTime);
+    String lastModifiedTime = SIMPLE_DATE_FORMAT.format(znRecord.getModifiedTime());
+    return new TableStats(creationTime, lastModifiedTime);
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2796,10 +2796,10 @@ public class PinotHelixResourceManager {
 
   public TableStats getTableStats(String tableNameWithType) {
     String zkPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(tableNameWithType);
-    ZNRecord znRecord = ZKMetadataProvider.getZnRecord(_propertyStore, zkPath);
-    String creationTime = SIMPLE_DATE_FORMAT.format(znRecord.getCreationTime());
-    String lastModifiedTime = SIMPLE_DATE_FORMAT.format(znRecord.getModifiedTime());
-    return new TableStats(tableNameWithType, creationTime, lastModifiedTime);
+    Stat stat = _propertyStore.getStat(zkPath, AccessOption.PERSISTENT);
+    Preconditions.checkState(stat != null, "Failed to read ZK stats for table: %s", tableNameWithType);
+    String creationTime = SIMPLE_DATE_FORMAT.format(stat.getCtime());
+    return new TableStats(creationTime);
   }
 
   /*

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
@@ -31,10 +31,16 @@ public class TableStats {
 
   private String _creationTime;
   private String _lastModifiedTime;
+  private String _tableName;
 
-  public TableStats(String creationTime, String lastModifiedTime) {
+  public TableStats(String creationTime, String lastModifiedTime, String tableName) {
     _creationTime = creationTime;
     _lastModifiedTime = lastModifiedTime;
+    _tableName = tableName;
+  }
+
+  public String getTableName() {
+    return _tableName;
   }
 
   @JsonProperty(CREATION_TIME_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
@@ -27,11 +27,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class TableStats {
   public static final String CREATION_TIME_KEY = "creationTime";
+  public static final String LAST_MODIFIED_TIME_KEY = "lastModifiedTime";
 
   private String _creationTime;
+  private String _lastModifiedTime;
 
-  public TableStats(String creationTime) {
+  public TableStats(String creationTime, String lastModifiedTime) {
     _creationTime = creationTime;
+    _lastModifiedTime = lastModifiedTime;
   }
 
   @JsonProperty(CREATION_TIME_KEY)
@@ -41,5 +44,14 @@ public class TableStats {
 
   public void setCreationTime(String creationTime) {
     _creationTime = creationTime;
+  }
+
+  @JsonProperty(LAST_MODIFIED_TIME_KEY)
+  public String getLastModifiedTime() {
+    return _lastModifiedTime;
+  }
+
+  public void setLastModifiedTime(String lastModifiedTime) {
+    _lastModifiedTime = lastModifiedTime;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
@@ -33,10 +33,10 @@ public class TableStats {
   private String _lastModifiedTime;
   private String _tableName;
 
-  public TableStats(String creationTime, String lastModifiedTime, String tableName) {
+  public TableStats(String tableName, String creationTime, String lastModifiedTime) {
+    _tableName = tableName;
     _creationTime = creationTime;
     _lastModifiedTime = lastModifiedTime;
-    _tableName = tableName;
   }
 
   public String getTableName() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStats.java
@@ -27,20 +27,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class TableStats {
   public static final String CREATION_TIME_KEY = "creationTime";
-  public static final String LAST_MODIFIED_TIME_KEY = "lastModifiedTime";
 
   private String _creationTime;
-  private String _lastModifiedTime;
-  private String _tableName;
 
-  public TableStats(String tableName, String creationTime, String lastModifiedTime) {
-    _tableName = tableName;
+  public TableStats(String creationTime) {
     _creationTime = creationTime;
-    _lastModifiedTime = lastModifiedTime;
-  }
-
-  public String getTableName() {
-    return _tableName;
   }
 
   @JsonProperty(CREATION_TIME_KEY)
@@ -50,14 +41,5 @@ public class TableStats {
 
   public void setCreationTime(String creationTime) {
     _creationTime = creationTime;
-  }
-
-  @JsonProperty(LAST_MODIFIED_TIME_KEY)
-  public String getLastModifiedTime() {
-    return _lastModifiedTime;
-  }
-
-  public void setLastModifiedTime(String lastModifiedTime) {
-    _lastModifiedTime = lastModifiedTime;
   }
 }


### PR DESCRIPTION
Signed-off-by: Yash Sharma <yashrsharma44@gmail.com>

## Description
Adds a query parameter - 
* `sortType` - for sorting based on name or creation time of table.
* `sortAsc` - sort ascending/descending order - use boolean values

Fixes #6865 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
