### PR TITLE
Fix typo in SegmentMetadataFetcher.

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
@@ -133,7 +133,7 @@ public class SegmentMetadataFetcher {
         indexStatus.put(NULL_VALUE_VECTOR_READER, INDEX_AVAILABLE);
       }
 
-      if (Objects.isNull(columnIndexContainer.getNullValueVector())) {
+      if (Objects.isNull(columnIndexContainer.getRangeIndex())) {
         indexStatus.put(RANGE_INDEX, INDEX_NOT_AVAILABLE);
       } else {
         indexStatus.put(RANGE_INDEX, INDEX_AVAILABLE);


### PR DESCRIPTION
## Description
The SegmentMetadataFetcher.getImmutableSegmentColumnIndexes has a typo where it is
calling the incorrect api when checking for range index. This PR fixes the typo.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
