### PR TITLE
Provide HTTP client to kinesis builder

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandler.java
@@ -87,7 +87,8 @@ public class KinesisConnectionHandler {
             .httpClientBuilder(new ApacheSdkHttpService().createHttpClientBuilder());
       } else {
         kinesisClientBuilder =
-            KinesisClient.builder().region(Region.of(_region)).credentialsProvider(DefaultCredentialsProvider.create());
+            KinesisClient.builder().region(Region.of(_region)).credentialsProvider(DefaultCredentialsProvider.create())
+                .httpClientBuilder(new ApacheSdkHttpService().createHttpClientBuilder());
       }
 
       if (StringUtils.isNotBlank(_endpoint)) {


### PR DESCRIPTION
Currently, kinesis stream ingestion plugin throws the following error due to missing HTTP client provider.

```json
{"code":500,"error":"shaded.software.amazon.awssdk.core.exception.SdkClientException: Unable to load an HTTP implementation from any provider in the chain. You must declare a dependency on an appropriate HTTP implementation or pass in an SdkHttpClient explicitly to the client builder."}
```
It is not able to discover the provider because of shading.
The PR fixes this issue by explicitly providing the http client.