### PR TITLE
Fix errors happening due to parallel builds

### DIFF
--- a/compatibility-verifier/compCheck.sh
+++ b/compatibility-verifier/compCheck.sh
@@ -45,6 +45,24 @@ logCount=1
 cmdName=`basename $0`
 source `dirname $0`/utils.inc
 
+function cleanupControllerDirs() {
+  local dirName=$(grep -F controller.data.dir ${CONTROLLER_CONF} | awk '{print $3}')
+  if [ ! -z "$dirName" ]; then
+    ${RM} -rf ${dirName}
+  fi
+}
+
+function cleanupServerDirs() {
+  local dirName=$(grep -F pinot.server.instance.dataDir ${SERVER_CONF} | awk '{print $3}')
+  if [ ! -z "$dirName" ]; then
+    ${RM} -rf ${dirName}
+  fi
+  dirName=$(grep -F pinot.server.instance.segmentTarDir ${SERVER_CONF} | awk '{print $3}')
+  if [ ! -z "$dirName" ]; then
+    ${RM} -rf ${dirName}
+  fi
+}
+
 # get usage of the script
 function usage() {
   echo "Usage: $cmdName -w <workingDir> -t <testSuiteDir> [-k]"
@@ -294,6 +312,9 @@ COMPAT_TESTER_PATH="pinot-integration-tests/target/pinot-integration-tests-pkg/b
 BROKER_CONF=${testSuiteDir}/config/BrokerConfig.properties
 CONTROLLER_CONF=${testSuiteDir}/config/ControllerConfig.properties
 SERVER_CONF=${testSuiteDir}/config/ServerConfig.properties
+
+cleanupControllerDirs
+cleanupServerDirs
 
 BROKER_QUERY_PORT=8099
 ZK_PORT=2181


### PR DESCRIPTION
Maven cache interferes when we build two trees in parallel,
causing (for example) pinot-spi of one tree to be linked
with that of the other tree (since they are of the same version)

Changed the build to use different version ID for old and new builds
so that they don't pull in each other's jars. Current build always
uses the same ID as the current tree so that any changes made
can be tested easily without backing out pom files.

A different build ID each time can cause maven cache to explode if we
run the compile multiple times, so changed the build to use a dedicated
cache that is deleted after builds.

Also added code to cleanup the controller and server's data
directories before starting compat checker.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
