### PR TITLE
Bug fix: JDBC driver throws null pointer exception when metric columns are not present in Schema

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
@@ -159,19 +159,25 @@ public class PinotConnectionMetaData extends AbstractBaseConnectionMetaData {
 
     String tableName = schemaResponse.getSchemaName();
     int ordinalPosition = 1;
-    for (JsonNode columns : schemaResponse.getDimensions()) {
-      appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
-      ordinalPosition++;
+    if (schemaResponse.getDimensions() != null) {
+      for (JsonNode columns : schemaResponse.getDimensions()) {
+        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        ordinalPosition++;
+      }
     }
 
-    for (JsonNode columns : schemaResponse.getMetrics()) {
-      appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
-      ordinalPosition++;
+    if (schemaResponse.getMetrics() != null) {
+      for (JsonNode columns : schemaResponse.getMetrics()) {
+        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        ordinalPosition++;
+      }
     }
 
-    for (JsonNode columns : schemaResponse.getDateTimeFieldSpecs()) {
-      appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
-      ordinalPosition++;
+    if (schemaResponse.getDateTimeFieldSpecs() != null) {
+      for (JsonNode columns : schemaResponse.getDateTimeFieldSpecs()) {
+        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        ordinalPosition++;
+      }
     }
 
     JsonNode resultTable = OBJECT_MAPPER.valueToTree(pinotMeta);


### PR DESCRIPTION
Currently, JDBC driver assumed metric columns are mandatory in schema which is not the case in pinot.
This PR implements a simple null check so that exceptions are not thrown when metric columns are not present.