### PR TITLE
Fixing pinot-admin script to parse env var PLUGINS_INCLUDE

### DIFF
--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -117,8 +117,8 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
   fi
   if [ -d "$PLUGINS_DIR" ] ; then
     if [ -n "$PLUGINS_INCLUDE" ] ; then
-      IFS=';' echo "$PLUGINS_INCLUDE" | read -ra PLUGINS_ARR
-      for PLUGIN_JAR in "${PLUGINS_ARR[@]}"; do
+      export IFS=";"
+      for PLUGIN_JAR in $PLUGINS_INCLUDE; do
           PLUGIN_JAR_PATH=$(find "$PLUGINS_DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)
           if [ -n "$PLUGINS_CLASSPATH" ] ; then
             PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
@@ -126,6 +126,7 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
             PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
           fi
       done
+      unset IFS
     else
       PLUGIN_JARS=$(find "$PLUGINS_DIR" -name \*.jar)
       for PLUGIN_JAR in $PLUGIN_JARS ; do


### PR DESCRIPTION
## Description
https://github.com/apache/incubator-pinot/issues/7124

After the fix, it shows the correct parsing:
```
➜ JAVA_OPTS="-Xms1G -Xmx4G" PLUGINS_INCLUDE="pinot-avro;pinot-json" bash bin/pinot-admin.sh QuickStart -type batch
PLUGINS_INCLUDE= pinot-avro;pinot-json
PLUGIN_JAR= pinot-avro
PLUGIN_JAR= pinot-json
PLUGIN_JAR_PATH= /Users/xiangfu/workspace/pinot-dev/pinot-distribution/target/apache-pinot-incubating-0.8.0-SNAPSHOT-bin/apache-pinot-incubating-0.8.0-SNAPSHOT-bin/plugins/pinot-input-format/pinot-json/pinot-json-0.8.0-SNAPSHOT-shaded.jar
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
